### PR TITLE
task(generate_manifest): supports vars-file without spruce processing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,12 +83,15 @@ Set a `iaas-type` credential in secrets repo to match the directory name.
 The newest bosh feature are not implemented in bosh cli v1. So some feature are only available to deployments using bosh cli v2.
 This can be combined with iaas specifics support 
 #### ops-files
-By convention, all files in template dir matching ```*-operators.yml``` are used by ```bosh-deployment``` 
+By convention, all files in template dir matching `*-operators.yml` are used by `bosh-deployment` 
 as ```ops-files``` inputs. Theses files **are not processed by spruce**. 
  
 #### vars-files
-By convention, all files in template dir matching ```*-vars-tpl.yml``` are processed by spruce and generate ```*-vars.yml``` files.
-Then files are used by ```bosh-deployment``` as ```vars-files``` inputs.
+By convention, all files in template dir matching `*-vars-tpl.yml` are processed by spruce and generate `*-vars.yml` files.
+As spruce is no longer required, it is also possible to include vars files directly, files matching `*-vars.yml` are used by `bosh-deployment`  but ignored by spruce.
+Theses files are used by ```bosh-deployment``` as ```vars-files``` inputs.
+
+**Warning**: if there is a naming conflict between `*-vars-tpl.yml` and `*-vars.yml`, the `tpl` wins !
 
 #### Cloud and runtime config
 Rules for ops-files and vars-files here. 

--- a/scripts/manifest/manifest-lifecycle-generation.sh
+++ b/scripts/manifest/manifest-lifecycle-generation.sh
@@ -8,6 +8,10 @@ COMMON_SCRIPT_DIR=${COMMON_SCRIPT_DIR:-scripts-resource/scripts/manifest}
 echo "Coping operators files from '${YML_TEMPLATE_DIR}' to '${OUTPUT_DIR}'"
 find ${YML_TEMPLATE_DIR} -maxdepth 1 -name "*-operators.yml" -exec cp --verbose {} ${OUTPUT_DIR} \;
 
+echo "Coping vars files from '${YML_TEMPLATE_DIR}' to '${OUTPUT_DIR}'"
+find ${YML_TEMPLATE_DIR} -maxdepth 1 -name "*-vars.yml" -exec cp --verbose {} ${OUTPUT_DIR} \;
+
+
 ${COMMON_SCRIPT_DIR}/generate-manifest.sh
 
 if [ -n "${IAAS_TYPE}" -a  -d "${YML_TEMPLATE_DIR}/${IAAS_TYPE}" ]; then


### PR DESCRIPTION
By convention, all files in template dir matching `*-vars-tpl.yml` are
processed by spruce and generate `*-vars.yml` files.
As spruce is no longer required, it is also possible to include vars
files directly, files matching `*-vars.yml` are used by `bosh-deployment`
 but ignored by spruce.