### PR TITLE
pipeline(depls): move stemcell support from bosh.io to S3

### DIFF
--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -51,9 +51,18 @@ resources:
 
 <% unless all_dependencies.empty? %>
 - name: bosh-stemcell
-  type: bosh-io-stemcell
+#    name: {{stemcell-name}}
+  type: s3
   source:
-    name: {{stemcell-name}}
+    bucket: ((s3-stemcell-bucket))
+    region_name: ((s3-stemcell-region-name))
+    # customization is required to remove bosh prefix in stemcell name
+    regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
+    access_key_id: ((s3-stemcell-access-key-id))
+    secret_access_key: ((s3-stemcell-secret-key))
+    endpoint: ((s3-stemcell-endpoint))
+    skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
+
 <% end %>
 
 - name: secrets-<%=depls %>
@@ -433,7 +442,7 @@ jobs:
   plan:
     - aggregate:
       - get: bosh-stemcell
-        version: { version: {{stemcell-version}} }
+        version: { path: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz }
         trigger: true
         attempts: 3
       - get: cf-ops-automation
@@ -562,7 +571,7 @@ jobs:
         target_file: bosh-generated-config/bosh_target
         <% end %>
         stemcells:
-          - bosh-stemcell/stemcell.tgz
+          - bosh-stemcell/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz
         releases: <%= '[]' if boshrelease['releases']&.empty? %>
           <% boshrelease['releases']&.sort&.each do |release, info| %>
           - <%= release %>/release.tgz
@@ -787,7 +796,8 @@ jobs:
           echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from version:{{<%= name %>-version}}" >> result-dir/flight-plan
           <% end %>
 
-          echo "check-resource -r $BUILD_PIPELINE_NAME/bosh-stemcell --from version:{{stemcell-version}}" >> result-dir/flight-plan
+          echo "check-resource -r $BUILD_PIPELINE_NAME/bosh-stemcell --from path:((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz" >> result-dir/flight-plan
+
       params:
         BUILD_PIPELINE_NAME: <%= depls %>-generated
   - task: fly-into-concourse

--- a/lib/directory_initializer.rb
+++ b/lib/directory_initializer.rb
@@ -24,9 +24,10 @@ class DirectoryInitializer
 
     files_to_create << "#{@secrets_dir}/#{@root_deployment_name}/secrets/meta.yml"
     files_to_create << "#{@secrets_dir}/#{@root_deployment_name}/secrets/secrets.yml"
-    # files_to_create << "#{@secrets_dir}/#{@root_deployment_name}/ci-deployment-overview.yml"
 
     create_non_existing_files files_to_create
+    generate_empty_map_yaml "#{@secrets_dir}/shared/secrets.yml"
+    generate_empty_map_yaml "#{@secrets_dir}/shared/meta.yml"
     generate_default_ci_deployment_overview
   end
 
@@ -75,6 +76,15 @@ class DirectoryInitializer
     File.open(filename, 'w') {
         |file| file << YAML.dump(file_content)
     }
+  end
+
+  def generate_empty_map_yaml(filename)
+    empty_map = {}
+
+    File.new(filename, 'w') do
+        |file| file << YAML.dump(empty_map)
+    end
+
   end
 
   def generate_default_ci_deployment_overview

--- a/lib/secrets.rb
+++ b/lib/secrets.rb
@@ -11,11 +11,11 @@ class Secrets
 
     Dir[@secrets_root_dir].select { |f| File.directory? f }.each do |depls_level_dir|
       depls_level_name = depls_level_dir.split('/').last
-      puts "Processing depls level: #{depls_level_name}"
+      puts "Processing Secrets depls level: #{depls_level_name}"
       dir_overview[depls_level_name] = []
       Dir[depls_level_dir + '/*'].select { |f| File.directory? f }.each do |boshrelease_level_dir|
         boshrelease_level_name= boshrelease_level_dir.split('/').last
-        puts "Processing boshrelease level: #{depls_level_name} -- #{boshrelease_level_name}"
+        puts "Processing Secrets boshrelease level: #{depls_level_name} -- #{boshrelease_level_name}"
         dir_overview[depls_level_name] << boshrelease_level_name
       end
     end

--- a/spec/lib/directory_initializer_spec.rb
+++ b/spec/lib/directory_initializer_spec.rb
@@ -29,12 +29,24 @@ describe DirectoryInitializer do
         subject.setup_secrets!
       end
 
-      it 'create a shared dir' do
-        expect( Dir.exist?("#{secrets_dir}/shared") ).to be_truthy
+      context 'when shared_dir structure is valid' do
+        it 'creates a shared dir' do
+          expect( Dir).to exist("#{secrets_dir}/shared")
+        end
+
+        it 'contains a secrets.yml' do
+          expect( File).to exist("#{secrets_dir}/shared/secrets.yml")
+        end
+
+        it 'contains a meta.yml' do
+          expect( File).to exist("#{secrets_dir}/shared/meta.yml")
+        end
+
       end
 
+
       it 'create a ci-deployment-overview.yml in new root deployment' do
-        expect(File.exist?("#{secrets_dir}/#{root_deployment_name}/ci-deployment-overview.yml")).to be_truthy
+        expect(File).to exist("#{secrets_dir}/#{root_deployment_name}/ci-deployment-overview.yml")
       end
 
       it 'create meta and secrets files in new root deployment' do

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
@@ -41,9 +41,16 @@ resources:
       - domain: {{slack-custom-root-domain}}
         cert: {{slack-custom-root-cert}}
   - name: bosh-stemcell
-    type: bosh-io-stemcell
+    type: s3
     source:
-      name: {{stemcell-name}}
+      bucket: ((s3-stemcell-bucket))
+      region_name: ((s3-stemcell-region-name))
+      regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
+      access_key_id: ((s3-stemcell-access-key-id))
+      secret_access_key: ((s3-stemcell-secret-key))
+      endpoint: ((s3-stemcell-endpoint))
+      skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
+
   - name: secrets-delete-depls
     type: git
     source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -50,9 +50,15 @@ resources:
       cert: {{slack-custom-root-cert}}
 
 - name: bosh-stemcell
-  type: bosh-io-stemcell
+  type: s3
   source:
-    name: {{stemcell-name}}
+    bucket: ((s3-stemcell-bucket))
+    region_name: ((s3-stemcell-region-name))
+    regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
+    access_key_id: ((s3-stemcell-access-key-id))
+    secret_access_key: ((s3-stemcell-secret-key))
+    endpoint: ((s3-stemcell-endpoint))
+    skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
 
 - name: secrets-simple-depls
   type: git
@@ -312,7 +318,7 @@ jobs:
   plan:
     - aggregate:
       - get: bosh-stemcell
-        version: { version: {{stemcell-version}} }
+        version: { path: "((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz" }
         trigger: true
         attempts: 3
       - get: cf-ops-automation
@@ -420,7 +426,7 @@ jobs:
 #        source_file: bosh-generated-config/bosh_config.json
         
         stemcells:
-        - bosh-stemcell/stemcell.tgz
+        - bosh-stemcell/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz
         releases: 
         
         - ntp_boshrelease/release.tgz
@@ -604,7 +610,7 @@ jobs:
           echo "check-resource -r $BUILD_PIPELINE_NAME/ntp_boshrelease --from version:{{ntp_boshrelease-version}}" >> result-dir/flight-plan
           
 
-          echo "check-resource -r $BUILD_PIPELINE_NAME/bosh-stemcell --from version:{{stemcell-version}}" >> result-dir/flight-plan
+          echo "check-resource -r $BUILD_PIPELINE_NAME/bosh-stemcell --from path:((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz" >> result-dir/flight-plan
       params:
         BUILD_PIPELINE_NAME: simple-depls-generated
   - task: fly-into-concourse

--- a/spec/scripts/generate-depls/fixtures/templates/apps-depls/apps-depls-versions.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/apps-depls/apps-depls-versions.yml
@@ -1,5 +1,5 @@
 ---
 deployment-name: simple-cf-apps-depls
 
-stemcell-version: 3363.14
+stemcell-version: "3468.1"
 stemcell-name: bosh-openstack-kvm-ubuntu-trusty-go_agent

--- a/spec/scripts/generate-depls/fixtures/templates/delete-depls/delete-depls-versions.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/delete-depls/delete-depls-versions.yml
@@ -1,5 +1,5 @@
 ---
 deployment-name: delete-depls
 
-stemcell-version: 3363.14
+stemcell-version: "3468.1"
 stemcell-name: bosh-openstack-kvm-ubuntu-trusty-go_agent

--- a/spec/scripts/generate-depls/fixtures/templates/no-dependency-depls/no-dependency-depls-versions.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/no-dependency-depls/no-dependency-depls-versions.yml
@@ -1,6 +1,6 @@
 ---
 deployment-name: simple-depls
-ntp_boshrelease-version: 4
+ntp_boshrelease-version: "4"
 
-stemcell-version: 3363.14
+stemcell-version: "3468.1"
 stemcell-name: bosh-openstack-kvm-ubuntu-trusty-go_agent

--- a/spec/scripts/generate-depls/fixtures/templates/simple-depls/simple-depls-versions.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/simple-depls/simple-depls-versions.yml
@@ -1,6 +1,6 @@
 ---
 deployment-name: simple-depls
-ntp_boshrelease-version: 4
+ntp_boshrelease-version: "4"
 
-stemcell-version: 3363.14
+stemcell-version: "3468.1"
 stemcell-name: bosh-openstack-kvm-ubuntu-trusty-go_agent


### PR DESCRIPTION
 pipeline(depls): move stemcell support from bosh.io to S3

Check-resource is also impacted as S3 resource requires a full scan path.
To avoid conflict with previous 'stemcell-name' properties, we use a new
property 'stemcell-main-name'. To get the full stemcell name, a concatenation of stemcell-name-prefix and stemcell-main-name is required.

Requires new concourse properties
    stemcell-name-prefix
    stemcell-main-name
    s3-stemcell-bucket
    s3-stemcell-region-name
    s3-stemcell-access-key-id
    s3-stemcell-secret-key
    s3-stemcell-endpoint
    s3-stemcell-skip-ssl-verification