### PR TITLE
pipeline(s3-*-upload): add pipeline to upload bosh releases or stemcells to s3

### DIFF
--- a/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
@@ -1,0 +1,199 @@
+---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
+resources:
+
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: ((slack-webhook))
+    ca_certs:
+    - domain: ((slack-custom-domain))
+      cert: ((slack-custom-cert))
+    - domain: ((slack-custom-root-domain))
+      cert: ((slack-custom-root-cert))
+
+- name: cf-ops-automation
+  type: git
+  source:
+    uri: ((cf-ops-automation-uri))
+    branch: ((cf-ops-automation-branch))
+    tag_filter: ((cf-ops-automation-tag-filter))
+    skip_ssl_verification: true
+
+<% uniq_releases= {} %>
+<% all_dependencies.sort.each do |name,boshrelease| %>
+<% boshrelease["releases"]&.each do |release, info|  %>
+<% uniq_releases[release]= info %>
+<% end %>
+<% end %>
+
+<% uniq_releases.sort.each do |release, info|  %>
+- name: <%= release %>
+  <% if info["base_location"].include?("bosh.io") %>
+  type: bosh-io-release
+  source:
+    repository: <%= info["repository"] %>
+  <% else %>
+  type: github-release
+  source:
+    user: <%= info["repository"].split('/').first %>
+    repository: <%= info["repository"].split('/').last %>
+  <% end %>
+
+- name: <%= release %>-s3
+  type: s3
+  source:
+    bucket: ((s3-br-bucket))
+    region_name: ((s3-br-region-name))
+    regexp: <%= release %>/<%= release %>-(.*).tgz
+    access_key_id: ((s3-br-access-key-id))
+    secret_access_key: ((s3-br-secret-key))
+    endpoint: ((s3-br-endpoint))
+    skip_ssl_verification: ((s3-br-skip-ssl-verification))
+<% end %>
+
+
+jobs:
+
+- name: init-concourse-boshrelease-for-<%= depls %>
+  on_failure:
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: cf-ops-automation
+      params: { submodules: none}
+      attempts: 3
+  - task: generate-<%= depls %>-flight-plan
+    output_mapping: {result-dir: init-<%= depls %>-plan}
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/busyboxplus, tag: "git"}
+      outputs:
+        - name: result-dir
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          <% uniq_releases.sort.each do |name,_| %>
+          echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from version:((<%= name %>-version))" >> result-dir/flight-plan
+          <% end %>
+
+      params:
+        BUILD_PIPELINE_NAME: <%= depls %>-s3-br-upload-generated
+  - task: fly-into-concourse
+    input_mapping: {fly-cmd: init-<%= depls %>-plan}
+    output_mapping: {flight-report: concourse-<%= depls %>-init-report}
+    file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
+    params:
+      ATC_EXTERNAL_URL: ((concourse-<%= depls %>-target))
+      FLY_USERNAME: ((concourse-<%= depls %>-username))
+      FLY_PASSWORD:  ((concourse-<%= depls %>-password))
+
+<% uniq_releases.sort.each do |release, info|  %>
+
+- name: upload-current-<%= release %>
+  serial_groups: [<%= release %>]
+  on_failure:
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+    - aggregate:
+      - get: <%= release %>
+        attempts: 3
+        version: {version: ((<%= release %>-version))}
+        trigger: true
+        params: {tarball: true}
+      - get: cf-ops-automation
+        params: { submodules: none}
+        attempts: 3
+        passed: [ init-concourse-boshrelease-for-<%= depls %> ]
+    - task: generate-<%= release %>-name
+      input_mapping: {release: <%= release %>}
+      output_mapping: {result-dir: <%= release %>}
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source: {repository: concourse/busyboxplus, tag: "git"}
+        inputs:
+          - name: release
+        outputs:
+          - name: result-dir
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            VERSION=$(cat release/version)
+            cp release/release.tgz result-dir/${RELEASE_PREFIX}-${VERSION}.tgz
+        params:
+          RELEASE_PREFIX: <%= release %>
+    - put: <%= release %>-s3
+      params:
+        file: <%= release %>/*.tgz
+        acl: public-read
+
+- name: upload-latest-<%= release %>
+  serial_groups: [<%= release %>]
+  on_failure:
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+    - aggregate:
+      - get: <%= release %>
+        attempts: 3
+        version: every
+        trigger: true
+        params: {tarball: true}
+      - get: cf-ops-automation
+        params: { submodules: none}
+        attempts: 3
+        passed: [ upload-current-<%= release %> ]
+    - task: generate-<%= release %>-name
+      input_mapping: {release: <%= release %>}
+      output_mapping: {result-dir: <%= release %>}
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source: {repository: concourse/busyboxplus, tag: "git"}
+        inputs:
+          - name: release
+        outputs:
+          - name: result-dir
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            VERSION=$(cat release/version)
+            cp release/release.tgz result-dir/${RELEASE_PREFIX}-${VERSION}.tgz
+        params:
+          RELEASE_PREFIX: <%= release %>
+    - put: <%= release %>-s3
+      params:
+        file: <%= release %>/*.tgz
+        acl: public-read
+
+<% end %>

--- a/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
@@ -90,7 +90,6 @@ jobs:
           <% uniq_releases.sort.each do |name,_| %>
           echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from version:((<%= name %>-version))" >> result-dir/flight-plan
           <% end %>
-
       params:
         BUILD_PIPELINE_NAME: <%= depls %>-s3-br-upload-generated
   - task: fly-into-concourse

--- a/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
@@ -1,0 +1,149 @@
+---
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+
+resources:
+
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: ((slack-webhook))
+    ca_certs:
+    - domain: ((slack-custom-domain))
+      cert: ((slack-custom-cert))
+    - domain: ((slack-custom-root-domain))
+      cert: ((slack-custom-root-cert))
+
+- name: cf-ops-automation
+  type: git
+  source:
+    uri: ((cf-ops-automation-uri))
+    branch: ((cf-ops-automation-branch))
+    tag_filter: ((cf-ops-automation-tag-filter))
+    skip_ssl_verification: true
+
+<% uniq_stemcells= {} %>
+<% all_dependencies.sort.each do |name,boshrelease| %>
+<% boshrelease["stemcells"]&.each do |stemcell, info|  %>
+<% uniq_stemcells[stemcell]= info %>
+<% end %>
+<% end %>
+
+<% uniq_stemcells.sort.each do |stemcell, info|  %>
+- name: <%= stemcell %>
+  type: bosh-io-stemcell
+  source:
+    name: <%= stemcell %>
+
+- name: <%= stemcell %>-s3
+  type: s3
+  source:
+    bucket: ((s3-stemcell-bucket))
+    region_name: ((s3-stemcell-region-name))
+    # customization is required to remove bosh prefix in stemcell name
+    regexp: <%= stemcell %>/bosh-stemcell-(.*)-<%= stemcell.sub('bosh-','') %>.tgz
+    access_key_id: ((s3-stemcell-access-key-id))
+    secret_access_key: ((s3-stemcell-secret-key))
+    endpoint: ((s3-stemcell-endpoint))
+    skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
+<% end %>
+
+
+jobs:
+
+- name: init-concourse-stemcells-for-<%= depls %>
+  on_failure:
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: cf-ops-automation
+      params: { submodules: none}
+      attempts: 3
+  - task: generate-<%= depls %>-flight-plan
+    output_mapping: {result-dir: init-<%= depls %>-plan}
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: concourse/busyboxplus, tag: "git"}
+      outputs:
+        - name: result-dir
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          <% uniq_stemcells.sort.each do |name,_| %>
+          echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from version:((stemcell-version))" >> result-dir/flight-plan
+          <% end %>
+      params:
+        BUILD_PIPELINE_NAME: <%= depls %>-s3-stemcell-upload-generated
+  - task: fly-into-concourse
+    input_mapping: {fly-cmd: init-<%= depls %>-plan}
+    output_mapping: {flight-report: concourse-<%= depls %>-init-report}
+    file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
+    params:
+      ATC_EXTERNAL_URL: ((concourse-<%= depls %>-target))
+      FLY_USERNAME: ((concourse-<%= depls %>-username))
+      FLY_PASSWORD:  ((concourse-<%= depls %>-password))
+
+<% uniq_stemcells.sort.each do |stemcell, _|  %>
+
+- name: upload-current-<%= stemcell %>
+  on_failure:
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+    - aggregate:
+      - get: <%= stemcell %>
+        attempts: 3
+        version: {version: ((stemcell-version))}
+        trigger: true
+        params: {tarball: true, preserve_filename: true}
+      - get: cf-ops-automation
+        params: { submodules: none}
+        attempts: 3
+        passed: [ init-concourse-stemcells-for-<%= depls %> ]
+    - put: <%= stemcell %>-s3
+      params:
+        file: <%= stemcell %>/*.tgz
+        acl: public-read
+
+
+- name: upload-lastest-<%= stemcell %>
+  on_failure:
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+    - aggregate:
+      - get: <%= stemcell %>
+        attempts: 3
+        version: every
+        trigger: true
+        params: {tarball: true, preserve_filename: true}
+      - get: cf-ops-automation
+        params: { submodules: none}
+        attempts: 3
+        passed: [ upload-current-<%= stemcell %> ]
+    - put: <%= stemcell %>-s3
+      params:
+        file: <%= stemcell %>/*.tgz
+        acl: public-read
+
+<% end %>

--- a/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
@@ -51,7 +51,6 @@ resources:
     skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
 <% end %>
 
-
 jobs:
 
 - name: init-concourse-stemcells-for-<%= depls %>

--- a/lib/ci_deployment_overview.rb
+++ b/lib/ci_deployment_overview.rb
@@ -34,7 +34,7 @@ class CiDeploymentOverview
       puts "Processing #{dirname}"
       Dir[filename + '/ci-deployment-overview.yml'].each do |deployment_file|
         puts "CI deployment detected: #{dirname}"
-        current_deployment=YAML.load_file(deployment_file)
+        current_deployment = YAML.load_file(deployment_file)
         raise "#{deployment_file} - Invalid deployment: expected 'ci-deployment' key as yaml root" if (current_deployment.nil? || current_deployment['ci-deployment'].nil?)
         current_deployment['ci-deployment'].each do |deployment_name, deployment_details|
           raise "#{deployment_file} - missing keys: expecting keys target and pipelines" if deployment_details.nil?
@@ -52,11 +52,11 @@ class CiDeploymentOverview
           end
         end
       end
-      #puts "##############################"
+      # puts "##############################"
       #    ci_deployment.each do |aDep|
       #        puts aDep
       #    end
-      #puts "##############################"
+      # puts "##############################"
     end
     puts "ci_deployment loaded: \n#{YAML.dump(ci_deployment)}"
     ci_deployment

--- a/scripts/concourse-manual-pipelines-update.rb
+++ b/scripts/concourse-manual-pipelines-update.rb
@@ -88,12 +88,16 @@ def set_pipeline(target_name:,name:, config:, load: [],options: [])
   return if OPTIONS.has_key?(:without) && name.include?(OPTIONS[:without])
   puts "   #{name} pipeline"
 
-  puts system(%{bash -c "fly -t #{target_name} set-pipeline \
+  fly_cmd=(%{bash -c "fly -t #{target_name} set-pipeline \
     -p #{PIPELINE_PREFIX}#{name} \
     -c #{config} \
-    #{load.collect { |l| "-l #{l}" }.join(' ')} \
-    #{options.collect { |opt| "#{opt}" }.join(' ')}
+  #{load.collect { |l| "-l #{l}" }.join(' ')} \
+  #{options.collect { |opt| "#{opt}" }.join(' ')}
   "})
+
+  puts "Executing: #{fly_cmd}"
+
+  puts system(fly_cmd)
 end
 
 def generate_full_path_for_concourse_vars_files(vars_files)

--- a/scripts/generate-depls.rb
+++ b/scripts/generate-depls.rb
@@ -81,14 +81,7 @@ depls = OPTIONS[:depls]
 opt_parser.abort("#{opt_parser}") if depls.nil?
 
 if OPTIONS[:input_pipelines].nil?
-  OPTIONS[:input_pipelines] =
-  [
-    "#{OPTIONS[:ops_automation]}/concourse/pipelines/template/depls-pipeline.yml.erb",
-    "#{OPTIONS[:ops_automation]}/concourse/pipelines/template/cf-apps-pipeline.yml.erb",
-    "#{OPTIONS[:ops_automation]}/concourse/pipelines/template/news-pipeline.yml.erb",
-    "#{OPTIONS[:ops_automation]}/concourse/pipelines/template/sync-helper-pipeline.yml.erb",
-    "#{OPTIONS[:ops_automation]}/concourse/pipelines/template/init-pipeline.yml.erb"
-  ]
+  OPTIONS[:input_pipelines] = Dir["#{OPTIONS[:ops_automation]}/concourse/pipelines/template/*.yml.erb"]
 end
 
 BOSH_CERT = BoshCertificates.new.load_from_location OPTIONS[:secret_path], BOSH_CERT_LOCATIONS

--- a/spec/scripts/generate-depls/fixtures/references/empty-s3-br-upload.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-s3-br-upload.yml
@@ -1,0 +1,67 @@
+---
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+resources:
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: "((slack-webhook))"
+    ca_certs:
+    - domain: "((slack-custom-domain))"
+      cert: "((slack-custom-cert))"
+    - domain: "((slack-custom-root-domain))"
+      cert: "((slack-custom-root-cert))"
+- name: cf-ops-automation
+  type: git
+  source:
+    uri: "((cf-ops-automation-uri))"
+    branch: "((cf-ops-automation-branch))"
+    tag_filter: "((cf-ops-automation-tag-filter))"
+    skip_ssl_verification: true
+jobs:
+- name: init-concourse-boshrelease-for-dummy-depls
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+  - task: generate-dummy-depls-flight-plan
+    output_mapping:
+      result-dir: init-dummy-depls-plan
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: concourse/busyboxplus
+          tag: git
+      outputs:
+      - name: result-dir
+      run:
+        path: sh
+        args:
+        - "-exc"
+        - ''
+      params:
+        BUILD_PIPELINE_NAME: dummy-depls-s3-br-upload-generated
+  - task: fly-into-concourse
+    input_mapping:
+      fly-cmd: init-dummy-depls-plan
+    output_mapping:
+      flight-report: concourse-dummy-depls-init-report
+    file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
+    params:
+      ATC_EXTERNAL_URL: "((concourse-dummy-depls-target))"
+      FLY_USERNAME: "((concourse-dummy-depls-username))"
+      FLY_PASSWORD: "((concourse-dummy-depls-password))"

--- a/spec/scripts/generate-depls/fixtures/references/empty-s3-stemcell-upload.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-s3-stemcell-upload.yml
@@ -1,0 +1,67 @@
+---
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+resources:
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: "((slack-webhook))"
+    ca_certs:
+    - domain: "((slack-custom-domain))"
+      cert: "((slack-custom-cert))"
+    - domain: "((slack-custom-root-domain))"
+      cert: "((slack-custom-root-cert))"
+- name: cf-ops-automation
+  type: git
+  source:
+    uri: "((cf-ops-automation-uri))"
+    branch: "((cf-ops-automation-branch))"
+    tag_filter: "((cf-ops-automation-tag-filter))"
+    skip_ssl_verification: true
+jobs:
+- name: init-concourse-stemcells-for-dummy-depls
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+  - task: generate-dummy-depls-flight-plan
+    output_mapping:
+      result-dir: init-dummy-depls-plan
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: concourse/busyboxplus
+          tag: git
+      outputs:
+      - name: result-dir
+      run:
+        path: sh
+        args:
+        - "-exc"
+        - ''
+      params:
+        BUILD_PIPELINE_NAME: dummy-depls-s3-stemcell-upload-generated
+  - task: fly-into-concourse
+    input_mapping:
+      fly-cmd: init-dummy-depls-plan
+    output_mapping:
+      flight-report: concourse-dummy-depls-init-report
+    file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
+    params:
+      ATC_EXTERNAL_URL: "((concourse-dummy-depls-target))"
+      FLY_USERNAME: "((concourse-dummy-depls-username))"
+      FLY_PASSWORD: "((concourse-dummy-depls-password))"

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
@@ -1,0 +1,190 @@
+---
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+resources:
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: "((slack-webhook))"
+    ca_certs:
+    - domain: "((slack-custom-domain))"
+      cert: "((slack-custom-cert))"
+    - domain: "((slack-custom-root-domain))"
+      cert: "((slack-custom-root-cert))"
+- name: cf-ops-automation
+  type: git
+  source:
+    uri: "((cf-ops-automation-uri))"
+    branch: "((cf-ops-automation-branch))"
+    tag_filter: "((cf-ops-automation-tag-filter))"
+    skip_ssl_verification: true
+- name: ntp_boshrelease
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry-community/ntp-release
+- name: ntp_boshrelease-s3
+  type: s3
+  source:
+    bucket: "((s3-br-bucket))"
+    region_name: "((s3-br-region-name))"
+    regexp: ntp_boshrelease/ntp_boshrelease-(.*).tgz
+    access_key_id: "((s3-br-access-key-id))"
+    secret_access_key: "((s3-br-secret-key))"
+    endpoint: "((s3-br-endpoint))"
+    skip_ssl_verification: "((s3-br-skip-ssl-verification))"
+jobs:
+- name: init-concourse-boshrelease-for-simple-depls
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+  - task: generate-simple-depls-flight-plan
+    output_mapping:
+      result-dir: init-simple-depls-plan
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: concourse/busyboxplus
+          tag: git
+      outputs:
+      - name: result-dir
+      run:
+        path: sh
+        args:
+        - "-exc"
+        - |2
+
+          echo "check-resource -r $BUILD_PIPELINE_NAME/ntp_boshrelease --from version:((ntp_boshrelease-version))" >> result-dir/flight-plan
+      params:
+        BUILD_PIPELINE_NAME: simple-depls-s3-br-upload-generated
+  - task: fly-into-concourse
+    input_mapping:
+      fly-cmd: init-simple-depls-plan
+    output_mapping:
+      flight-report: concourse-simple-depls-init-report
+    file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
+    params:
+      ATC_EXTERNAL_URL: "((concourse-simple-depls-target))"
+      FLY_USERNAME: "((concourse-simple-depls-username))"
+      FLY_PASSWORD: "((concourse-simple-depls-password))"
+- name: upload-current-ntp_boshrelease
+  serial_groups:
+  - ntp_boshrelease
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: ntp_boshrelease
+      attempts: 3
+      version:
+        version: "((ntp_boshrelease-version))"
+      trigger: true
+      params:
+        tarball: true
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+      passed:
+      - init-concourse-boshrelease-for-simple-depls
+  - task: generate-ntp_boshrelease-name
+    input_mapping:
+      release: ntp_boshrelease
+    output_mapping:
+      result-dir: ntp_boshrelease
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: concourse/busyboxplus
+          tag: git
+      inputs:
+      - name: release
+      outputs:
+      - name: result-dir
+      run:
+        path: sh
+        args:
+        - "-exc"
+        - |
+          VERSION=$(cat release/version)
+          cp release/release.tgz result-dir/${RELEASE_PREFIX}-${VERSION}.tgz
+      params:
+        RELEASE_PREFIX: ntp_boshrelease
+  - put: ntp_boshrelease-s3
+    params:
+      file: ntp_boshrelease/*.tgz
+      acl: public-read
+- name: upload-latest-ntp_boshrelease
+  serial_groups:
+  - ntp_boshrelease
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: ntp_boshrelease
+      attempts: 3
+      version: every
+      trigger: true
+      params:
+        tarball: true
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+      passed:
+      - upload-current-ntp_boshrelease
+  - task: generate-ntp_boshrelease-name
+    input_mapping:
+      release: ntp_boshrelease
+    output_mapping:
+      result-dir: ntp_boshrelease
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: concourse/busyboxplus
+          tag: git
+      inputs:
+      - name: release
+      outputs:
+      - name: result-dir
+      run:
+        path: sh
+        args:
+        - "-exc"
+        - |
+          VERSION=$(cat release/version)
+          cp release/release.tgz result-dir/${RELEASE_PREFIX}-${VERSION}.tgz
+      params:
+        RELEASE_PREFIX: ntp_boshrelease
+  - put: ntp_boshrelease-s3
+    params:
+      file: ntp_boshrelease/*.tgz
+      acl: public-read

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-stemcell-upload-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-stemcell-upload-ref.yml
@@ -1,0 +1,139 @@
+---
+resource_types:
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+resources:
+- name: failure-alert
+  type: slack-notification
+  source:
+    url: "((slack-webhook))"
+    ca_certs:
+    - domain: "((slack-custom-domain))"
+      cert: "((slack-custom-cert))"
+    - domain: "((slack-custom-root-domain))"
+      cert: "((slack-custom-root-cert))"
+- name: cf-ops-automation
+  type: git
+  source:
+    uri: "((cf-ops-automation-uri))"
+    branch: "((cf-ops-automation-branch))"
+    tag_filter: "((cf-ops-automation-tag-filter))"
+    skip_ssl_verification: true
+- name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+  type: bosh-io-stemcell
+  source:
+    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+- name: bosh-openstack-kvm-ubuntu-trusty-go_agent-s3
+  type: s3
+  source:
+    bucket: "((s3-stemcell-bucket))"
+    region_name: "((s3-stemcell-region-name))"
+    regexp: bosh-openstack-kvm-ubuntu-trusty-go_agent/bosh-stemcell-(.*)-openstack-kvm-ubuntu-trusty-go_agent.tgz
+    access_key_id: "((s3-stemcell-access-key-id))"
+    secret_access_key: "((s3-stemcell-secret-key))"
+    endpoint: "((s3-stemcell-endpoint))"
+    skip_ssl_verification: "((s3-stemcell-skip-ssl-verification))"
+jobs:
+- name: init-concourse-stemcells-for-simple-depls
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+  - task: generate-simple-depls-flight-plan
+    output_mapping:
+      result-dir: init-simple-depls-plan
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: concourse/busyboxplus
+          tag: git
+      outputs:
+      - name: result-dir
+      run:
+        path: sh
+        args:
+        - "-exc"
+        - |2
+
+          echo "check-resource -r $BUILD_PIPELINE_NAME/bosh-openstack-kvm-ubuntu-trusty-go_agent --from version:((stemcell-version))" >> result-dir/flight-plan
+
+      params:
+        BUILD_PIPELINE_NAME: simple-depls-s3-stemcell-upload-generated
+  - task: fly-into-concourse
+    input_mapping:
+      fly-cmd: init-simple-depls-plan
+    output_mapping:
+      flight-report: concourse-simple-depls-init-report
+    file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
+    params:
+      ATC_EXTERNAL_URL: "((concourse-simple-depls-target))"
+      FLY_USERNAME: "((concourse-simple-depls-username))"
+      FLY_PASSWORD: "((concourse-simple-depls-password))"
+- name: upload-current-bosh-openstack-kvm-ubuntu-trusty-go_agent
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: bosh-openstack-kvm-ubuntu-trusty-go_agent
+      attempts: 3
+      version:
+        version: "((stemcell-version))"
+      trigger: true
+      params:
+        tarball: true
+        preserve_filename: true
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+      passed:
+      - init-concourse-stemcells-for-simple-depls
+  - put: bosh-openstack-kvm-ubuntu-trusty-go_agent-s3
+    params:
+      file: bosh-openstack-kvm-ubuntu-trusty-go_agent/*.tgz
+      acl: public-read
+- name: upload-lastest-bosh-openstack-kvm-ubuntu-trusty-go_agent
+  on_failure:
+    put: failure-alert
+    params:
+      channel: "((slack-channel))"
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+  - aggregate:
+    - get: bosh-openstack-kvm-ubuntu-trusty-go_agent
+      attempts: 3
+      version: every
+      trigger: true
+      params:
+        tarball: true
+        preserve_filename: true
+    - get: cf-ops-automation
+      params:
+        submodules: none
+      attempts: 3
+      passed:
+      - upload-current-bosh-openstack-kvm-ubuntu-trusty-go_agent
+  - put: bosh-openstack-kvm-ubuntu-trusty-go_agent-s3
+    params:
+      file: bosh-openstack-kvm-ubuntu-trusty-go_agent/*.tgz
+      acl: public-read

--- a/spec/scripts/generate-depls/generate_depls_for_s3_br_upload_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_s3_br_upload_pipeline_spec.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+
+require 'digest'
+require 'yaml'
+require 'open3'
+require 'rspec'
+require_relative 'test_helper'
+
+# require 'spec_helper.rb'
+
+describe 'generate-depls for s3 boshrelease upload pipeline' do
+
+  ci_path = Dir.pwd
+  test_path = File.join(ci_path, '/spec/scripts/generate-depls')
+  fixture_path = File.join(test_path, '/fixtures')
+
+
+  context 'when a simple deployment is used' do
+    let(:depls_name) { 'simple-depls' }
+    let(:output_path) { Dir.mktmpdir }
+    let(:templates_path) { "#{fixture_path}/templates" }
+    let(:secrets_path) { "#{fixture_path}/secrets" }
+
+    after do
+      FileUtils.rm_rf(output_path) unless output_path.nil?
+    end
+
+    context 'when valid' do
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/s3-br-upload-pipeline.yml.erb" }
+
+      stdout_str = stderr_str = ''
+      before do
+        stdout_str, stderr_str, = Open3.capture3("#{ci_path}/scripts/generate-depls.rb #{options}")
+      end
+
+      it 'no error message are displayed' do
+        expect(stderr_str).to eq('')
+      end
+
+      it 'only s3-br-upload template is processed' do
+        expect(stdout_str).to include('processing ./concourse/pipelines/template/s3-br-upload-pipeline.yml.erb').and \
+          include('1 concourse pipeline templates were processed')
+      end
+
+      context 'when s3-br-upload pipeline is generated' do
+        it_behaves_like 'pipeline checker', 'simple-depls-s3-br-upload-generated.yml', 'simple-depls-s3-br-upload-ref.yml'
+      end
+
+    end
+
+
+  end
+
+end
+
+
+
+

--- a/spec/scripts/generate-depls/generate_depls_for_s3_stemcell_upload_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_s3_stemcell_upload_pipeline_spec.rb
@@ -1,0 +1,58 @@
+# encoding: utf-8
+
+require 'digest'
+require 'yaml'
+require 'open3'
+require 'rspec'
+require_relative 'test_helper'
+
+# require 'spec_helper.rb'
+
+describe 'generate-depls for s3 stemcell upload pipeline' do
+
+  ci_path = Dir.pwd
+  test_path = File.join(ci_path, '/spec/scripts/generate-depls')
+  fixture_path = File.join(test_path, '/fixtures')
+
+
+  context 'when a simple deployment is used' do
+    let(:depls_name) { 'simple-depls' }
+    let(:output_path) { Dir.mktmpdir }
+    let(:templates_path) { "#{fixture_path}/templates" }
+    let(:secrets_path) { "#{fixture_path}/secrets" }
+
+    after do
+      FileUtils.rm_rf(output_path) unless output_path.nil?
+    end
+
+    context 'when valid' do
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb" }
+
+      stdout_str = stderr_str = ''
+      before do
+        stdout_str, stderr_str, = Open3.capture3("#{ci_path}/scripts/generate-depls.rb #{options}")
+      end
+
+      it 'no error message are displayed' do
+        expect(stderr_str).to eq('')
+      end
+
+      it 'only s3-stemcell-upload template is processed' do
+        expect(stdout_str).to include('processing ./concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb').and \
+          include('1 concourse pipeline templates were processed')
+      end
+
+      context 'when s3-stemcell-upload pipeline is generated' do
+        it_behaves_like 'pipeline checker', 'simple-depls-s3-stemcell-upload-generated.yml', 'simple-depls-s3-stemcell-upload-ref.yml'
+      end
+
+    end
+
+
+  end
+
+end
+
+
+
+

--- a/spec/scripts/generate-depls/generate_depls_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_spec.rb
@@ -156,6 +156,14 @@ describe 'generate-depls' do
         it_behaves_like 'pipeline checker', 'dummy-depls-sync-helper-generated.yml', 'empty-sync-helper.yml'
       end
 
+      context 'when s3-stemcell-upload pipeline is checked' do
+        it_behaves_like 'pipeline checker', 'dummy-depls-s3-stemcell-upload-generated.yml', 'empty-s3-stemcell-upload.yml'
+      end
+
+      context 'when s3-br-upload pipeline is checked' do
+        it_behaves_like 'pipeline checker', 'dummy-depls-s3-br-upload-generated.yml', 'empty-s3-br-upload.yml'
+      end
+
     end
   end
 end

--- a/spec/scripts/generate-depls/test_helper.rb
+++ b/spec/scripts/generate-depls/test_helper.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'pipeline checker' do |generated_pipeline_name, reference_
     reference_file = YAML.load_file("#{test_path}/fixtures/references/#{reference_pipeline}") || {}
     expected_generated_dir = File.join(output_path, 'pipelines')
     expected_generated_filename = File.join(expected_generated_dir, generated_pipeline_name)
-    raise "file not found: #{expected_generated_filename}. Dir content: #{Dir[expected_generated_dir '/../*']}"  unless File.exist?(expected_generated_filename)
+    raise "file not found: #{expected_generated_filename}. Dir content: #{Dir.glob(expected_generated_dir + '/*')}" unless File.exist?(expected_generated_filename)
     generated_file = YAML.load_file(expected_generated_filename)
     expect(generated_file.to_yaml).to eq(reference_file.to_yaml)
   end


### PR DESCRIPTION
This is a first step to be independent from bosh.io availability,
and to save bandwith.
 
Restrictions: 
 - pipelines must be enabled for each root deployment

 - only the current version and the latest version are uploaded (Concourse
is not able to load the full history)