### PR TITLE
Upgrading terraform to 0.10.2 and cloudfoundry provider to 0.9.1

### DIFF
--- a/concourse/tasks/terraform_apply_cloudfoundry.yml
+++ b/concourse/tasks/terraform_apply_cloudfoundry.yml
@@ -16,7 +16,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: hashicorp/terraform, tag: 0.9.8}
+  source: {repository: hashicorp/terraform, tag: 0.10.2}
 
 inputs:
   - name: secret-state-resource
@@ -57,10 +57,10 @@ run:
     fi
 
     cd generated-files/
-    terraform get  ../spec-applied/
+    terraform init -input=false -upgrade ../spec-applied/
     terraform apply  ../spec-applied/
 
 params:
   SPEC_PATH:
   SECRET_STATE_FILE_PATH:
-  PROVIDER_CLOUDFOUNDRY_VERSION: v0.7.3
+  PROVIDER_CLOUDFOUNDRY_VERSION: v0.9.1

--- a/concourse/tasks/terraform_plan_cloudfoundry.yml
+++ b/concourse/tasks/terraform_plan_cloudfoundry.yml
@@ -16,7 +16,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: hashicorp/terraform, tag: 0.9.8}
+  source: {repository: hashicorp/terraform, tag: 0.10.2}
 
 inputs:
   - name: secret-state-resource
@@ -57,10 +57,10 @@ run:
     fi
 
     cd generated-files/
-    terraform get  ../spec-applied/
+    terraform init -input=false -upgrade ../spec-applied/
     terraform plan  ../spec-applied/
 
 params:
   SPEC_PATH:
   SECRET_STATE_FILE_PATH:
-  PROVIDER_CLOUDFOUNDRY_VERSION: v0.7.3
+  PROVIDER_CLOUDFOUNDRY_VERSION: v0.9.1

--- a/spec/tasks/terraform_apply_cloudfoundry/task_spec.rb
+++ b/spec/tasks/terraform_apply_cloudfoundry/task_spec.rb
@@ -3,8 +3,9 @@ require 'yaml'
 require 'tmpdir'
 
 describe 'terraform_apply_cloudfoundry task' do
-  EXPECTED_TERRAFORM_VERSION='0.9.8'
-  EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.7.3'
+  EXPECTED_TERRAFORM_VERSION='0.10.2'
+  EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.9.1'
+  SKIP_REMOTE_FLY_DOWNLOAD=false
 
   context 'when pre-requisite are valid' do
     before(:context) do
@@ -59,8 +60,10 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     after(:context) do
-      FileUtils.rm_rf @generated_files
-      FileUtils.rm_rf @spec_applied
+      unless SKIP_REMOTE_FLY_DOWNLOAD
+        FileUtils.rm_rf @generated_files
+        FileUtils.rm_rf @spec_applied
+      end
     end
 
     it 'applies to add only one resource' do
@@ -85,7 +88,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     it 'matches files in generated-files output' do
-      expected_files = %w[. .. .gitkeep terraform.tfvars terraform.tfstate spec-only.txt].sort
+      expected_files = %w[. .. .gitkeep .terraform terraform.tfvars terraform.tfstate spec-only.txt].sort
       expect(Dir.entries(@generated_files).sort).to eq(expected_files)
     end
 
@@ -111,8 +114,10 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     after(:context) do
-      FileUtils.rm_rf @generated_files
-      FileUtils.rm_rf @spec_applied
+      unless SKIP_REMOTE_FLY_DOWNLOAD
+        FileUtils.rm_rf @generated_files
+        FileUtils.rm_rf @spec_applied
+      end
     end
 
     it 'applies to add resources' do
@@ -163,9 +168,11 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     after(:context) do
-      FileUtils.rm_rf @generated_files
-      FileUtils.rm_rf @spec_applied
-      FileUtils.rm_rf @terraform_tfvars
+      unless SKIP_REMOTE_FLY_DOWNLOAD
+        FileUtils.rm_rf @generated_files
+        FileUtils.rm_rf @spec_applied
+        FileUtils.rm_rf @terraform_tfvars
+      end
     end
 
     it 'applies to add only one resource' do
@@ -192,7 +199,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     it 'matches files in generated-files output' do
-      expected_files = %w[. .. .gitkeep terraform.tfstate secrets.txt].sort
+      expected_files = %w[. .. .gitkeep .terraform terraform.tfstate secrets.txt].sort
       expect(Dir.entries(@generated_files).sort).to eq(expected_files)
     end
   end

--- a/spec/tasks/terraform_apply_cloudfoundry/task_spec.rb
+++ b/spec/tasks/terraform_apply_cloudfoundry/task_spec.rb
@@ -5,7 +5,7 @@ require 'tmpdir'
 describe 'terraform_apply_cloudfoundry task' do
   EXPECTED_TERRAFORM_VERSION='0.10.2'
   EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.9.1'
-  SKIP_REMOTE_FLY_DOWNLOAD=false
+  SKIP_TMP_FILE_CLEANUP=false
 
   context 'when pre-requisite are valid' do
     before(:context) do
@@ -60,7 +60,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     after(:context) do
-      unless SKIP_REMOTE_FLY_DOWNLOAD
+      unless SKIP_TMP_FILE_CLEANUP
         FileUtils.rm_rf @generated_files
         FileUtils.rm_rf @spec_applied
       end
@@ -114,7 +114,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     after(:context) do
-      unless SKIP_REMOTE_FLY_DOWNLOAD
+      unless SKIP_TMP_FILE_CLEANUP
         FileUtils.rm_rf @generated_files
         FileUtils.rm_rf @spec_applied
       end
@@ -168,7 +168,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     after(:context) do
-      unless SKIP_REMOTE_FLY_DOWNLOAD
+      unless SKIP_TMP_FILE_CLEANUP
         FileUtils.rm_rf @generated_files
         FileUtils.rm_rf @spec_applied
         FileUtils.rm_rf @terraform_tfvars

--- a/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
+++ b/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
@@ -5,7 +5,7 @@ require 'tmpdir'
 describe 'terraform_plan_cloudfoundry task' do
   EXPECTED_TERRAFORM_VERSION='0.10.2'
   EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.9.1'
-  SKIP_REMOTE_FLY_DOWNLOAD=false
+  SKIP_TMP_FILE_CLEANUP=false
 
   context 'when pre-requisite are valid' do
     before(:context) do
@@ -24,7 +24,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      unless SKIP_REMOTE_FLY_DOWNLOAD
+      unless SKIP_TMP_FILE_CLEANUP
         FileUtils.rm_rf @generated_files
         FileUtils.rm_rf @spec_applied
       end
@@ -63,7 +63,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      unless SKIP_REMOTE_FLY_DOWNLOAD
+      unless SKIP_TMP_FILE_CLEANUP
         FileUtils.rm_rf @generated_files
         FileUtils.rm_rf @spec_applied
       end
@@ -112,7 +112,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      unless SKIP_REMOTE_FLY_DOWNLOAD
+      unless SKIP_TMP_FILE_CLEANUP
         FileUtils.rm_rf @generated_files
         FileUtils.rm_rf @spec_applied
       end
@@ -166,7 +166,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      unless SKIP_REMOTE_FLY_DOWNLOAD
+      unless SKIP_TMP_FILE_CLEANUP
         FileUtils.rm_rf @generated_files
         FileUtils.rm_rf @spec_applied
         FileUtils.rm_rf @terraform_tfvars

--- a/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
+++ b/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
@@ -3,8 +3,9 @@ require 'yaml'
 require 'tmpdir'
 
 describe 'terraform_plan_cloudfoundry task' do
-  EXPECTED_TERRAFORM_VERSION='0.9.8'
-  EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.7.3'
+  EXPECTED_TERRAFORM_VERSION='0.10.2'
+  EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.9.1'
+  SKIP_REMOTE_FLY_DOWNLOAD=false
 
   context 'when pre-requisite are valid' do
     before(:context) do
@@ -23,8 +24,10 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      FileUtils.rm_rf @generated_files
-      FileUtils.rm_rf @spec_applied
+      unless SKIP_REMOTE_FLY_DOWNLOAD
+        FileUtils.rm_rf @generated_files
+        FileUtils.rm_rf @spec_applied
+      end
     end
 
     it 'ensures terraform version is correct' do
@@ -60,8 +63,10 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      FileUtils.rm_rf @generated_files
-      FileUtils.rm_rf @spec_applied
+      unless SKIP_REMOTE_FLY_DOWNLOAD
+        FileUtils.rm_rf @generated_files
+        FileUtils.rm_rf @spec_applied
+      end
     end
 
     it 'plans to add only one change' do
@@ -79,7 +84,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     it 'copies terraform-tfvars files in generated-files output' do
-      cred_dir= %w[.gitkeep]
+      cred_dir= %w[.gitkeep .terraform]
 
       expected_dirs = Dir.entries(@terraform_tfvars) + cred_dir
       expect(Dir.entries(@generated_files).sort).to eq(expected_dirs.sort)
@@ -107,8 +112,10 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      FileUtils.rm_rf @generated_files
-      FileUtils.rm_rf @spec_applied
+      unless SKIP_REMOTE_FLY_DOWNLOAD
+        FileUtils.rm_rf @generated_files
+        FileUtils.rm_rf @spec_applied
+      end
     end
 
     it 'plans to add resources' do
@@ -159,9 +166,11 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     after(:context) do
-      FileUtils.rm_rf @generated_files
-      FileUtils.rm_rf @spec_applied
-      FileUtils.rm_rf @terraform_tfvars
+      unless SKIP_REMOTE_FLY_DOWNLOAD
+        FileUtils.rm_rf @generated_files
+        FileUtils.rm_rf @spec_applied
+        FileUtils.rm_rf @terraform_tfvars
+      end
     end
 
     it 'plans to add only one resource' do
@@ -184,7 +193,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     it 'does not contain any files in generated-files output' do
-      expect(Dir.entries(@generated_files).sort).to eq(%w[. .. .gitkeep].sort)
+      expect(Dir.entries(@generated_files).sort).to eq(%w[. .. .gitkeep .terraform].sort)
     end
 
   end


### PR DESCRIPTION
This required to invoke terraform init (as a replacement for terraform get: init also handles fetching modules).
"The downloaded plugins are installed to a subdirectory of the working directory, and are thus local to that working directory" according to https://www.terraform.io/docs/commands/init.html#plugin-installation
The pipeline only commits the tfstate file to git, so it should ignore this directort.

Updated spec files to expect the .terraform/ directory holding plugins and modules and added a SKIP_REMOTE_FLY_DOWNLOAD constant to ease tests debugging

Fix #23 