### PR TITLE
feature: Support ops-files and var-files for [cloud|runtime]-config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,18 +72,31 @@ If a template directory contains hook scripts with specific name, then these scr
       - SECRETS_DIR: directory holding secrets related to current deployment. It's an relative path.
 
 * to generate an additional errand step, in a `deployment-dependencies.yml` file, insert a key ```errands``` with a subkey named like the errand job to execute 
+
+### Iaas specifics support
+Manifest generation supports dedicated part to
+Add directories (like openstack, cloudstack, etc...) for each specific iaas, in the template directory.
+Set a `iaas-type` credential in secrets repo to match the directory name. 
+
   
 ### Bosh cli v2 specific features support
 The newest bosh feature are not implemented in bosh cli v1. So some feature are only available to deployments using bosh cli v2.
- 
+This can be combined with iaas specifics support 
 #### ops-files
 By convention, all files in template dir matching ```*-operators.yml``` are used by ```bosh-deployment``` 
-as ```ops-files``` inputs. Theses files **are not processed by spruce**.
-
+as ```ops-files``` inputs. Theses files **are not processed by spruce**. 
  
 #### vars-files
 By convention, all files in template dir matching ```*-vars-tpl.yml``` are processed by spruce and generate ```*-vars.yml``` files.
 Then files are used by ```bosh-deployment``` as ```vars-files``` inputs.
+
+#### Cloud and runtime config
+Rules for ops-files and vars-files here. 
+To support operators and vars files for cloud and runtime config, we have to define addition convention, as there are in the same directory.
+ - ```*cloud-operators.yml```: operators for cloud-config 
+ - ```*cloud-vars.yml```: vars for cloud-config
+ - ```*runtime-operators.yml```: operators for runtime-config
+ - ```*runtime-vars.yml```: vars for runtime-config
 
 **Migration v1 to v2 tips**: empty vars-files and ops-files are generated to avoid an error message
 

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -364,6 +364,7 @@ jobs:
             ./credentials-resource/<%= depls %>/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/<%= depls %>/template
+        IAAS_TYPE: {{iaas-type}}
 
     - aggregate:
       - task: update-cloud-config-for-<%= depls %>
@@ -484,6 +485,7 @@ jobs:
             ./credentials-resource/<%= depls %>/<%= name %>/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/<%= depls %>/<%= name %>/template
+        IAAS_TYPE: {{iaas-type}}
     - task: execute-<%= name %>-spiff-pre-bosh-deploy
       input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-template-<%= name %>, credentials-resource: secrets-<%= name %>, additional-resource: release-manifest}
       output_mapping: {generated-files: pre-bosh-deploy-resource}
@@ -951,6 +953,7 @@ jobs:
         YML_TEMPLATE_DIR: additional-resource/<%= terraform_config_path %>/template
         CUSTOM_SCRIPT_DIR: additional-resource/<%= terraform_config_path %>/template
         SUFFIX: -tpl.tfvars.yml
+        IAAS_TYPE: {{iaas-type}}
     - task: terraform-plan
       input_mapping: {secret-state-resource: secrets-full,spec-resource: paas-templates-full}
       file: cf-ops-automation/concourse/tasks/terraform_plan_cloudfoundry.yml
@@ -1006,6 +1009,7 @@ jobs:
         YML_TEMPLATE_DIR: additional-resource/<%= terraform_config_path %>/template
         CUSTOM_SCRIPT_DIR: additional-resource/<%= terraform_config_path %>/template
         SUFFIX: -tpl.tfvars.yml
+        IAAS_TYPE: {{iaas-type}}
     - task: terraform-apply
       input_mapping: {secret-state-resource: secrets-full,spec-resource: paas-templates-full}
       output_mapping: {generated-files: terraform-cf}

--- a/concourse/tasks/bosh_update_cloud_config.yml
+++ b/concourse/tasks/bosh_update_cloud_config.yml
@@ -22,22 +22,11 @@ inputs:
   - name: secrets
   - name: script-resource
 run:
-  path: sh
-  args:
-    - -e
-    - -c
-    - |
-      ls -lrt
-      ls -lrt script-resource
-      source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
-      cat config-manifest/cloud-config.yml
-      OLD_CONFIG=$(mktemp cloud-config-XXXXXX)
-      bosh cloud-config >$OLD_CONFIG || true
-      diff $OLD_CONFIG config-manifest/cloud-config.yml || true
-      bosh -n update-cloud-config config-manifest/cloud-config.yml
-
+  path: script-resource/concourse/tasks/bosh_update_cloud_config/run.sh
 params:
    BOSH_TARGET:
    BOSH_CLIENT:
    BOSH_CLIENT_SECRET:
    BOSH_CA_CERT:
+   VARS_FILES_SUFFIX: cloud-vars.yml
+   OPS_FILES_SUFFIX:  cloud-operator.yml

--- a/concourse/tasks/bosh_update_cloud_config/run.sh
+++ b/concourse/tasks/bosh_update_cloud_config/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2015-2017 Orange
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -eC
+ls -lrt config-manifest
+
+VARS_FILES=""
+OPS_FILES=""
+
+for a_vars_file in $(ls ./config-manifest/*${VARS_FILES_SUFFIX}); do
+    VARS_FILES="-l ${a_vars_file} ${VARS_FILES}"
+done
+
+for an_ops_file in $(ls ./config-manifest/*${OPS_FILES_SUFFIX}); do
+    OPS_FILES="-o ${an_ops_file} ${OPS_FILES}"
+done
+
+echo "Operators detected: <${OPS_FILES}>"
+echo "Vars files detected: <${VARS_FILES}>"
+
+source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
+cat config-manifest/cloud-config.yml
+OLD_CONFIG=$(mktemp cloud-config-XXXXXX)
+bosh cloud-config >$OLD_CONFIG || true
+diff $OLD_CONFIG config-manifest/cloud-config.yml || true
+
+bosh -n int ${VARS_FILES} ${OPS_FILES} config-manifest/cloud-config.yml
+
+bosh -n update-cloud-config ${VARS_FILES} ${OPS_FILES} config-manifest/cloud-config.yml
+

--- a/concourse/tasks/bosh_update_runtime_config.yml
+++ b/concourse/tasks/bosh_update_runtime_config.yml
@@ -23,19 +23,11 @@ inputs:
   - name: script-resource
 
 run:
-  path: sh
-  args:
-    - -e
-    - -c
-    - |
-      source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
-      cat config-manifest/runtime-config.yml
-      OLD_CONFIG=$(mktemp runtime-config-XXXXXX)
-      bosh runtime-config >$OLD_CONFIG || true
-      diff $OLD_CONFIG config-manifest/runtime-config.yml || true
-      bosh -n update-runtime-config config-manifest/runtime-config.yml
+  path: script-resource/concourse/tasks/bosh_update_runtime_config/run.sh
 params:
    BOSH_TARGET:
    BOSH_CLIENT:
    BOSH_CLIENT_SECRET:
    BOSH_CA_CERT:
+   VARS_FILES_SUFFIX: runtime-vars.yml
+   OPS_FILES_SUFFIX:  runtime-operator.yml

--- a/concourse/tasks/bosh_update_runtime_config/run.sh
+++ b/concourse/tasks/bosh_update_runtime_config/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2015-2017 Orange
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -eC
+
+ls -lrt config-manifest
+
+VARS_FILES=""
+OPS_FILES=""
+
+for a_vars_file in $(ls ./config-manifest/*${VARS_FILES_SUFFIX}); do
+    VARS_FILES="-l ${a_vars_file} ${VARS_FILES}"
+done
+
+for an_ops_file in $(ls ./config-manifest/*${OPS_FILES_SUFFIX}); do
+    OPS_FILES="-o ${an_ops_file} ${OPS_FILES}"
+done
+
+echo "Operators detected: <${OPS_FILES}>"
+echo "Vars files detected: <${VARS_FILES}>"
+
+source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
+cat config-manifest/runtime-config.yml
+OLD_CONFIG=$(mktemp runtime-config-XXXXXX)
+bosh runtime-config >$OLD_CONFIG || true
+diff $OLD_CONFIG config-manifest/runtime-config.yml || true
+
+bosh -n int ${VARS_FILES} ${OPS_FILES} config-manifest/runtime-config.yml
+
+bosh -n update-runtime-config ${VARS_FILES} ${OPS_FILES} config-manifest/runtime-config.yml
+

--- a/concourse/tasks/generate-manifest.yml
+++ b/concourse/tasks/generate-manifest.yml
@@ -17,3 +17,4 @@ params:
   YML_FILES:
   SUFFIX:
   CUSTOM_SCRIPT_DIR:
+  IAAS_TYPE:

--- a/scripts/manifest/manifest-lifecycle-generation.sh
+++ b/scripts/manifest/manifest-lifecycle-generation.sh
@@ -10,6 +10,16 @@ find ${YML_TEMPLATE_DIR} -maxdepth 1 -name "*-operators.yml" -exec cp --verbose 
 
 ${COMMON_SCRIPT_DIR}/generate-manifest.sh
 
+if [ -n "${IAAS_TYPE}" -a  -d "${YML_TEMPLATE_DIR}/${IAAS_TYPE}" ]; then
+    echo "Customization detected for ${IAAS_TYPE}"
+    find ${YML_TEMPLATE_DIR}/${IAAS_TYPE} -maxdepth 1 -name "*-operators.yml" -exec cp --verbose {} ${OUTPUT_DIR} \;
+    YML_TEMPLATE_DIR=${YML_TEMPLATE_DIR}/${IAAS_TYPE} ${COMMON_SCRIPT_DIR}/generate-manifest.sh
+else
+    echo "ignoring Iaas customization. No IAAS_TYPE set or ${YML_TEMPLATE_DIR}/<IAAS_TYPE> detected. IAAS_TYPE: <${IAAS_TYPE}>"
+fi
+
+
+
 if [ -n "$CUSTOM_SCRIPT_DIR" -a  -f "$CUSTOM_SCRIPT_DIR/post-generate.sh" ]
 then
     echo "post generation script detected"

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
@@ -255,6 +255,8 @@ jobs:
           ./credentials-resource/delete-depls/secrets/secrets.yml
           ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/delete-depls/template
+        IAAS_TYPE: {{iaas-type}}
+
     - aggregate:
       - task: update-cloud-config-for-delete-depls
         attempts: 3

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -171,6 +171,7 @@ jobs:
             ./credentials-resource/dummy-depls/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/dummy-depls/template
+        IAAS_TYPE: {{iaas-type}}
 
     - aggregate:
       - task: update-cloud-config-for-dummy-depls

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -239,6 +239,7 @@ jobs:
             ./credentials-resource/simple-depls/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/simple-depls/template
+        IAAS_TYPE: {{iaas-type}}
 
     - aggregate:
       - task: update-cloud-config-for-simple-depls
@@ -358,6 +359,7 @@ jobs:
             ./credentials-resource/simple-depls/ntp/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/simple-depls/ntp/template
+        IAAS_TYPE: {{iaas-type}}
     - task: execute-ntp-spiff-pre-bosh-deploy
       input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-template-ntp, credentials-resource: secrets-ntp, additional-resource: release-manifest}
       output_mapping: {generated-files: pre-bosh-deploy-resource}

--- a/spec/tasks/bosh_update_cloud_config/task_spec.rb
+++ b/spec/tasks/bosh_update_cloud_config/task_spec.rb
@@ -11,14 +11,20 @@ describe 'bosh_update_cloud_config task' do
       @config_manifest = Dir.mktmpdir
       @secrets = Dir.mktmpdir
 
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-cloud-vars.yml'))
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-cloud-operator.yml'))
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-runtime-vars.yml'))
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-runtime-operator.yml'))
+
       @output = execute('-c concourse/tasks/bosh_update_cloud_config.yml ' \
         '-i script-resource=. ' \
-        "-i config-manifest=#{@config_manifest} " \
-        "-i secrets=#{@secrets} ",
-        'BOSH_TARGET' =>'https://dummy-bosh',
-        'BOSH_CLIENT' =>'aUser',
-        'BOSH_CLIENT_SECRET' =>'aPassword',
-        'BOSH_CA_CERT' => 'secrets/dummy' )
+        "-i secrets=#{@secrets} " \
+        "-i config-manifest=#{@config_manifest} ", \
+                        'BOSH_TARGET' => 'https://dummy-bosh',
+                        'BOSH_CLIENT' => 'aUser',
+                        'BOSH_CLIENT_SECRET' => 'aPassword',
+                        'BOSH_CA_CERT' => 'secrets/shared/certs/internal_paas-ca/server-ca.crt' )
+
     end
 
     after(:context) do
@@ -28,6 +34,14 @@ describe 'bosh_update_cloud_config task' do
 
     it 'tries to login' do
       expect(@output).to include('targeting https://dummy-bosh')
+    end
+
+    it 'selects only config operators' do
+      expect(@output).to include('Operators detected: <-o ./config-manifest/my-custom-cloud-operator.yml >')
+    end
+
+    it 'selects only config vars' do
+      expect(@output).to include('Vars files detected: <-l ./config-manifest/my-custom-cloud-vars.yml >')
     end
 
     it 'displays an error message' do

--- a/spec/tasks/bosh_update_runtime_config/task_spec.rb
+++ b/spec/tasks/bosh_update_runtime_config/task_spec.rb
@@ -11,13 +11,18 @@ describe 'bosh_update_runtime_config task' do
       @config_manifest = Dir.mktmpdir
       @secrets = Dir.mktmpdir
 
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-config-vars.yml'))
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-config-operator.yml'))
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-runtime-vars.yml'))
+      FileUtils.touch(File.join(@config_manifest, 'my-custom-runtime-operator.yml'))
+
       @output = execute('-c concourse/tasks/bosh_update_runtime_config.yml ' \
         '-i script-resource=. ' \
         "-i secrets=#{@secrets} " \
         "-i config-manifest=#{@config_manifest} ", \
-        'BOSH_TARGET' =>'https://dummy-bosh',
-        'BOSH_CLIENT' =>'aUser',
-        'BOSH_CLIENT_SECRET' =>'aPassword',
+        'BOSH_TARGET' => 'https://dummy-bosh',
+        'BOSH_CLIENT' => 'aUser',
+        'BOSH_CLIENT_SECRET' => 'aPassword',
         'BOSH_CA_CERT' => 'secrets/dummy' )
     end
 
@@ -33,6 +38,15 @@ describe 'bosh_update_runtime_config task' do
     it 'displays an error message' do
       expect(@output).to include("Expected to extract host from URL 'https://:25555'")
     end
+
+    it 'selects only runtime operators' do
+      expect(@output).to include('Operators detected: <-o ./config-manifest/my-custom-runtime-operator.yml >')
+    end
+
+    it 'selects only runtime vars' do
+      expect(@output).to include('Vars files detected: <-l ./config-manifest/my-custom-runtime-vars.yml >')
+    end
+
 
   end
 

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/another_file.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/another_file.yml
@@ -1,0 +1,2 @@
+---
+message: "this is an empty yaml file"

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/gcp/my-gcp-iaas-operators.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/gcp/my-gcp-iaas-operators.yml
@@ -1,0 +1,6 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: a-new-release
+    version: 1.0.0

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/gcp/my-gcp-iaas-tpl.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/gcp/my-gcp-iaas-tpl.yml
@@ -1,0 +1,7 @@
+---
+name: first_deployment
+director_uuid: (( grab secrets.bosh_uuid ))
+
+releases:
+- name: ntp
+  version: (( grab meta.ntp.version ))

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/gcp/my-gcp-iaas-vars-tpl.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/gcp/my-gcp-iaas-vars-tpl.yml
@@ -1,0 +1,5 @@
+iaas:
+  consul:
+    domain: custom.internal.paas
+container: (( concat "backup-" secrets.site ))
+    

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/openstack/iaas-operators.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/openstack/iaas-operators.yml
@@ -1,0 +1,6 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: a-new-release
+    version: 1.0.0

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/openstack/iaas-tpl.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/openstack/iaas-tpl.yml
@@ -1,0 +1,7 @@
+---
+name: first_deployment
+director_uuid: (( grab secrets.bosh_uuid ))
+
+releases:
+- name: ntp
+  version: (( grab meta.ntp.version ))

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/openstack/iaas-vars-tpl.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/openstack/iaas-vars-tpl.yml
@@ -1,0 +1,5 @@
+iaas:
+  consul:
+    domain: custom.internal.paas
+container: (( concat "backup-" secrets.site ))
+    

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/shared-operators.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/shared-operators.yml
@@ -1,0 +1,6 @@
+---
+- type: replace
+  path: /releases/-
+  value:
+    name: a-new-release
+    version: 1.0.0

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/shared-tpl.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/shared-tpl.yml
@@ -1,0 +1,7 @@
+---
+name: first_deployment
+director_uuid: (( grab secrets.bosh_uuid ))
+
+releases:
+- name: ntp
+  version: (( grab meta.ntp.version ))

--- a/spec/tasks/generate_manifest/additional-resource/template-with-iaas/shared-vars-tpl.yml
+++ b/spec/tasks/generate_manifest/additional-resource/template-with-iaas/shared-vars-tpl.yml
@@ -1,0 +1,5 @@
+iaas:
+  consul:
+    domain: custom.internal.paas
+container: (( concat "backup-" secrets.site ))
+    


### PR DESCRIPTION
TODO:
 - [x] update generate-manifest task and tests
    - [x] add a `IAAS_TYPE` properties. 
    - [x] update `scripts-resource/scripts/manifest/manifest-lifecycle-generation.sh` to copy iaas-specific operators
    - [x] update `scripts-resource/scripts/manifest/manifest-lifecycle-generation.sh` to add multiple calls to `generate-manifest.sh` with customized `YML_TEMPLATE_DIR` dir (ie `$YML_TEMPLATE_DIR/$IAAS_TYPE`)

- [x] update depls-pipeline and tests
    - [x] add a `IAAS_TYPE` properties matching a `iaas-type` concourse property. 
    - [x] use these files in config and runtime config

- [ ] add `iaas-type` concourse property to secrets

Checks jobs:
 - [ ] cloud-config-and-runtime-config-for-<%= depls %>
 - [ ] deploy-<%= name %>
 - [ ] check-terraform-cf-consistency
 - [ ] enforce-terraform-cf-consistency