### PR TITLE
Fix Tf pipeline

### DIFF
--- a/concourse/pipelines/template/tf-pipeline.yml.erb
+++ b/concourse/pipelines/template/tf-pipeline.yml.erb
@@ -97,7 +97,7 @@ jobs:
         params: { submodules: none}
         trigger: true
     - task: generate-terraform-tfvars
-      input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-full, additional-resource: paas-templates-full}
+      input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-<%=depls %>-trigger, additional-resource: paas-templates-full}
       output_mapping: {generated-files: terraform-tfvars}
       file: cf-ops-automation/concourse/tasks/generate-manifest.yml
       params:


### PR DESCRIPTION
Fix improper input mapping build triggers on secrets-<%=depls %>-trigger but was using secrets-full in the pipeline for TF apply.