### PR TITLE
script(generate-depls): supports shared config with override

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -236,6 +236,12 @@ to ```enabled```, otherwise to ```disabled```.
 #### cf-app deployment
 NYI
 
+### shared and private configuration
+we provide a new config mechanism shared across all root deployments. A [default](lib/config.rb#L11) will be provided by cf-ops-automation, 
+but it is possible to override these values with a `shared-config.yml` file located in paas-template root directory. It 
+also possible to override again with a `private-config.yml` file located in secrets root directory.
+
+
 # Pipelines
 ## standalone
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,0 +1,27 @@
+require 'yaml'
+require 'fileutils'
+
+class Config
+  def initialize(public_yaml_location, private_yaml_location)
+    @public_yaml = public_yaml_location
+    @private_yaml = private_yaml_location
+    @loaded_config = default_config
+  end
+
+  def default_config
+    {
+      'offline-mode' => {
+         'boshreleases' => false,
+         'stemcells' => true ,
+         'docker-images' => false }
+    }
+  end
+
+  def load
+    public_config = YAML.load_file(@public_yaml) if File.exist?(@public_yaml)
+    private_config = YAML.load_file(@private_yaml) if File.exist?(@private_yaml)
+    @loaded_config.merge!(public_config) unless public_config.nil?
+    @loaded_config.merge!(private_config) unless private_config.nil?
+    @loaded_config
+  end
+end

--- a/scripts/generate-depls.rb
+++ b/scripts/generate-depls.rb
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 require 'optparse'
+require_relative '../lib/config'
 require_relative '../lib/bosh_certificates'
 require_relative '../lib/deployment_factory'
 require_relative '../lib/template_processor'
@@ -102,6 +103,11 @@ all_cf_apps = CfAppOverview.new(File.join(OPTIONS[:secret_path], depls, '/*'), d
 
 git_submodules = GitModules.list(OPTIONS[:git_submodule_path])
 
+shared_config = File.join(OPTIONS[:paas_template_root], 'shared-config.yml')
+private_shared_config = File.join(OPTIONS[:secret_path], 'private-config.yml')
+loaded_config = Config.new(shared_config, private_shared_config).load
+puts "loaded config: #{loaded_config}"
+
 erb_context = {
   depls: depls,
   bosh_cert: BOSH_CERT,
@@ -110,7 +116,8 @@ erb_context = {
   all_dependencies: all_dependencies,
   all_ci_deployments: all_ci_deployments,
   all_cf_apps: all_cf_apps,
-  git_submodules: git_submodules
+  git_submodules: git_submodules,
+  config: loaded_config
 }
 
 processor = TemplateProcessor.new depls, OPTIONS, erb_context

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,0 +1,71 @@
+require 'rspec'
+require 'yaml'
+require 'fileutils'
+require_relative '../../lib/config'
+
+describe Config do
+  let(:config_dir) { Dir.mktmpdir }
+  let(:default_config) do
+    {
+      'offline-mode' => {
+        'boshreleases' => false,
+        'stemcells' => true,
+        'docker-images' => false
+      }
+    }
+  end
+
+  # offline-mode:
+  #   boshreleases: false
+  #   stemcells: true
+  #   docker-images: false
+
+  describe 'shared-config.yml format validation' do
+  end
+
+  describe 'private-config.yml format validation' do
+  end
+
+  describe '#load' do
+    subject { described_class.new('not-existing-public-config.yml', 'not-existing-private-config.yml') }
+
+    it 'generates a default config when no yaml detected' do
+      expect(subject.load).to eq(default_config)
+    end
+
+    context 'when shared config exists' do
+      subject { described_class.new(shared_config_file, 'not-existing-private-config.yml') }
+
+      let(:shared_config_file) { File.join(config_dir, 'my-public-config.yml') }
+      let(:shared_config_file_content) { { 'public-override' => true, 'offline-mode' => false } }
+
+
+      before do
+        File.open(shared_config_file, 'w') do |file|
+          file.write shared_config_file_content.to_yaml
+        end
+      end
+
+      it 'overrides default value with shared-config' do
+        expect(subject.load).to eq(shared_config_file_content)
+      end
+
+      context 'when private config also exists' do
+        subject { described_class.new(shared_config_file, private_config_file) }
+
+        let(:private_config_file) { File.join(config_dir, 'my-private-config.yml') }
+        let(:private_config_file_content) { { 'private-override' => true, 'offline-mode' => true } }
+
+        before do
+          File.open(private_config_file, 'w') do |file|
+            file.write private_config_file_content.to_yaml
+          end
+        end
+
+        it 'overrides value from shared-config with private-config' do
+        expect(subject.load).to eq(private_config_file_content.merge({ 'public-override' => true}))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
we provide a new config mechanism shared across all root deployments. A
default will be provided by cf-ops-automation, but it is possible to
override these values with a `shared-config.yml` file located in
paas-template root directory. It also possible to override again with a
`private-config.yml` file located in secrets root directory.

Usage sample: it will be used to manage offline access (stemcell, bosh
release, docker image, etc...)