### PR TITLE
pipeline(depls): introduces a new staging branch on paas-templates

### DIFF
--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -47,16 +47,16 @@ resources:
 - name: failure-alert
   type: slack-notification
   source:
-    url: {{slack-webhook}}
+    url: ((slack-webhook))
     ca_certs:
-    - domain: {{slack-custom-domain}}
-      cert: {{slack-custom-cert}}
-    - domain: {{slack-custom-root-domain}}
-      cert: {{slack-custom-root-cert}}
+    - domain: ((slack-custom-domain))
+      cert: ((slack-custom-cert))
+    - domain: ((slack-custom-root-domain))
+      cert: ((slack-custom-root-cert))
 
 <% unless all_dependencies.empty? %>
 - name: bosh-stemcell
-#    name: {{stemcell-name}}
+#    name: ((stemcell-name))
   type: s3
   source:
     bucket: ((s3-stemcell-bucket))
@@ -73,25 +73,25 @@ resources:
 - name: secrets-<%=depls %>
   type: git
   source:
-    uri: {{secrets-uri}}
+    uri: ((secrets-uri))
     paths: ["<%= depls %>/secrets","shared"]
-    branch: {{secrets-branch}}
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-template-<%=depls %>
   type: git
   source:
-    uri: {{paas-templates-uri}}
+    uri: ((paas-templates-uri))
     paths: ["<%= depls %>/template"]
-    branch: {{paas-templates-branch}}
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 - name: cf-ops-automation
   type: git
   source:
-    uri: {{cf-ops-automation-uri}}
-    branch: {{cf-ops-automation-branch}}
-    tag_filter: {{cf-ops-automation-tag-filter}}
+    uri: ((cf-ops-automation-uri))
+    branch: ((cf-ops-automation-branch))
+    tag_filter: ((cf-ops-automation-tag-filter))
     skip_ssl_verification: true
 
 <% disabled_deployments = all_dependencies.select{|_,deployment_infos| deployment_infos['status']=='disabled'} %>
@@ -101,36 +101,36 @@ resources:
 - name: secrets-<%= name %>
   type: git
   source:
-    uri: {{secrets-uri}}
+    uri: ((secrets-uri))
     <% ext_scan_path = boshrelease['resources']['secrets']['extended_scan_path'] if ( boshrelease['resources'] && boshrelease['resources']['secrets']['extended_scan_path'] ) %>
     <% ext_scan_path_value = ",\"#{ext_scan_path.join('","')}\"" if ext_scan_path %>
     paths: ["<%= depls %>/<%= name %>","shared"<%= ext_scan_path_value || '' %>]
-    branch: {{secrets-branch}}
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-template-<%= name %>
   type: git
   source:
-    uri: {{paas-templates-uri}}
+    uri: ((paas-templates-uri))
     paths: ["<%= depls %>/<%= name %>"<%= ',.gitmodules' if git_submodules[depls] && git_submodules[depls][name] %>]
-    branch: {{paas-templates-branch}}
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 <% if boshrelease['cli_version'] == "v1" %>
 - name: <%= name %>-deployment
   type: bosh-deployment
   source:
-#    target: https://{{bosh-target)):25555
-    username: {{bosh-username}}
-    password: {{bosh-password}}
+#    target: https://((bosh-target)):25555
+    username: ((bosh-username))
+    password: ((bosh-password))
     deployment: <%= name %>
 <% else %>
 - name: <%= name %>-deployment
   type: bosh-deployment-v2
   source:
-    target: {{bosh-target}}
-    client: {{bosh-username}}
-    client_secret: {{bosh-password}}
+    target: ((bosh-target))
+    client: ((bosh-username))
+    client_secret: ((bosh-password))
     deployment: <%= name %>
     ca_cert: <%= bosh_cert[depls]&.dump %>
 <% end %>
@@ -139,9 +139,9 @@ resources:
 - name: errand-<%= name %>
   type: bosh-errand
   source:
-    target: {{bosh-target}}
-    client: {{bosh-username}}
-    client_secret: {{bosh-password}}
+    target: ((bosh-target))
+    client: ((bosh-username))
+    client_secret: ((bosh-password))
     deployment: <%= name %>
     ca_cert: <%= bosh_cert[depls].dump %>
 <% end %>
@@ -152,27 +152,27 @@ resources:
 - name: <%= all_ci_deployments[depls]['target_name'] %>
   type: concourse-pipeline
   source:
-    target: {{concourse-<%= depls %>-target}}
-    insecure: {{concourse-<%= depls %>-insecure}}
+    target: ((concourse-<%= depls %>-target))
+    insecure: ((concourse-<%= depls %>-insecure))
     teams:
     - name: main
-      username: {{concourse-<%= depls %>-username}}
-      password: {{concourse-<%= depls %>-password}}
+      username: ((concourse-<%= depls %>-username))
+      password: ((concourse-<%= depls %>-password))
 <% end %>
 
 <% unless all_ci_deployments.empty? && disabled_deployments.empty? %>
 - name: secrets-full
   type: git
   source:
-    uri: {{secrets-uri}}
-    branch: {{secrets-branch}}
+    uri: ((secrets-uri))
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-templates-full
   type: git
   source:
-    uri: {{paas-templates-uri}}
-    branch: {{paas-templates-branch}}
+    uri: ((paas-templates-uri))
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 <% end %>
@@ -209,7 +209,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -250,7 +250,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -285,9 +285,9 @@ jobs:
                 source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
                 bosh -n delete-deployment
       params:
-         BOSH_TARGET: {{bosh-target}}
-         BOSH_CLIENT: {{bosh-username}}
-         BOSH_CLIENT_SECRET: {{bosh-password}}
+         BOSH_TARGET: ((bosh-target))
+         BOSH_CLIENT: ((bosh-username))
+         BOSH_CLIENT_SECRET: ((bosh-password))
          BOSH_CA_CERT: secrets/<%= BOSH_CERT_LOCATIONS[depls] %>
          BOSH_DEPLOYMENT: <%= deployment_name %>
     <% end %>
@@ -300,7 +300,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -325,9 +325,9 @@ jobs:
         CURRENT_DEPLS: <%= depls %>/template
         COMMON_SCRIPT_DIR: script-resource/scripts
         SECRETS_DIR: secrets
-        BOSH_TARGET: {{bosh-target}}
-        BOSH_CLIENT: {{bosh-username}}
-        BOSH_CLIENT_SECRET: {{bosh-password}}
+        BOSH_TARGET: ((bosh-target))
+        BOSH_CLIENT: ((bosh-username))
+        BOSH_CLIENT_SECRET: ((bosh-password))
         BOSH_CA_CERT: secrets/<%= BOSH_CERT_LOCATIONS[depls] %>
 
 - name: cloud-config-and-runtime-config-for-<%= depls %>
@@ -335,7 +335,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -364,7 +364,7 @@ jobs:
             ./credentials-resource/<%= depls %>/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/<%= depls %>/template
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
 
     - aggregate:
       - task: update-cloud-config-for-<%= depls %>
@@ -372,9 +372,9 @@ jobs:
         input_mapping: {script-resource: cf-ops-automation, secrets: secrets-<%= depls %>}
         file: cf-ops-automation/concourse/tasks/bosh_update_cloud_config.yml
         params:
-           BOSH_TARGET: {{bosh-target}}
-           BOSH_CLIENT: {{bosh-username}}
-           BOSH_CLIENT_SECRET: {{bosh-password}}
+           BOSH_TARGET: ((bosh-target))
+           BOSH_CLIENT: ((bosh-username))
+           BOSH_CLIENT_SECRET: ((bosh-password))
            BOSH_CA_CERT: secrets/<%= BOSH_CERT_LOCATIONS[depls] %>
 
         ensure:
@@ -389,7 +389,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -405,9 +405,9 @@ jobs:
         input_mapping: {script-resource: cf-ops-automation, secrets: secrets-<%= depls %>}
         file: cf-ops-automation/concourse/tasks/bosh_update_runtime_config.yml
         params:
-           BOSH_TARGET: {{bosh-target}}
-           BOSH_CLIENT: {{bosh-username}}
-           BOSH_CLIENT_SECRET: {{bosh-password}}
+           BOSH_TARGET: ((bosh-target))
+           BOSH_CLIENT: ((bosh-username))
+           BOSH_CLIENT_SECRET: ((bosh-password))
            BOSH_CA_CERT: secrets/<%= BOSH_CERT_LOCATIONS[depls] %>
 
         ensure:
@@ -422,7 +422,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -441,7 +441,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -457,9 +457,9 @@ jobs:
       <% boshrelease['releases']&.sort&.each do |release, info| %>
       - get: <%= release %>
         <% if info['base_location'].include?('bosh.io') %>
-        version: { version: {{<%= release %>-version}} }
+        version: { version: ((<%= release %>-version)) }
         <% else %>
-        version: { tag: v{{<%= release %>-version}} }
+        version: { tag: v((<%= release %>-version)) }
         <% end %>
         trigger: true
         attempts: 3
@@ -485,7 +485,7 @@ jobs:
             ./credentials-resource/<%= depls %>/<%= name %>/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/<%= depls %>/<%= name %>/template
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
     - task: execute-<%= name %>-spiff-pre-bosh-deploy
       input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-template-<%= name %>, credentials-resource: secrets-<%= name %>, additional-resource: release-manifest}
       output_mapping: {generated-files: pre-bosh-deploy-resource}
@@ -522,7 +522,7 @@ jobs:
             export BOSH_ENVIRONMENT="${DIRECTOR_IP_NO_SPACE}"
             echo "https://$BOSH_ENVIRONMENT:25555" > result-dir/bosh_target
         params:
-          BOSH_TARGET: {{bosh-target}}
+          BOSH_TARGET: ((bosh-target))
     <% else %>
     - task: convert-bosh-dns-to-ip
       output_mapping: {result-dir: bosh-generated-config}
@@ -544,7 +544,7 @@ jobs:
             export BOSH_ENVIRONMENT="${DIRECTOR_IP_NO_SPACE}"
             echo '{"target": "'"$BOSH_ENVIRONMENT"'"}' > result-dir/bosh_config.json
         params:
-          BOSH_TARGET: {{bosh-target}}
+          BOSH_TARGET: ((bosh-target))
     - task: generate-empty-ops-and-vars-files
       # this task is required as long as all deployments still don't use ops/vars files
       output_mapping: {result-dir: ops-and-vars-files}
@@ -618,7 +618,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -643,7 +643,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -677,9 +677,9 @@ jobs:
       output_mapping: {flight-report: concourse-<%= depls %>-trigger-report}
       file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
       params:
-        ATC_EXTERNAL_URL: {{concourse-<%= depls %>-target}}
-        FLY_USERNAME: {{concourse-<%= depls %>-username}}
-        FLY_PASSWORD:  {{concourse-<%= depls %>-password}}
+        ATC_EXTERNAL_URL: ((concourse-<%= depls %>-target))
+        FLY_USERNAME: ((concourse-<%= depls %>-username))
+        FLY_PASSWORD:  ((concourse-<%= depls %>-password))
 <% end %>
 
 - name: recreate-all
@@ -688,7 +688,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -711,7 +711,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -752,9 +752,9 @@ jobs:
                 source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
                 bosh -n recreate
       params:
-         BOSH_TARGET: {{bosh-target}}
-         BOSH_CLIENT: {{bosh-username}}
-         BOSH_CLIENT_SECRET: {{bosh-password}}
+         BOSH_TARGET: ((bosh-target))
+         BOSH_CLIENT: ((bosh-username))
+         BOSH_CLIENT_SECRET: ((bosh-password))
          BOSH_CA_CERT: secrets/<%= BOSH_CERT_LOCATIONS[depls] %>
          BOSH_DEPLOYMENT: <%= name %>
 <% end %>
@@ -771,7 +771,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -800,7 +800,7 @@ jobs:
         - -exc
         - |
           <% uniq_releases.sort.each do |name,_| %>
-          echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from version:{{<%= name %>-version}}" >> result-dir/flight-plan
+          echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from version:((<%= name %>-version))" >> result-dir/flight-plan
           <% end %>
 
           echo "check-resource -r $BUILD_PIPELINE_NAME/bosh-stemcell --from path:((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz" >> result-dir/flight-plan
@@ -812,9 +812,9 @@ jobs:
     output_mapping: {flight-report: concourse-<%= depls %>-init-report}
     file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
     params:
-      ATC_EXTERNAL_URL: {{concourse-<%= depls %>-target}}
-      FLY_USERNAME: {{concourse-<%= depls %>-username}}
-      FLY_PASSWORD:  {{concourse-<%= depls %>-password}}
+      ATC_EXTERNAL_URL: ((concourse-<%= depls %>-target))
+      FLY_USERNAME: ((concourse-<%= depls %>-username))
+      FLY_PASSWORD:  ((concourse-<%= depls %>-password))
 <% end %>
 
 - name: update-pipeline-<%= depls %>-generated
@@ -822,7 +822,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -926,7 +926,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -953,7 +953,7 @@ jobs:
         YML_TEMPLATE_DIR: additional-resource/<%= terraform_config_path %>/template
         CUSTOM_SCRIPT_DIR: additional-resource/<%= terraform_config_path %>/template
         SUFFIX: -tpl.tfvars.yml
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
     - task: terraform-plan
       input_mapping: {secret-state-resource: secrets-full,spec-resource: paas-templates-full}
       file: cf-ops-automation/concourse/tasks/terraform_plan_cloudfoundry.yml
@@ -979,7 +979,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -1009,7 +1009,7 @@ jobs:
         YML_TEMPLATE_DIR: additional-resource/<%= terraform_config_path %>/template
         CUSTOM_SCRIPT_DIR: additional-resource/<%= terraform_config_path %>/template
         SUFFIX: -tpl.tfvars.yml
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
     - task: terraform-apply
       input_mapping: {secret-state-resource: secrets-full,spec-resource: paas-templates-full}
       output_mapping: {generated-files: terraform-cf}
@@ -1029,7 +1029,7 @@ jobs:
         on_failure:
           put: failure-alert
           params:
-            channel: {{slack-channel}}
+            channel: ((slack-channel))
             text: Failure during [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
             icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
             username: Concourse

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -172,6 +172,13 @@ resources:
   type: git
   source:
     uri: ((paas-templates-uri))
+    branch: pipeline-current-((paas-templates-branch))
+    skip_ssl_verification: true
+
+- name: paas-templates-wip
+  type: git
+  source:
+    uri: ((paas-templates-uri))
     branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
@@ -218,8 +225,10 @@ jobs:
       - get: cf-ops-automation
         params: { submodules: none}
         <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
+        trigger: true
       - get: paas-templates-full
         params: { submodules: none}
+        <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
       - get: secrets-full
         trigger: true
         <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
@@ -310,10 +319,10 @@ jobs:
     - aggregate:
       - get: secrets-<%= depls %>
         params: { submodules: none}
-        <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
+#        <!--<%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>-->
       - get: paas-template-<%= depls %>
         params: { submodules: none}
-        <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
+#        <!--<%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>-->
       - get: cf-ops-automation
         params: { submodules: none}
         <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
@@ -343,11 +352,11 @@ jobs:
     - get: secrets-<%=depls %>
       params: { submodules: none}
       trigger: true
-      <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
+#      <!--<%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>-->
     - get: paas-template-<%=depls %>
       params: { submodules: none}
       trigger: true
-      <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
+#      <!--<%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>-->
     - get: cf-ops-automation
       params: { submodules: none}
       trigger: true
@@ -454,6 +463,7 @@ jobs:
       - get: cf-ops-automation
         params: { submodules: none}
         <%= "passed: [update-pipeline-#{depls}-generated]" if ! all_ci_deployments.empty? %>
+        trigger: true
       <% boshrelease['releases']&.sort&.each do |release, info| %>
       - get: <%= release %>
         <% if info['base_location'].include?('bosh.io') %>
@@ -467,12 +477,12 @@ jobs:
       - get: secrets-<%= name %>
         params: { submodules: none}
         trigger: true
-        <%= "passed: [update-pipeline-#{depls}-generated]" unless all_ci_deployments.empty? %>
+#        <!--<%= "passed: [update-pipeline-#{depls}-generated]" unless all_ci_deployments.empty? %>-->
       - get: paas-template-<%= name %>
         trigger: true
         <% current_git_submodule = git_submodules[depls][name] if git_submodules[depls] %>
         params: { submodules: <%= current_git_submodule || 'none' %>}
-        <%= "passed: [update-pipeline-#{depls}-generated]" unless all_ci_deployments.empty? %>
+#        <!--<%= "passed: [update-pipeline-#{depls}-generated]" unless all_ci_deployments.empty? %>-->
     - task: generate-<%= name %>-manifest
       input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-<%= name %>, additional-resource: paas-template-<%= name %>}
       output_mapping: {generated-files: release-manifest}
@@ -831,6 +841,9 @@ jobs:
     - get: paas-template-<%= depls %>
       params: { submodules: none}
       attempts: 3
+    - get: paas-templates-wip
+      params: { submodules: none}
+      attempts: 3
       trigger: true
     - get: secrets-<%= depls %>
       params: { submodules: none}
@@ -843,20 +856,13 @@ jobs:
     - get: paas-templates-full
       params: { submodules: none}
       attempts: 3
-      trigger: true
+
     - get: secrets-full
       params: { submodules: none}
       attempts: 3
-      trigger: true
-    <% enabled_deployments.sort.each do |name,_| %>
-    - get: secrets-<%= name %>
-      params: { submodules: none}
-    - get: paas-template-<%= name %>
-      params: { submodules: none}
-    <% end %>
 
   - task: generate-<%= depls %>-pipeline
-    input_mapping: {script-resource: cf-ops-automation,templates: paas-templates-full,secrets: secrets-full}
+    input_mapping: {script-resource: cf-ops-automation,templates: paas-templates-wip,secrets: secrets-full}
     output_mapping: {result-dir: concourse-<%= depls %>-pipeline}
     config:
       platform: linux
@@ -892,7 +898,7 @@ jobs:
           <% pipeline_details['vars_files'].each do |a_vars_file| %>
           # trick to manage <depls>-versions.yml (not included in secrets)
          <%= "- secrets-full/#{a_vars_file}" if ! a_vars_file.end_with?('-versions.yml') %>
-         <%= "- paas-templates-full/#{a_vars_file}" if a_vars_file.end_with?('-versions.yml') %>
+         <%= "- paas-templates-wip/#{a_vars_file}" if a_vars_file.end_with?('-versions.yml') %>
           <% end %>
      <% end %>
   - task: update-concourse-depls-pipeline
@@ -916,6 +922,12 @@ jobs:
     params:
       repository: updated-secrets
       rebase: true
+  - put: paas-templates-full
+    get_params: {submodules: none}
+    params:
+      repository: paas-templates-wip
+      force: true
+
 
 <% if ! all_ci_deployments[depls]['terraform_config'].nil? %>
 <% terraform_config_path= all_ci_deployments[depls]['terraform_config']['state_file_path'] %>
@@ -936,6 +948,7 @@ jobs:
     - get: cf-ops-automation
       params: { submodules: none}
       passed: [update-pipeline-<%= depls %>-generated]
+      trigger: true
     - get: paas-templates-full
       params: { submodules: none}
     - get: secrets-full

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -54,22 +54,6 @@ resources:
     - domain: ((slack-custom-root-domain))
       cert: ((slack-custom-root-cert))
 
-<% unless all_dependencies.empty? %>
-- name: bosh-stemcell
-#    name: ((stemcell-name))
-  type: s3
-  source:
-    bucket: ((s3-stemcell-bucket))
-    region_name: ((s3-stemcell-region-name))
-    # customization is required to remove bosh prefix in stemcell name
-    regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
-    access_key_id: ((s3-stemcell-access-key-id))
-    secret_access_key: ((s3-stemcell-secret-key))
-    endpoint: ((s3-stemcell-endpoint))
-    skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
-
-<% end %>
-
 - name: secrets-<%=depls %>
   type: git
   source:
@@ -97,6 +81,22 @@ resources:
 <% disabled_deployments = all_dependencies.select{|_,deployment_infos| deployment_infos['status']=='disabled'} %>
 <% enabled_deployments = all_dependencies.select{|_,deployment_infos| deployment_infos['status']=='enabled'} %>
 <% puts enabled_deployments %>
+
+<% unless enabled_deployments.empty? %>
+- name: bosh-stemcell
+#    name: ((stemcell-name))
+  type: s3
+  source:
+    bucket: ((s3-stemcell-bucket))
+    region_name: ((s3-stemcell-region-name))
+    # customization is required to remove bosh prefix in stemcell name
+    regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
+    access_key_id: ((s3-stemcell-access-key-id))
+    secret_access_key: ((s3-stemcell-secret-key))
+    endpoint: ((s3-stemcell-endpoint))
+    skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
+
+<% end %>
 <% enabled_deployments.sort.each do |name,boshrelease| %>
 - name: secrets-<%= name %>
   type: git

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
@@ -46,17 +46,6 @@ resources:
       - domain: ((slack-custom-root-domain))
         cert: ((slack-custom-root-cert))
 
-  - name: bosh-stemcell
-    type: s3
-    source:
-      bucket: ((s3-stemcell-bucket))
-      region_name: ((s3-stemcell-region-name))
-      regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
-      access_key_id: ((s3-stemcell-access-key-id))
-      secret_access_key: ((s3-stemcell-secret-key))
-      endpoint: ((s3-stemcell-endpoint))
-      skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
-
   - name: secrets-delete-depls
     type: git
     source:

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
@@ -39,12 +39,13 @@ resources:
   - name: failure-alert
     type: slack-notification
     source:
-      url: {{slack-webhook}}
+      url: ((slack-webhook))
       ca_certs:
-      - domain: {{slack-custom-domain}}
-        cert: {{slack-custom-cert}}
-      - domain: {{slack-custom-root-domain}}
-        cert: {{slack-custom-root-cert}}
+      - domain: ((slack-custom-domain))
+        cert: ((slack-custom-cert))
+      - domain: ((slack-custom-root-domain))
+        cert: ((slack-custom-root-cert))
+
   - name: bosh-stemcell
     type: s3
     source:
@@ -59,45 +60,46 @@ resources:
   - name: secrets-delete-depls
     type: git
     source:
-      uri: {{secrets-uri}}
+      uri: ((secrets-uri))
       paths:
       - delete-depls/secrets
       - shared
-      branch: {{secrets-branch}}
+      branch: ((secrets-branch))
       skip_ssl_verification: true
   - name: paas-template-delete-depls
     type: git
     source:
-      uri: {{paas-templates-uri}}
+      uri: ((paas-templates-uri))
       paths:
       - delete-depls/template
-      branch: {{paas-templates-branch}}
+      branch: ((paas-templates-branch))
       skip_ssl_verification: true
   - name: cf-ops-automation
     type: git
     source:
-      uri: {{cf-ops-automation-uri}}
-      branch: {{cf-ops-automation-branch}}
-      tag_filter: {{cf-ops-automation-tag-filter}}
+      uri: ((cf-ops-automation-uri))
+      branch: ((cf-ops-automation-branch))
+      tag_filter: ((cf-ops-automation-tag-filter))
       skip_ssl_verification: true
+
   - name: secrets-full
     type: git
     source:
-      uri: {{secrets-uri}}
-      branch: {{secrets-branch}}
+      uri: ((secrets-uri))
+      branch: ((secrets-branch))
       skip_ssl_verification: true
   - name: paas-templates-full
     type: git
     source:
-      uri: {{paas-templates-uri}}
-      branch: {{paas-templates-branch}}
+      uri: ((paas-templates-uri))
+      branch: ((paas-templates-branch))
       skip_ssl_verification: true
 jobs:
   - name: delete-deployments-review
     on_failure:
       put: failure-alert
       params:
-        channel: {{slack-channel}}
+        channel: ((slack-channel))
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
@@ -138,7 +140,7 @@ jobs:
     on_failure:
       put: failure-alert
       params:
-        channel: {{slack-channel}}
+        channel: ((slack-channel))
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
@@ -177,16 +179,16 @@ jobs:
             source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
             bosh -n delete-deployment
       params:
-        BOSH_TARGET: {{bosh-target}}
-        BOSH_CLIENT: {{bosh-username}}
-        BOSH_CLIENT_SECRET: {{bosh-password}}
+        BOSH_TARGET: ((bosh-target))
+        BOSH_CLIENT: ((bosh-username))
+        BOSH_CLIENT_SECRET: ((bosh-password))
         BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
         BOSH_DEPLOYMENT: ntp
   - name: execute-deploy-script
     on_failure:
       put: failure-alert
       params:
-        channel: {{slack-channel}}
+        channel: ((slack-channel))
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
@@ -214,15 +216,15 @@ jobs:
         COMMON_SCRIPT_DIR: script-resource/scripts
         SECRETS_DIR: secrets
         BOSH_TARGET:
-        BOSH_TARGET: {{bosh-target}}
-        BOSH_CLIENT: {{bosh-username}}
-        BOSH_CLIENT_SECRET: {{bosh-password}}
+        BOSH_TARGET: ((bosh-target))
+        BOSH_CLIENT: ((bosh-username))
+        BOSH_CLIENT_SECRET: ((bosh-password))
         BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
   - name: cloud-config-and-runtime-config-for-delete-depls
     on_failure:
       put: failure-alert
       params:
-        channel: {{slack-channel}}
+        channel: ((slack-channel))
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
@@ -255,7 +257,7 @@ jobs:
           ./credentials-resource/delete-depls/secrets/secrets.yml
           ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/delete-depls/template
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
 
     - aggregate:
       - task: update-cloud-config-for-delete-depls
@@ -265,9 +267,9 @@ jobs:
           secrets: secrets-delete-depls
         file: cf-ops-automation/concourse/tasks/bosh_update_cloud_config.yml
         params:
-          BOSH_TARGET: {{bosh-target}}
-          BOSH_CLIENT: {{bosh-username}}
-          BOSH_CLIENT_SECRET: {{bosh-password}}
+          BOSH_TARGET: ((bosh-target))
+          BOSH_CLIENT: ((bosh-username))
+          BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
         ensure:
           task: update-cloud-config
@@ -284,7 +286,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -302,9 +304,9 @@ jobs:
           secrets: secrets-delete-depls
         file: cf-ops-automation/concourse/tasks/bosh_update_runtime_config.yml
         params:
-          BOSH_TARGET: {{bosh-target}}
-          BOSH_CLIENT: {{bosh-username}}
-          BOSH_CLIENT_SECRET: {{bosh-password}}
+          BOSH_TARGET: ((bosh-target))
+          BOSH_CLIENT: ((bosh-username))
+          BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
         ensure:
           task: update-runtime-config
@@ -321,7 +323,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -336,7 +338,7 @@ jobs:
     on_failure:
       put: failure-alert
       params:
-        channel: {{slack-channel}}
+        channel: ((slack-channel))
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
@@ -81,6 +81,13 @@ resources:
     type: git
     source:
       uri: ((paas-templates-uri))
+      branch: pipeline-current-((paas-templates-branch))
+      skip_ssl_verification: true
+
+  - name: paas-templates-wip
+    type: git
+    source:
+      uri: ((paas-templates-uri))
       branch: ((paas-templates-branch))
       skip_ssl_verification: true
 jobs:
@@ -97,6 +104,7 @@ jobs:
       - get: cf-ops-automation
         params:
           submodules: none
+        trigger: true
       - get: paas-templates-full
         params:
           submodules: none

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -47,36 +47,36 @@ resources:
 - name: failure-alert
   type: slack-notification
   source:
-    url: {{slack-webhook}}
+    url: ((slack-webhook))
     ca_certs:
-    - domain: {{slack-custom-domain}}
-      cert: {{slack-custom-cert}}
-    - domain: {{slack-custom-root-domain}}
-      cert: {{slack-custom-root-cert}}
+    - domain: ((slack-custom-domain))
+      cert: ((slack-custom-cert))
+    - domain: ((slack-custom-root-domain))
+      cert: ((slack-custom-root-cert))
 
 
 - name: secrets-dummy-depls
   type: git
   source:
-    uri: {{secrets-uri}}
+    uri: ((secrets-uri))
     paths: ["dummy-depls/secrets","shared"]
-    branch: {{secrets-branch}}
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-template-dummy-depls
   type: git
   source:
-    uri: {{paas-templates-uri}}
+    uri: ((paas-templates-uri))
     paths: ["dummy-depls/template"]
-    branch: {{paas-templates-branch}}
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 - name: cf-ops-automation
   type: git
   source:
-    uri: {{cf-ops-automation-uri}}
-    branch: {{cf-ops-automation-branch}}
-    tag_filter: {{cf-ops-automation-tag-filter}}
+    uri: ((cf-ops-automation-uri))
+    branch: ((cf-ops-automation-branch))
+    tag_filter: ((cf-ops-automation-tag-filter))
     skip_ssl_verification: true
 
 
@@ -90,7 +90,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -115,9 +115,9 @@ jobs:
         CURRENT_DEPLS: dummy-depls/template
         COMMON_SCRIPT_DIR: script-resource/scripts
         SECRETS_DIR: secrets
-        BOSH_TARGET: {{bosh-target}}
-        BOSH_CLIENT: {{bosh-username}}
-        BOSH_CLIENT_SECRET: {{bosh-password}}
+        BOSH_TARGET: ((bosh-target))
+        BOSH_CLIENT: ((bosh-username))
+        BOSH_CLIENT_SECRET: ((bosh-password))
         BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
 
 
@@ -126,7 +126,7 @@ jobs:
   on_failure:
    put: failure-alert
    params:
-     channel: {{slack-channel}}
+     channel: ((slack-channel))
      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
      username: Concourse
@@ -171,7 +171,7 @@ jobs:
             ./credentials-resource/dummy-depls/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/dummy-depls/template
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
 
     - aggregate:
       - task: update-cloud-config-for-dummy-depls
@@ -181,9 +181,9 @@ jobs:
           secrets: secrets-dummy-depls
         file: cf-ops-automation/concourse/tasks/bosh_update_cloud_config.yml
         params:
-          BOSH_TARGET: {{bosh-target}}
-          BOSH_CLIENT: {{bosh-username}}
-          BOSH_CLIENT_SECRET: {{bosh-password}}
+          BOSH_TARGET: ((bosh-target))
+          BOSH_CLIENT: ((bosh-username))
+          BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
         ensure:
           task: update-cloud-config
@@ -197,7 +197,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -215,9 +215,9 @@ jobs:
           secrets: secrets-dummy-depls
         file: cf-ops-automation/concourse/tasks/bosh_update_runtime_config.yml
         params:
-          BOSH_TARGET: {{bosh-target}}
-          BOSH_CLIENT: {{bosh-username}}
-          BOSH_CLIENT_SECRET: {{bosh-password}}
+          BOSH_TARGET: ((bosh-target))
+          BOSH_CLIENT: ((bosh-username))
+          BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
         ensure:
           task: update-runtime-config
@@ -231,7 +231,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -249,7 +249,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -47,12 +47,12 @@ resources:
 - name: failure-alert
   type: slack-notification
   source:
-    url: {{slack-webhook}}
+    url: ((slack-webhook))
     ca_certs:
-    - domain: {{slack-custom-domain}}
-      cert: {{slack-custom-cert}}
-    - domain: {{slack-custom-root-domain}}
-      cert: {{slack-custom-root-cert}}
+    - domain: ((slack-custom-domain))
+      cert: ((slack-custom-cert))
+    - domain: ((slack-custom-root-domain))
+      cert: ((slack-custom-root-cert))
 
 - name: bosh-stemcell
   type: s3
@@ -68,51 +68,51 @@ resources:
 - name: secrets-simple-depls
   type: git
   source:
-    uri: {{secrets-uri}}
+    uri: ((secrets-uri))
     paths: ["simple-depls/secrets","shared"]
-    branch: {{secrets-branch}}
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-template-simple-depls
   type: git
   source:
-    uri: {{paas-templates-uri}}
+    uri: ((paas-templates-uri))
     paths: ["simple-depls/template"]
-    branch: {{paas-templates-branch}}
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 - name: cf-ops-automation
   type: git
   source:
-    uri: {{cf-ops-automation-uri}}
-    branch: {{cf-ops-automation-branch}}
-    tag_filter: {{cf-ops-automation-tag-filter}}
+    uri: ((cf-ops-automation-uri))
+    branch: ((cf-ops-automation-branch))
+    tag_filter: ((cf-ops-automation-tag-filter))
     skip_ssl_verification: true
 
 - name: secrets-ntp
   type: git
   source:
-    uri: {{secrets-uri}}
+    uri: ((secrets-uri))
     
     
     paths: ["simple-depls/ntp","shared"]
-    branch: {{secrets-branch}}
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-template-ntp
   type: git
   source:
-    uri: {{paas-templates-uri}}
+    uri: ((paas-templates-uri))
     paths: ["simple-depls/ntp"]
-    branch: {{paas-templates-branch}}
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 - name: ntp-deployment
   type: bosh-deployment-v2
   source:
-    target: {{bosh-target}}
-    client: {{bosh-username}}
-    client_secret: {{bosh-password}}
+    target: ((bosh-target))
+    client: ((bosh-username))
+    client_secret: ((bosh-password))
     deployment: ntp
     ca_cert: "-----BEGIN CERTIFICATE-----\nMIIDXDCCAkSgAwIBAgIBATANBgkqhkiG9w0BAQsFADA/MRMwEQYKCZImiZPyLGQB\nGRYDY29tMRYwFAYKCZImiZPyLGQBGRYGb3JhbmdlMRAwDgYDVQQDDAdUZXN0IENB\nMB4XDTE3MDkwODE0NTI1OVoXDTE5MDkwODE0NTI1OVowPzETMBEGCgmSJomT8ixk\nARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBm9yYW5nZTEQMA4GA1UEAwwHVGVzdCBD\nQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALQTi5oWSpKAY5n9KtyZ\nZlo3TQBL1DWgbTgkDeSortVOL/F2niP9DI81acbIjLo2o572Z41jnz3K6GaSwviJ\nvY/K5XAgE0A66KV3ZJm6eNI7LmLXyxV59q+rtp75NuYQqqdS8FEiKUVDPUD5nJca\nQk/b+b6V/wHXz7KV6A/j/NQb9qaQu4X7WWfCXk2v2JzRd5PdBO2XNuF8WArm3zXG\nVeg3j7rB782iAKjUX93U+VYu3m7DyPQkA/owIHpw7nEaJS7KdDFFDubLwD6d0FG3\nAr9b4ttL83UlJOvvgNBo+zuIuUuOFCBtpYMI9N84fUhkh62jZa4vtfeI0tI9UBIk\nBbECAwEAAaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYD\nVR0OBBYEFJ+LRoMZCoJoPXETODONOO29xTkAMB8GA1UdIwQYMBaAFJ+LRoMZCoJo\nPXETODONOO29xTkAMA0GCSqGSIb3DQEBCwUAA4IBAQCz0iumGgPuIGttcuFCaHc8\nmBVH7D/yj8otzZAMyz91aiArooUlnzCO9xHtnwIv6qe5V4D4D8YuaIiv/tXD86tL\nVwE2TyfLeTpvHcclRAB+thhbYkVC2GgAbEOeA/JtSLGOhPbgrf/BKdjLTOEqsFJi\nqmpMrzEb08TG9CRiWo68LPu6GE84P3WFXVhC/s0ymlb5cITwTHKOwcVyu+8dIw1I\nwZ5atyWiFB040HeKe+kwxWHEG9L6NT3+R9cCTMpfYCdv4DcUlEt8WNtDcNJa5Cv1\nzVke99FdeG0PzuWmaymHrTRaAAIbjaARrp98mwxtJF1e2ANl9Qli9qiHqI4mX0Qw\n-----END CERTIFICATE-----\n"
 
@@ -121,25 +121,25 @@ resources:
 - name: TO_BE_DEFINED
   type: concourse-pipeline
   source:
-    target: {{concourse-simple-depls-target}}
-    insecure: {{concourse-simple-depls-insecure}}
+    target: ((concourse-simple-depls-target))
+    insecure: ((concourse-simple-depls-insecure))
     teams:
     - name: main
-      username: {{concourse-simple-depls-username}}
-      password: {{concourse-simple-depls-password}}
+      username: ((concourse-simple-depls-username))
+      password: ((concourse-simple-depls-password))
 
 - name: secrets-full
   type: git
   source:
-    uri: {{secrets-uri}}
-    branch: {{secrets-branch}}
+    uri: ((secrets-uri))
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-templates-full
   type: git
   source:
-    uri: {{paas-templates-uri}}
-    branch: {{paas-templates-branch}}
+    uri: ((paas-templates-uri))
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 
@@ -159,7 +159,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -184,9 +184,9 @@ jobs:
         CURRENT_DEPLS: simple-depls/template
         COMMON_SCRIPT_DIR: script-resource/scripts
         SECRETS_DIR: secrets
-        BOSH_TARGET: {{bosh-target}}
-        BOSH_CLIENT: {{bosh-username}}
-        BOSH_CLIENT_SECRET: {{bosh-password}}
+        BOSH_TARGET: ((bosh-target))
+        BOSH_CLIENT: ((bosh-username))
+        BOSH_CLIENT_SECRET: ((bosh-password))
         BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
 
 - name: cloud-config-and-runtime-config-for-simple-depls
@@ -194,7 +194,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -239,7 +239,7 @@ jobs:
             ./credentials-resource/simple-depls/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/simple-depls/template
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
 
     - aggregate:
       - task: update-cloud-config-for-simple-depls
@@ -249,9 +249,9 @@ jobs:
           secrets: secrets-simple-depls
         file: cf-ops-automation/concourse/tasks/bosh_update_cloud_config.yml
         params:
-          BOSH_TARGET: {{bosh-target}}
-          BOSH_CLIENT: {{bosh-username}}
-          BOSH_CLIENT_SECRET: {{bosh-password}}
+          BOSH_TARGET: ((bosh-target))
+          BOSH_CLIENT: ((bosh-username))
+          BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
         ensure:
           task: update-cloud-config
@@ -265,7 +265,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -283,9 +283,9 @@ jobs:
           secrets: secrets-simple-depls
         file: cf-ops-automation/concourse/tasks/bosh_update_runtime_config.yml
         params:
-          BOSH_TARGET: {{bosh-target}}
-          BOSH_CLIENT: {{bosh-username}}
-          BOSH_CLIENT_SECRET: {{bosh-password}}
+          BOSH_TARGET: ((bosh-target))
+          BOSH_CLIENT: ((bosh-username))
+          BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
         ensure:
           task: update-runtime-config
@@ -299,7 +299,7 @@ jobs:
           on_failure:
             put: failure-alert
             params:
-              channel: {{slack-channel}}
+              channel: ((slack-channel))
               text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
               icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
               username: Concourse
@@ -317,7 +317,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -333,7 +333,7 @@ jobs:
       
       - get: ntp_boshrelease
         
-        version: { version: {{ntp_boshrelease-version}} }
+        version: { version: ((ntp_boshrelease-version)) }
         
         trigger: true
         attempts: 3
@@ -359,7 +359,7 @@ jobs:
             ./credentials-resource/simple-depls/ntp/secrets/secrets.yml
             ./credentials-resource/shared/secrets.yml
         CUSTOM_SCRIPT_DIR: additional-resource/simple-depls/ntp/template
-        IAAS_TYPE: {{iaas-type}}
+        IAAS_TYPE: ((iaas-type))
     - task: execute-ntp-spiff-pre-bosh-deploy
       input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-template-ntp, credentials-resource: secrets-ntp, additional-resource: release-manifest}
       output_mapping: {generated-files: pre-bosh-deploy-resource}
@@ -400,7 +400,7 @@ jobs:
             export BOSH_ENVIRONMENT="${DIRECTOR_IP_NO_SPACE}"
             echo '{"target": "'"$BOSH_ENVIRONMENT"'"}' > result-dir/bosh_config.json
         params:
-          BOSH_TARGET: {{bosh-target}}
+          BOSH_TARGET: ((bosh-target))
     
     - task: generate-empty-ops-and-vars-files
       # this task is required as long as all deployments still don't use ops/vars files
@@ -468,7 +468,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -502,15 +502,15 @@ jobs:
       output_mapping: {flight-report: concourse-simple-depls-trigger-report}
       file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
       params:
-        ATC_EXTERNAL_URL: {{concourse-simple-depls-target}}
-        FLY_USERNAME: {{concourse-simple-depls-username}}
-        FLY_PASSWORD:  {{concourse-simple-depls-password}}
+        ATC_EXTERNAL_URL: ((concourse-simple-depls-target))
+        FLY_USERNAME: ((concourse-simple-depls-username))
+        FLY_PASSWORD:  ((concourse-simple-depls-password))
 
 - name: recreate-all
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -532,7 +532,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -573,9 +573,9 @@ jobs:
                 source ./script-resource/scripts/bosh_cli_v2_login.sh ${BOSH_TARGET}
                 bosh -n recreate
       params:
-         BOSH_TARGET: {{bosh-target}}
-         BOSH_CLIENT: {{bosh-username}}
-         BOSH_CLIENT_SECRET: {{bosh-password}}
+         BOSH_TARGET: ((bosh-target))
+         BOSH_CLIENT: ((bosh-username))
+         BOSH_CLIENT_SECRET: ((bosh-password))
          BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
          BOSH_DEPLOYMENT: ntp
 
@@ -585,7 +585,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -614,7 +614,7 @@ jobs:
         - -exc
         - |
           
-          echo "check-resource -r $BUILD_PIPELINE_NAME/ntp_boshrelease --from version:{{ntp_boshrelease-version}}" >> result-dir/flight-plan
+          echo "check-resource -r $BUILD_PIPELINE_NAME/ntp_boshrelease --from version:((ntp_boshrelease-version))" >> result-dir/flight-plan
           
 
           echo "check-resource -r $BUILD_PIPELINE_NAME/bosh-stemcell --from path:((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz" >> result-dir/flight-plan
@@ -625,16 +625,16 @@ jobs:
     output_mapping: {flight-report: concourse-simple-depls-init-report}
     file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
     params:
-      ATC_EXTERNAL_URL: {{concourse-simple-depls-target}}
-      FLY_USERNAME: {{concourse-simple-depls-username}}
-      FLY_PASSWORD:  {{concourse-simple-depls-password}}
+      ATC_EXTERNAL_URL: ((concourse-simple-depls-target))
+      FLY_USERNAME: ((concourse-simple-depls-username))
+      FLY_PASSWORD:  ((concourse-simple-depls-password))
 
 - name: update-pipeline-simple-depls-generated
   
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -139,11 +139,15 @@ resources:
   type: git
   source:
     uri: ((paas-templates-uri))
-    branch: ((paas-templates-branch))
+    branch: pipeline-current-((paas-templates-branch))
     skip_ssl_verification: true
 
-
-
+- name: paas-templates-wip
+  type: git
+  source:
+    uri: ((paas-templates-uri))
+    branch: ((paas-templates-branch))
+    skip_ssl_verification: true
 
 - name: ntp_boshrelease
   
@@ -169,10 +173,8 @@ jobs:
     - aggregate:
       - get: secrets-simple-depls
         params: { submodules: none}
-        passed: [update-pipeline-simple-depls-generated]
       - get: paas-template-simple-depls
         params: { submodules: none}
-        passed: [update-pipeline-simple-depls-generated]
       - get: cf-ops-automation
         params: { submodules: none}
         passed: [update-pipeline-simple-depls-generated]
@@ -202,11 +204,9 @@ jobs:
     - get: secrets-simple-depls
       params: { submodules: none}
       trigger: true
-      passed: [update-pipeline-simple-depls-generated]
     - get: paas-template-simple-depls
       params: { submodules: none}
       trigger: true
-      passed: [update-pipeline-simple-depls-generated]
     - get: cf-ops-automation
       params: { submodules: none}
       trigger: true
@@ -330,7 +330,8 @@ jobs:
       - get: cf-ops-automation
         params: { submodules: none}
         passed: [update-pipeline-simple-depls-generated]
-      
+        trigger: true
+
       - get: ntp_boshrelease
         
         version: { version: ((ntp_boshrelease-version)) }
@@ -341,12 +342,10 @@ jobs:
       - get: secrets-ntp
         params: { submodules: none}
         trigger: true
-        passed: [update-pipeline-simple-depls-generated]
       - get: paas-template-ntp
         trigger: true
         
         params: { submodules: none}
-        passed: [update-pipeline-simple-depls-generated]
     - task: generate-ntp-manifest
       input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-ntp, additional-resource: paas-template-ntp}
       output_mapping: {generated-files: release-manifest}
@@ -643,6 +642,10 @@ jobs:
     - get: paas-template-simple-depls
       params: { submodules: none}
       attempts: 3
+    - get: paas-templates-wip
+      params:
+        submodules: none
+      attempts: 3
       trigger: true
     - get: secrets-simple-depls
       params: { submodules: none}
@@ -655,20 +658,11 @@ jobs:
     - get: paas-templates-full
       params: { submodules: none}
       attempts: 3
-      trigger: true
     - get: secrets-full
       params: { submodules: none}
       attempts: 3
-      trigger: true
-    
-    - get: secrets-ntp
-      params: { submodules: none}
-    - get: paas-template-ntp
-      params: { submodules: none}
-    
-
   - task: generate-simple-depls-pipeline
-    input_mapping: {script-resource: cf-ops-automation,templates: paas-templates-full,secrets: secrets-full}
+    input_mapping: {script-resource: cf-ops-automation,templates: paas-templates-wip,secrets: secrets-full}
     output_mapping: {result-dir: concourse-simple-depls-pipeline}
     config:
       platform: linux
@@ -705,7 +699,7 @@ jobs:
           
           # trick to manage <depls>-versions.yml (not included in secrets)
          
-         - paas-templates-full/simple-depls/simple-depls-versions.yml
+         - paas-templates-wip/simple-depls/simple-depls-versions.yml
           
      
       - name: simple-depls-cf-apps-generated
@@ -715,7 +709,7 @@ jobs:
           
           # trick to manage <depls>-versions.yml (not included in secrets)
          
-         - paas-templates-full/simple-depls/simple-depls-versions.yml
+         - paas-templates-wip/simple-depls/simple-depls-versions.yml
           
      
   - task: update-concourse-depls-pipeline
@@ -739,7 +733,12 @@ jobs:
     params:
       repository: updated-secrets
       rebase: true
-
+  - put: paas-templates-full
+    get_params:
+      submodules: none
+    params:
+      repository: paas-templates-wip
+      force: true
 
 
 

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -54,17 +54,6 @@ resources:
     - domain: ((slack-custom-root-domain))
       cert: ((slack-custom-root-cert))
 
-- name: bosh-stemcell
-  type: s3
-  source:
-    bucket: ((s3-stemcell-bucket))
-    region_name: ((s3-stemcell-region-name))
-    regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
-    access_key_id: ((s3-stemcell-access-key-id))
-    secret_access_key: ((s3-stemcell-secret-key))
-    endpoint: ((s3-stemcell-endpoint))
-    skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
-
 - name: secrets-simple-depls
   type: git
   source:
@@ -88,6 +77,17 @@ resources:
     branch: ((cf-ops-automation-branch))
     tag_filter: ((cf-ops-automation-tag-filter))
     skip_ssl_verification: true
+
+- name: bosh-stemcell
+  type: s3
+  source:
+    bucket: ((s3-stemcell-bucket))
+    region_name: ((s3-stemcell-region-name))
+    regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
+    access_key_id: ((s3-stemcell-access-key-id))
+    secret_access_key: ((s3-stemcell-secret-key))
+    endpoint: ((s3-stemcell-endpoint))
+    skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
 
 - name: secrets-ntp
   type: git


### PR DESCRIPTION
To allow pipeline auto update, we introduce a new staging branch called
    `pipeline-current-((paas-templates-branch))`.

    `update-pipeline-<%= depls %>-generated` job is now scanning
    `paas-templates-wip` for changes, is updating pipeline and committing to
    `paas-templates-full`. All other jobs are still scanning
    `paas-templates-full`. Using this mechanism, reduces dependencies on
    `update-pipeline-<%= depls %>-generated`
    and reduces inputs.

    It should help to fix #19 and #29, but we probably need to introduce a
    staging branch for secrets using similar mechanism.
    pipeline(depls): only declares bosh-stemcell for `enabled_deployment`
    pipeline(depls): migrates to new syntax