### PR TITLE
pipeline(depls): support deployment manifest without template

### DIFF
--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -90,7 +90,7 @@ resources:
     uri: {{secrets-uri}}
     <% ext_scan_path = boshrelease['resources']['secrets']['extended_scan_path'] if ( boshrelease['resources'] && boshrelease['resources']['secrets']['extended_scan_path'] ) %>
     <% ext_scan_path_value = ",\"#{ext_scan_path.join('","')}\"" if ext_scan_path %>
-    paths: ["<%= depls %>/<%= name %>","shared"<%= ext_scan_path_value || ""%>]
+    paths: ["<%= depls %>/<%= name %>","shared"<%= ext_scan_path_value || '' %>]
     branch: {{secrets-branch}}
     skip_ssl_verification: true
 
@@ -492,12 +492,12 @@ jobs:
       - get: secrets-<%= name %>
         params: { submodules: none}
         trigger: true
-        <%= "passed: [update-pipeline-#{depls}-generated]" if  ! all_ci_deployments.empty? %>
+        <%= "passed: [update-pipeline-#{depls}-generated]" unless all_ci_deployments.empty? %>
       - get: paas-template-<%= name %>
         trigger: true
         <% current_git_submodule = git_submodules[depls][name] if git_submodules[depls] %>
         params: { submodules: <%= current_git_submodule || 'none' %>}
-        <%= "passed: [update-pipeline-#{depls}-generated]" if  ! all_ci_deployments.empty? %>
+        <%= "passed: [update-pipeline-#{depls}-generated]" unless all_ci_deployments.empty? %>
     - task: generate-<%= name %>-manifest
       input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-<%= name %>, additional-resource: paas-template-<%= name %>}
       output_mapping: {generated-files: release-manifest}
@@ -512,12 +512,20 @@ jobs:
         CUSTOM_SCRIPT_DIR: additional-resource/<%= depls %>/<%= name %>/template
     - task: execute-<%= name %>-spiff-pre-bosh-deploy
       input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-template-<%= name %>, credentials-resource: secrets-<%= name %>, additional-resource: release-manifest}
-      output_mapping: {generated-files: final-release-manifest}
+      output_mapping: {generated-files: pre-bosh-deploy-resource}
       file: cf-ops-automation/concourse/tasks/spiff_pre_bosh_deploy.yml
       params:
         CUSTOM_SCRIPT_DIR: template-resource/<%= depls %>/<%= name %>/template
         SECRETS_DIR: credentials-resource/<%= depls %>/<%= name %>
-    <% if boshrelease['cli_version'] == "v1" %>
+    - task: copy-<%= name %>-required-files
+      input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-template-<%= name %>, credentials-resource: secrets-<%= name %>, additional-resource: pre-bosh-deploy-resource}
+      output_mapping: {generated-files: final-release-manifest}
+      file: cf-ops-automation/concourse/tasks/copy_deployment_required_files.yml
+      params:
+        CUSTOM_SCRIPT_DIR: template-resource/<%= depls %>/<%= name %>/template
+        SECRETS_DIR: credentials-resource/<%= depls %>/<%= name %>
+        MANIFEST_NAME: <%= name %>.yml
+    <% if boshrelease['cli_version'] == 'v1' %>
     - task: convert-bosh-dns-to-bosh-target-v1
       output_mapping: {result-dir: bosh-generated-config}
       config:

--- a/concourse/tasks/copy_deployment_required_files.yml
+++ b/concourse/tasks/copy_deployment_required_files.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source: {repository: concourse/busyboxplus, tag: "git"}
+inputs:
+  - name: scripts-resource
+  - name: template-resource
+  - name: credentials-resource
+  - name: additional-resource
+outputs:
+  - name: generated-files
+run:
+  path: scripts-resource/scripts/manifest/copy-deployment-required-files.sh
+params:
+  SECRETS_DIR:
+  CUSTOM_SCRIPT_DIR:
+  MANIFEST_NAME:

--- a/scripts/manifest/copy-deployment-required-files.sh
+++ b/scripts/manifest/copy-deployment-required-files.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -ex
+
+CURRENT_DIR=$(pwd)
+OUTPUT_DIR=${OUTPUT_DIR:-${CURRENT_DIR}/generated-files}
+COMMON_SCRIPT_DIR=${COMMON_SCRIPT_DIR:-scripts-resource/scripts/manifest}
+
+echo "copying additional resources"
+cp -r additional-resource/. ${OUTPUT_DIR}/
+
+echo "checking manifest '${MANIFEST_NAME}' existence"
+if [ -n "$OUTPUT_DIR" -a  ! -f "$OUTPUT_DIR/${MANIFEST_NAME}" ]
+then
+    if [ -n "$CUSTOM_SCRIPT_DIR" -a  -f "${CUSTOM_SCRIPT_DIR}/${MANIFEST_NAME}" ]
+    then
+        echo "default '${MANIFEST_NAME}' detected."
+        cp ${CUSTOM_SCRIPT_DIR}/${MANIFEST_NAME} ${OUTPUT_DIR}/
+    else
+        echo "ignoring '${MANIFEST_NAME}'. No manifest detected."
+    fi
+else
+    echo "'${MANIFEST_NAME}' already exists in additional-resource. Skipping copy !!!"
+fi

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -374,12 +374,24 @@ jobs:
         CUSTOM_SCRIPT_DIR: additional-resource/simple-depls/ntp/template
     - task: execute-ntp-spiff-pre-bosh-deploy
       input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-template-ntp, credentials-resource: secrets-ntp, additional-resource: release-manifest}
-      output_mapping: {generated-files: final-release-manifest}
+      output_mapping: {generated-files: pre-bosh-deploy-resource}
       file: cf-ops-automation/concourse/tasks/spiff_pre_bosh_deploy.yml
       params:
         CUSTOM_SCRIPT_DIR: template-resource/simple-depls/ntp/template
         SECRETS_DIR: credentials-resource/simple-depls/ntp
-
+    - task: copy-ntp-required-files
+      input_mapping:
+        scripts-resource: cf-ops-automation
+        template-resource: paas-template-ntp
+        credentials-resource: secrets-ntp
+        additional-resource: pre-bosh-deploy-resource
+      output_mapping:
+        generated-files: final-release-manifest
+      file: cf-ops-automation/concourse/tasks/copy_deployment_required_files.yml
+      params:
+        CUSTOM_SCRIPT_DIR: template-resource/simple-depls/ntp/template
+        SECRETS_DIR: credentials-resource/simple-depls/ntp
+        MANIFEST_NAME: ntp.yml
     - task: convert-bosh-dns-to-ip
       output_mapping: {result-dir: bosh-generated-config}
       config:

--- a/spec/tasks/copy_deployment_required_files/additional-resource/a-depls.yml
+++ b/spec/tasks/copy_deployment_required_files/additional-resource/a-depls.yml
@@ -1,0 +1,2 @@
+---
+message: "this is an empty yaml file"

--- a/spec/tasks/copy_deployment_required_files/task_spec.rb
+++ b/spec/tasks/copy_deployment_required_files/task_spec.rb
@@ -1,0 +1,130 @@
+# encoding: utf-8
+# require 'spec_helper.rb'
+require 'yaml'
+
+describe 'copy_deployment_required_files task' do
+
+
+  context 'when no manifest has been generated' do
+
+    before(:context) do
+      @generated_files = Dir.mktmpdir
+      @additional_resource = Dir.mktmpdir
+      FileUtils.touch(File.join(@additional_resource,'an-auto-generated-file-1.yml'))
+      FileUtils.touch(File.join(@additional_resource,'an-auto-generated-file-2.yml'))
+      @manifest_name = 'not-existing-manifest.yml'
+
+      @output = execute('-c concourse/tasks/copy_deployment_required_files.yml ' \
+        '-i scripts-resource=. ' \
+        '-i template-resource=spec/tasks/copy_deployment_required_files/template-resource ' \
+        '-i credentials-resource=spec/tasks/copy_deployment_required_files/credentials-resource ' \
+        "-i additional-resource=#{@additional_resource} " \
+        "-o generated-files=#{@generated_files} ",
+        'CUSTOM_SCRIPT_DIR' =>'',
+        'SECRETS_DIR' => '',
+        'MANIFEST_NAME' => @manifest_name)
+    end
+
+    after(:context) do
+      FileUtils.rm_rf @generated_files if File.exist?(@generated_files)
+      FileUtils.rm_rf @additional_resource if File.exist?(@additional_resource)
+    end
+
+    it 'displays an message checking manifest existence' do
+      expect(@output).to include("checking manifest '#{@manifest_name}' existence")
+    end
+
+    it 'displays an message ignoring manifest existence' do
+      expect(@output).to include("ignoring '#{@manifest_name}'. No manifest detected.")
+    end
+
+    it 'adds additional resource to generated' do
+      additional_resource_dir_content = Dir[File.join(@additional_resource, '*')]&.map! { |filename| File.basename(filename) }
+      generated_files_dir_content = Dir[File.join(@generated_files, '*')]&.map! { |filename| File.basename(filename) }
+
+      expect(generated_files_dir_content).to match_array(additional_resource_dir_content)
+    end
+
+  end
+
+  context 'when no manifest generated but a default manifest is detected' do
+
+    before(:context) do
+      @generated_files = Dir.mktmpdir
+      @additional_resource = Dir.mktmpdir
+      @manifest_name = 'default-manifest-depls.yml'
+      FileUtils.touch(File.join(@additional_resource,'an-auto-generated-file-1.yml'))
+      FileUtils.touch(File.join(@additional_resource,'an-auto-generated-file-2.yml'))
+
+      @output = execute('-c concourse/tasks/copy_deployment_required_files.yml ' \
+        '-i scripts-resource=. ' \
+        '-i template-resource=spec/tasks/copy_deployment_required_files/template-resource ' \
+        '-i credentials-resource=spec/tasks/copy_deployment_required_files/credentials-resource ' \
+        "-i additional-resource=#{@additional_resource} " \
+        "-o generated-files=#{@generated_files} ",
+                        'CUSTOM_SCRIPT_DIR' => 'template-resource/default-manifest-depls',
+                        'SECRETS_DIR' => 'credentials-resource/default-manifest-depls',
+                        'MANIFEST_NAME' => @manifest_name)
+    end
+    after(:context) do
+      FileUtils.rm_rf @generated_files if File.exist?(@generated_files)
+      FileUtils.rm_rf @additional_resource if File.exist?(@additional_resource)
+    end
+
+    it 'displays an execution message' do
+      expect(@output).to include("default '#{@manifest_name}' detected.")
+    end
+
+
+    it 'exists a manifest file in generation dir' do
+      expect(File).to exist(File.join(@generated_files, @manifest_name))
+    end
+
+    it 'adds additional resource to generated' do
+        additional_resource_dir_content = Dir[File.join(@additional_resource, '*')]&.map! { |filename| File.basename(filename) }
+        generated_files_dir_content = Dir[File.join(@generated_files, '*')]&.map! { |filename| File.basename(filename) }
+
+        expect(generated_files_dir_content).to match_array(additional_resource_dir_content.push(@manifest_name))
+    end
+  end
+
+  context 'when a generated manifest is detected' do
+
+    before(:context) do
+      @generated_files = Dir.mktmpdir
+      @additional_resource = 'spec/tasks/copy_deployment_required_files/additional-resource'
+      @manifest_name = 'a-depls.yml'
+
+      @output = execute('-c concourse/tasks/copy_deployment_required_files.yml ' \
+        '-i scripts-resource=. ' \
+        '-i template-resource=spec/tasks/copy_deployment_required_files/template-resource ' \
+        '-i credentials-resource=spec/tasks/copy_deployment_required_files/credentials-resource ' \
+        "-i additional-resource=#{@additional_resource} " \
+        "-o generated-files=#{@generated_files} ",
+                        'CUSTOM_SCRIPT_DIR' => 'template-resource/a-depls',
+                        'SECRETS_DIR' => 'credentials-resource/a-depls',
+                        'MANIFEST_NAME' => @manifest_name)
+    end
+    after(:context) do
+      FileUtils.rm_rf @generated_files if File.exist?(@generated_files)
+    end
+
+    it 'displays an execution message' do
+      expect(@output).to include("'#{@manifest_name}' already exists in additional-resource. Skipping copy !!!")
+    end
+
+    it 'exists a manifest file in generation dir' do
+      expect(File).to exist(File.join(@generated_files, @manifest_name))
+    end
+
+    it 'adds additional resource to generated' do
+      additional_resource_dir_content = Dir[File.join(@additional_resource, '*')]&.map! { |filename| File.basename(filename) }
+
+      additional_resource_dir_content&.each do |filename|
+        expect(File).to exist(File.join(@generated_files,filename))
+      end
+    end
+  end
+
+
+end

--- a/spec/tasks/copy_deployment_required_files/template-resource/default-manifest-depls/default-manifest-depls.yml
+++ b/spec/tasks/copy_deployment_required_files/template-resource/default-manifest-depls/default-manifest-depls.yml
@@ -1,0 +1,2 @@
+---
+name: default-manifest


### PR DESCRIPTION
The bosh deploy task still expects a manifest name, but it can be
provided by a xxx-tpl.yml or directly as xxx.yml

close #25