### PR TITLE
pipeline(depls): introduce active/inactive deployment

### DIFF
--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -80,7 +80,9 @@ resources:
     tag_filter: {{cf-ops-automation-tag-filter}}
     skip_ssl_verification: true
 
-<% all_dependencies.sort.each do |name,boshrelease| %>
+<% active_deployments = all_dependencies.select{|name,boshrelease| boshrelease['status']=='active'} %>
+<% puts active_deployments %>
+<% active_deployments.sort.each do |name,boshrelease| %>
 - name: secrets-<%= name %>
   type: git
   source:
@@ -160,7 +162,7 @@ resources:
 
 
 <% uniq_releases= {} %>
-<% all_dependencies.sort.each do |name,boshrelease| %>
+<% active_deployments.sort.each do |name,boshrelease| %>
 <% boshrelease['releases']&.each do |release, info|  %>
 <% uniq_releases[release]= info %>
 <% end %>
@@ -364,7 +366,7 @@ jobs:
               rebase: true
 
 
-<% all_dependencies.sort.each do |name,boshrelease| %>
+<% active_deployments.sort.each do |name,boshrelease| %>
 
 - name: deploy-<%= name %>
   <% jobs["deploy-#{name[0]}*"] << "deploy-#{name}" %>
@@ -558,7 +560,7 @@ jobs:
 
 <% end %>
 
-<% unless all_dependencies.empty? %>
+<% unless active_deployments.empty? %>
 - name: retrigger-all-jobs
   <% jobs['utils'] << 'retrigger-all-jobs' %>
   on_failure:
@@ -588,7 +590,7 @@ jobs:
           args:
           - -exc
           - |
-            <% all_dependencies.sort.each do |name,_| %>
+            <% active_deployments.sort.each do |name,_| %>
             echo "trigger-job -j $BUILD_PIPELINE_NAME/deploy-<%= name %>" >> result-dir/flight-plan
             <% end %>
         params:
@@ -626,7 +628,7 @@ jobs:
          params: { submodules: none}
          <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
 
-<% all_dependencies.sort.each do |name,boshrelease| %>
+<% active_deployments.sort.each do |name,boshrelease| %>
 - name: recreate-<%= name %>
   <% jobs['recreate'] << "recreate-#{name}" %>
   on_failure:
@@ -685,7 +687,7 @@ jobs:
 <% current_cf_apps_generated= all_ci_deployments[depls]["pipelines"]["#{depls}-cf-apps-generated"] || all_ci_deployments[depls]["pipelines"].to_a[1][1]%>
 <% raise "invalid ci-deployment-overview.yml. Missing key [#{depls}][pipelines][#{depls}-cf-apps-generated]"  if current_cf_apps_generated == nil  %>
 
-<% unless all_dependencies.empty? %>
+<% unless active_deployments.empty? %>
 - name: init-concourse-boshrelease-and-stemcell-for-<%= depls %>
   <% jobs['utils'] << "init-concourse-boshrelease-and-stemcell-for-#{depls}" %>
   on_failure:
@@ -767,7 +769,7 @@ jobs:
       params: { submodules: none}
       attempts: 3
       trigger: true
-    <% all_dependencies.sort.each do |name,_| %>
+    <% active_deployments.sort.each do |name,_| %>
     - get: secrets-<%= name %>
       params: { submodules: none}
     - get: paas-template-<%= name %>
@@ -975,5 +977,3 @@ groups:
     - <%= a_job %>
    <% end %>
 <% end %>
-
-<% puts "#{all_dependencies} - #{all_dependencies.empty?} "%>

--- a/lib/root_deployment.rb
+++ b/lib/root_deployment.rb
@@ -4,15 +4,36 @@ require_relative 'deployment_factory.rb'
 class RootDeployment
   DEPLOYMENT_DEPENDENCIES_FILENAME = 'deployment-dependencies.yml'.freeze
   ENABLE_DEPLOYMENT_FILENAME = 'enable-deployment.yml'.freeze
+  DEFAULT_EXCLUDE = %w(secrets cf-apps-deployments terraform-config)
 
-  def initialize(root_deployment_name, dependency_root_path, enable_deployment_root_path)
+  def initialize(root_deployment_name, dependency_root_path, enable_deployment_root_path, exclude_list = DEFAULT_EXCLUDE)
     @root_deployment_name = root_deployment_name
     @dependency_root_path = dependency_root_path
     @enable_deployment_root_path = enable_deployment_root_path
+    @excluded_file = exclude_list
 
     raise 'invalid root_deployment_name' unless validate_string @root_deployment_name
     raise 'invalid dependency_root_path' unless validate_string @dependency_root_path
     raise 'invalid enable_deployment_root_path' unless validate_string @enable_deployment_root_path
+  end
+
+  def deployments_status()
+    status = {}
+    Dir[@enable_deployment_root_path]
+        .select { |f| File.directory? f }
+        .each do |filename|
+      deployment_name = filename.split(File::SEPARATOR).last
+      puts "Processing #{dirname}"
+      puts "result #{@excluded_file.include?(dirname)} "
+      next if @excluded_file.include?(dirname)
+      enable_deployment_file = File.join(filename, ENABLE_DEPLOYMENT_FILENAME)
+      if File.exist?(enable_deployment_file)
+        status[deployment_name] = { 'status' => 'active' }
+      end
+
+
+    end
+    status
   end
 
   def overview_from_hash(deployment_factory)
@@ -20,20 +41,25 @@ class RootDeployment
     puts "Path deployment overview: #{@enable_deployment_root_path}"
 
     Dir[@enable_deployment_root_path]
-      .select { |f| File.directory? f }
+      .select { |f| File.directory?(f) && !@excluded_file.include?(f.split(File::SEPARATOR).last) }
       .each do |filename|
         dirname = filename.split(File::SEPARATOR).last
         puts "Processing #{dirname}"
-        Dir[File.join(filename, ENABLE_DEPLOYMENT_FILENAME)].each do |enable_deployment_filename|
+        enable_deployment_file = File.join(filename, ENABLE_DEPLOYMENT_FILENAME)
+        if File.exist?(enable_deployment_file)
           dependency_filename = File.join(@dependency_root_path, @root_deployment_name, dirname, DEPLOYMENT_DEPENDENCIES_FILENAME)
 
           puts "Bosh release detected: #{dirname}"
           raise "Inconsistency detected: found #{enable_deployment_filename}, but no #{DEPLOYMENT_DEPENDENCIES_FILENAME} found at #{dependency_filename}" unless File.exist?(dependency_filename)
 
           deployment_factory.load_file(dependency_filename).each do |deployment|
+            deployment.details['status'] = 'active'
             dependencies[deployment.name] = deployment.details
             raise "#{filename} - Invalid deployment: expected <#{dirname}> - Found <#{deployment.name}>" if deployment.name != dirname
           end
+        else
+          puts "Deployment #{dirname} is inactive"
+          dependencies[dirname] = { 'status' => 'inactive' }
         end
         # puts "##############################"
         #    dependencies.each do |aDep|


### PR DESCRIPTION
step to support delete lifecycle. It scans secrets/<root_deployment> for
directories. If a ```enable-deployment.yml``` is found, deployment status
is set to ```active```, otherwise to ```inactive```.
```inactive``` deployment are going to be candidates for deletion.

