### PR TITLE
task(post_bosh_deploy): switch to cf-cli image

### DIFF
--- a/concourse/tasks/post_bosh_deploy.yml
+++ b/concourse/tasks/post_bosh_deploy.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: governmentpaas/curl-ssl
+    repository: governmentpaas/cf-cli
 inputs:
   - name: scripts-resource
   - name: template-resource

--- a/spec/tasks/post_bosh_deploy/task_spec.rb
+++ b/spec/tasks/post_bosh_deploy/task_spec.rb
@@ -4,6 +4,16 @@ require 'yaml'
 
 describe 'post_bosh_deploy task' do
 
+  context 'Pre-requisite' do
+    let(:task) { YAML.load_file 'concourse/tasks/post_bosh_deploy.yml' }
+
+    it 'uses alphagov cf-cli image' do
+      docker_image_used = task['image_resource']['source']['repository'].to_s
+      expect(docker_image_used).to match('governmentpaas/cf-cli')
+    end
+
+  end
+
 
   context 'when no script is detected' do
 


### PR DESCRIPTION
To be able to use other tools based on dynamically linked binary, we
 switch to cf-cli image. Indeed, it doesn't work with curl-ssl container
 because Alpine uses musl-libc.

The `libc6-compat` package provides `ld-linux-x86-64.so.2` which enables
 glibc linked binaries to work. Another commit will follow to make this
 work for 64bit binaries on Alpine <= 3.5

See https://github.com/alphagov/paas-docker-cloudfoundry-tools/commits/master/cf-cli/Dockerfile