### PR TITLE
Fix failed download of terraform provider 0.7.3

### DIFF
--- a/concourse/tasks/terraform_apply_cloudfoundry.yml
+++ b/concourse/tasks/terraform_apply_cloudfoundry.yml
@@ -32,7 +32,7 @@ run:
   args:
   - -exc
   - |
-    sh -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
+    bash -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/$(echo ${PROVIDER_CLOUDFOUNDRY_VERSION:-master})/bin/install.sh)"
     terraform version
     CURRENT_DIR=$(pwd)
 

--- a/concourse/tasks/terraform_plan_cloudfoundry.yml
+++ b/concourse/tasks/terraform_plan_cloudfoundry.yml
@@ -32,7 +32,7 @@ run:
   args:
   - -exc
   - |
-    sh -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
+    bash -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/$(echo ${PROVIDER_CLOUDFOUNDRY_VERSION:-master})/bin/install.sh)"
     terraform version
     CURRENT_DIR=$(pwd)
 


### PR DESCRIPTION
Now use the install script version matching the provider version.
Also explicitly use bash instead of sh.

Relates to #1 and https://github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/pull/25