### PR TITLE
task(terraform_*): switch to custom image with providers and bump TF 0.11.2

### DIFF
--- a/concourse/tasks/terraform_apply.yml
+++ b/concourse/tasks/terraform_apply.yml
@@ -16,14 +16,16 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: hashicorp/terraform, tag: 0.8.7}
+  source: {repository: orangecloudfoundry/terraform, tag: f9b52b72631f192ad3710e47f98e10f13b09801c}
 
 inputs:
   - name: secret-state-resource
   - name: spec-resource
+  - name: terraform-tfvars
 
 outputs:
   - name: generated-files
+  - name: spec-applied
 
 run:
   path: sh
@@ -32,9 +34,30 @@ run:
   - |
     terraform version
     CURRENT_DIR=$(pwd)
-    find secret-state-resource/${SECRET_STATE_FILE_PATH}/ -type f -maxdepth 1 -exec cp {} generated-files/ \;
+
+    ###
+    ### don't use cp to copy file, or you'll get an error on empty dir
+    ### cp: can't stat 'terraform-tfvars/*': No such file or directory
+    ###
+
+    # copy tfstate and secrets
+    find secret-state-resource/${SECRET_STATE_FILE_PATH}/ -type f -exec cp {} generated-files/ \;
+
+    # copy generated tfvars
+    find terraform-tfvars -type f -exec cp {} generated-files/ \;
+
+    # copy spec in spec, preserving the nested modules if any
+    find spec-resource/${SPEC_PATH} -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
+
+    # copy spec in secrets, preserving the nested modules if any
+    if [ -d "secret-state-resource/${SPEC_PATH}" ]
+    then
+    find secret-state-resource/${SPEC_PATH} -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
+    fi
+
     cd generated-files/
-    terraform apply  ../spec-resource/$SPEC_PATH
+    terraform init -input=false -upgrade ../spec-applied/
+    terraform apply -input=false -auto-approve ../spec-applied/
 
 params:
   SPEC_PATH:

--- a/concourse/tasks/terraform_apply_cloudfoundry.yml
+++ b/concourse/tasks/terraform_apply_cloudfoundry.yml
@@ -16,7 +16,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: hashicorp/terraform, tag: 0.10.2}
+  source: {repository: orangecloudfoundry/terraform, tag: f9b52b72631f192ad3710e47f98e10f13b09801c}
 
 inputs:
   - name: secret-state-resource
@@ -32,7 +32,6 @@ run:
   args:
   - -exc
   - |
-    sh -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
     terraform version
     CURRENT_DIR=$(pwd)
 
@@ -45,22 +44,21 @@ run:
     find secret-state-resource/${SECRET_STATE_FILE_PATH}/ -type f -exec cp {} generated-files/ \;
 
     # copy generated tfvars
-    find terraform-tfvars/ -type f -exec cp {} generated-files/ \;
+    find terraform-tfvars -type f -exec cp {} generated-files/ \;
 
     # copy spec in spec, preserving the nested modules if any
-    find spec-resource/${SPEC_PATH}/ -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
+    find spec-resource/${SPEC_PATH} -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
 
     # copy spec in secrets, preserving the nested modules if any
     if [ -d "secret-state-resource/${SPEC_PATH}" ]
     then
-    find secret-state-resource/${SPEC_PATH}/ -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
+    find secret-state-resource/${SPEC_PATH} -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
     fi
 
     cd generated-files/
     terraform init -input=false -upgrade ../spec-applied/
-    terraform apply -input=false ../spec-applied/
+    terraform apply -input=false -auto-approve ../spec-applied/
 
 params:
   SPEC_PATH:
   SECRET_STATE_FILE_PATH:
-  PROVIDER_CLOUDFOUNDRY_VERSION: v0.9.1

--- a/concourse/tasks/terraform_plan_cloudfoundry.yml
+++ b/concourse/tasks/terraform_plan_cloudfoundry.yml
@@ -16,7 +16,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: hashicorp/terraform, tag: 0.10.2}
+  source: {repository: orangecloudfoundry/terraform, tag: f9b52b72631f192ad3710e47f98e10f13b09801c}
 
 inputs:
   - name: secret-state-resource
@@ -32,7 +32,6 @@ run:
   args:
   - -exc
   - |
-    sh -c "$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
     terraform version
     CURRENT_DIR=$(pwd)
 
@@ -53,7 +52,7 @@ run:
     # copy spec in secrets, preserving the nested modules if any
     if [ -d "secret-state-resource/${SPEC_PATH}" ]
     then
-    find secret-state-resource/${SPEC_PATH}/ -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
+    find secret-state-resource/${SPEC_PATH} -mindepth 1 -maxdepth 1 -exec cp --verbose -r {} spec-applied/ \;
     fi
 
     cd generated-files/
@@ -63,4 +62,3 @@ run:
 params:
   SPEC_PATH:
   SECRET_STATE_FILE_PATH:
-  PROVIDER_CLOUDFOUNDRY_VERSION: v0.9.1

--- a/spec/tasks/terraform_apply_cloudfoundry/task_spec.rb
+++ b/spec/tasks/terraform_apply_cloudfoundry/task_spec.rb
@@ -1,23 +1,22 @@
 # encoding: utf-8
 require 'yaml'
 require 'tmpdir'
+require_relative '../terraform_plan_cloudfoundry/task_spec'
 
 describe 'terraform_apply_cloudfoundry task' do
-  EXPECTED_TERRAFORM_VERSION='0.10.2'
-  EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.9.1'
-  SKIP_TMP_FILE_CLEANUP=false
+  SKIP_TMP_FILE_CLEANUP = false
 
   context 'Pre-requisite' do
     let(:task) { YAML.load_file 'concourse/tasks/terraform_apply_cloudfoundry.yml' }
 
-    it 'uses official hashicorp/terraform image' do
+    it 'uses official orange-cloudfoundry/terraform image' do
       docker_image_used = task['image_resource']['source']['repository'].to_s
-      expect(docker_image_used).to match('hashicorp/terraform')
+      expect(docker_image_used).to match('orangecloudfoundry/terraform')
     end
 
     it 'uses a tagged image' do
       docker_tag_used = task['image_resource']['source']['tag'].to_s
-      expect(docker_tag_used).to match(EXPECTED_TERRAFORM_VERSION)
+      expect(docker_tag_used).to match(EXPECTED_TERRAFORM_IMAGE_TAG)
     end
   end
 
@@ -47,7 +46,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     it 'ensures terraform cloudfoundry provider version is correct' do
-      expect(@output).to include("terraform-provider-cloudfoundry-#{EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION} has been installed")
+      expect(@output).to include("provider.cloudfoundry #{EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION}")
     end
 
     it 'ensures tfvars files are also in generated-files' do
@@ -102,7 +101,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     it 'matches files in generated-files output' do
-      expected_files = %w[. .. .gitkeep .terraform terraform.tfvars terraform.tfstate spec-only.txt].sort
+      expected_files = %w[. .. .gitkeep terraform.tfvars terraform.tfstate spec-only.txt].sort
       expect(Dir.entries(@generated_files).sort).to eq(expected_files)
     end
 
@@ -213,7 +212,7 @@ describe 'terraform_apply_cloudfoundry task' do
     end
 
     it 'matches files in generated-files output' do
-      expected_files = %w[. .. .gitkeep .terraform terraform.tfstate secrets.txt].sort
+      expected_files = %w[. .. .gitkeep terraform.tfstate secrets.txt].sort
       expect(Dir.entries(@generated_files).sort).to eq(expected_files)
     end
   end

--- a/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
+++ b/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
@@ -3,21 +3,22 @@ require 'yaml'
 require 'tmpdir'
 
 describe 'terraform_plan_cloudfoundry task' do
-  EXPECTED_TERRAFORM_VERSION='0.10.2'
-  EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION='v0.9.1'
-  SKIP_TMP_FILE_CLEANUP=false
+  EXPECTED_TERRAFORM_IMAGE_TAG = 'f9b52b72631f192ad3710e47f98e10f13b09801c'.freeze
+  EXPECTED_TERRAFORM_VERSION = '0.11.2'.freeze
+  EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION = 'v0.9.1'.freeze
+  SKIP_TMP_FILE_CLEANUP = false
 
   context 'Pre-requisite' do
     let(:task) { YAML.load_file 'concourse/tasks/terraform_plan_cloudfoundry.yml' }
 
-    it 'uses official hashicorp/terraform image' do
+    it 'uses official orange-cloudfoundry/terraform image' do
       docker_image_used = task['image_resource']['source']['repository'].to_s
-      expect(docker_image_used).to match('hashicorp/terraform')
+      expect(docker_image_used).to match('orangecloudfoundry/terraform')
     end
 
     it 'uses a tagged image' do
       docker_tag_used = task['image_resource']['source']['tag'].to_s
-      expect(docker_tag_used).to match(EXPECTED_TERRAFORM_VERSION)
+      expect(docker_tag_used).to match(EXPECTED_TERRAFORM_IMAGE_TAG)
     end
   end
 
@@ -49,7 +50,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     it 'ensures terraform cloudfoundry provider version is correct' do
-      expect(@output).to include("terraform-provider-cloudfoundry-#{EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION} has been installed")
+      expect(@output).to include("provider.cloudfoundry #{EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION}")
     end
 
     it 'ensures tfvars files are also in generated-files' do
@@ -98,7 +99,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     it 'copies terraform-tfvars files in generated-files output' do
-      cred_dir= %w[.gitkeep .terraform]
+      cred_dir = %w[.gitkeep]
 
       expected_dirs = Dir.entries(@terraform_tfvars) + cred_dir
       expect(Dir.entries(@generated_files).sort).to eq(expected_dirs.sort)
@@ -207,7 +208,7 @@ describe 'terraform_plan_cloudfoundry task' do
     end
 
     it 'does not contain any files in generated-files output' do
-      expect(Dir.entries(@generated_files).sort).to eq(%w[. .. .gitkeep .terraform].sort)
+      expect(Dir.entries(@generated_files).sort).to eq(%w[. .. .gitkeep].sort)
     end
 
   end


### PR DESCRIPTION
We no longer used official image provided by hashicorp. We use a custom
image with all providers already installed, so we don't need internet
access to download providers.
The docker image is a customization of AlphaGov: see [1]
We don't need any reference to terraform-provider-cloudfoundry, as it is
already included in the image.

[1]: https://github.com/orange-cloudfoundry/paas-docker-cloudfoundry-tools/tree/master/terraform