### PR TITLE
pipeline(depls,s3-br-upload): supports offline boshrelease and updates boshrelease upload location - REQUIRES shared/private config feature

### DIFF
--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -55,10 +55,11 @@ resources:
       cert: ((slack-custom-root-cert))
 
 <% terraform_config_path = nil %>
-<% unless all_ci_deployments.empty? || all_ci_deployments[depls]['terraform_config'].nil? %>
+<% unless all_ci_deployments&.empty? || all_ci_deployments[depls]['terraform_config'].nil? %>
   <% terraform_config_path = all_ci_deployments[depls]['terraform_config']['state_file_path'] %>
 <% end %>
 <% terraform_config_path_value = ",\"#{terraform_config_path}\"" if terraform_config_path %>
+
 - name: secrets-<%=depls %>
   type: git
   source:
@@ -211,6 +212,17 @@ resources:
 
 <% uniq_releases.sort.each do |release, info|  %>
 - name: <%= release %>
+  <% if !config['offline-mode'].nil? && config['offline-mode']['boshreleases'] %>
+  type: s3
+  source:
+    bucket: ((s3-br-bucket))
+    region_name: ((s3-br-region-name))
+    regexp: <%= info['repository']&.split('/')&.first %>/<%= release %>-(.*).tgz
+    access_key_id: ((s3-br-access-key-id))
+    secret_access_key: ((s3-br-secret-key))
+    endpoint: ((s3-br-endpoint))
+    skip_ssl_verification: ((s3-br-skip-ssl-verification))
+  <% else %>
   <% if info['base_location'].include?('bosh.io') %>
   type: bosh-io-release
   source:
@@ -220,6 +232,7 @@ resources:
   source:
     user: <%= info['repository'].split('/').first %>
     repository: <%= info['repository'].split('/').last %>
+  <% end %>
   <% end %>
 <% end %>
 
@@ -490,10 +503,14 @@ jobs:
         trigger: true
       <% boshrelease['releases']&.sort&.each do |release, info| %>
       - get: <%= release %>
+        <% if !config['offline-mode'].nil? && config['offline-mode']['boshreleases'] %>
+        version: { path: <%= info['repository']&.split('/')&.first %>/<%= release %>-((<%= release %>-version)).tgz }
+        <% else %>
         <% if info['base_location'].include?('bosh.io') %>
         version: { version: ((<%= release %>-version)) }
         <% else %>
         version: { tag: v((<%= release %>-version)) }
+        <% end %>
         <% end %>
         trigger: true
         attempts: 3
@@ -615,7 +632,11 @@ jobs:
           - bosh-stemcell/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz
         releases: <%= '[]' if boshrelease['releases']&.empty? %>
           <% boshrelease['releases']&.sort&.each do |release, info| %>
+          <% if !config['offline-mode'].nil? && config['offline-mode']['boshreleases'] %>
+          - <%= info['repository']&.split('/')&.first %>/<%= release %>-((<%= release %>-version)).tgz
+          <% else %>
           - <%= release %>/release.tgz
+          <% end %>
           <% end %>
         <% unless boshrelease['cli_version'] == 'v1' %>
         ops_files:
@@ -1089,16 +1110,14 @@ jobs:
 groups:
 - name: <%= depls.capitalize %>
   jobs:
-  <% jobs.each_value do |jobs_list| %>
-   <% jobs_list.each do |a_job| %>
+  <% jobs.map {|k,jobs_list| jobs_list}.flatten.uniq.sort.each do |a_job| %>
     - <%= a_job %>
-   <% end %>
   <% end %>
 
 <% jobs&.sort&.each do |group_name, jobs_list| %>
 - name: <%= group_name.capitalize %>
   jobs:
-   <% jobs_list&.each do |a_job| %>
+   <% jobs_list&.sort&.each do |a_job| %>
     - <%= a_job %>
    <% end %>
 <% end %>

--- a/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
@@ -4,8 +4,18 @@ resource_types:
     type: docker-image
     source:
       repository: cfcommunity/slack-notification-resource
+  - name: cron-resource
+    type: docker-image
+    source:
+      repository: cftoolsmiths/cron-resource
 
 resources:
+- name: weekday-morning
+  type: cron-resource
+  source:
+    expression: 40 8 * * 1-5
+    location: "Europe/Paris"
+    fire_immediately: true
 
 - name: failure-alert
   type: slack-notification
@@ -50,7 +60,7 @@ resources:
   source:
     bucket: ((s3-br-bucket))
     region_name: ((s3-br-region-name))
-    regexp: <%= release %>/<%= release %>-(.*).tgz
+    regexp: <%= info['repository']&.split('/')&.first %>/<%= release %>-(.*).tgz
     access_key_id: ((s3-br-access-key-id))
     secret_access_key: ((s3-br-secret-key))
     endpoint: ((s3-br-endpoint))
@@ -73,6 +83,8 @@ jobs:
     - get: cf-ops-automation
       params: { submodules: none}
       attempts: 3
+    - get: weekday-morning
+      trigger: true
   - task: generate-<%= depls %>-flight-plan
     output_mapping: {result-dir: init-<%= depls %>-plan}
     config:

--- a/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
@@ -4,8 +4,17 @@ resource_types:
     type: docker-image
     source:
       repository: cfcommunity/slack-notification-resource
-
+  - name: cron-resource
+    type: docker-image
+    source:
+      repository: cftoolsmiths/cron-resource
 resources:
+- name: weekday-morning
+  type: cron-resource
+  source:
+    expression: 50 8 * * 1-5
+    location: "Europe/Paris"
+    fire_immediately: true
 
 - name: failure-alert
   type: slack-notification
@@ -66,6 +75,8 @@ jobs:
     - get: cf-ops-automation
       params: { submodules: none}
       attempts: 3
+    - get: weekday-morning
+      trigger: true
   - task: generate-<%= depls %>-flight-plan
     output_mapping: {result-dir: init-<%= depls %>-plan}
     config:

--- a/lib/template_processor.rb
+++ b/lib/template_processor.rb
@@ -16,11 +16,10 @@ class TemplateProcessor
   end
 
   def process(dir)
-    processed_template_count = 0
-    return processed_template_count if dir.nil?
+    processed_template = {}
+    return processed_template if dir.nil?
 
     Dir[dir]&.each do |filename|
-      processed_template_count += 1
 
       puts "processing #{filename}"
       output = ERB.new(File.read(filename), 0, '<>').result(load_context_into_a_binding)
@@ -34,6 +33,7 @@ class TemplateProcessor
       a_pipeline = File.new(File.join(target_dir, pipeline_name), 'w')
       a_pipeline << output
       a_pipeline.close
+      processed_template[filename] = pipeline_name
       puts "Trying to parse generated Yaml: #{pipeline_name} (#{a_pipeline&.path})"
       raise "invalid #{pipeline_name} file" unless YAML.load_file(a_pipeline)
       puts "> #{pipeline_name} seems a valid Yaml file"
@@ -41,7 +41,7 @@ class TemplateProcessor
       puts '####################################################################################'
     end
 
-    processed_template_count
+    processed_template
   end
 
   private
@@ -61,7 +61,7 @@ class TemplateProcessor
 
   def load_context_into_a_binding
     new_binding = binding
-    context.each do |k, v|
+    context&.each do |k, v|
       new_binding.local_variable_set k.to_sym, v
     end
     puts "Local var: #{new_binding.local_variables}"

--- a/scripts/generate-depls.rb
+++ b/scripts/generate-depls.rb
@@ -125,7 +125,8 @@ processor = TemplateProcessor.new depls, OPTIONS, erb_context
 
 processed_template_count = 0
 OPTIONS[:input_pipelines].each do |dir|
-  processed_template_count += processor.process(dir)
+  processed_template = processor.process(dir)
+  processed_template_count += processed_template.length
 end
 
 if processed_template_count.positive?

--- a/spec/lib/template_processor_for_depls_pipeline_spec.rb
+++ b/spec/lib/template_processor_for_depls_pipeline_spec.rb
@@ -1,0 +1,311 @@
+require 'rspec'
+require 'fileutils'
+
+require_relative '../../lib/template_processor'
+require_relative '../../lib/ci_deployment_overview'
+
+describe 'DeplsPipelineTemplateProcessing' do
+  let(:root_deployment_name) { 'my-root-depls' }
+  let(:bosh_cert) { BOSH_CERT_LOCATIONS = { root_deployment_name => 'shared/certificate.pem' }.freeze }
+  let(:processor_context) do
+    { depls: root_deployment_name,
+      bosh_cert: bosh_cert,
+      all_dependencies: all_dependencies,
+      all_ci_deployments: all_ci_deployments,
+      git_submodules: git_submodules,
+      config: loaded_config }
+  end
+  let(:secrets_dirs_overview) { {} }
+  let(:root_deployment_versions) { {} }
+  let(:all_dependencies) do
+    deps_yaml = <<~YAML
+      bosh-bats:
+          status: disabled
+      maria-db:
+          status: disabled
+      shield-expe:
+          stemcells:
+          bosh-openstack-kvm-ubuntu-trusty-go_agent:
+          releases:
+            cf-routing-release:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-incubator/cf-routing-release
+              version: 0.169.0
+              errands:
+                  import:
+          status: enabled
+      bui:
+          stemcells:
+          bosh-openstack-kvm-ubuntu-trusty-go_agent:
+          releases:
+            route-registrar-boshrelease:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-community/route-registrar-boshrelease
+              version: '3'
+            haproxy-boshrelease:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-community/haproxy-boshrelease
+              version: 8.0.12
+          status: enabled
+    YAML
+    YAML.safe_load(deps_yaml)
+  end
+  let(:all_ci_deployments) { {} }
+  let(:git_submodules) { {} }
+  let(:loaded_config) do
+    my_config_yaml = <<~YAML
+      offline-mode:
+        boshreleases: true
+        stemcells: true
+        docker-images: false
+    YAML
+    YAML.safe_load(my_config_yaml)
+  end
+  let(:expected_resource_types) do
+    resource_types_yaml = <<~YAML
+      - name: bosh-deployment
+        type: docker-image
+        source:
+          repository: concourse/bosh-deployment-resource
+          tag: latest
+      - name: slack-notification
+        type: docker-image
+        source:
+          repository: cfcommunity/slack-notification-resource
+      - name: cron-resource
+        type: docker-image
+        source:
+          repository: cftoolsmiths/cron-resource
+      - name: bosh-config
+        type: docker-image
+        source:
+          repository: dellemcdojo/bosh-config-resource
+      - name: concourse-pipeline
+        type: docker-image
+        source:
+          repository: concourse/concourse-pipeline-resource
+      - name: bosh-deployment-v2
+        type: docker-image
+        source:
+          repository: cloudfoundry/bosh-deployment-resource
+      - name: bosh-errand
+        type: docker-image
+        source:
+          repository: starkandwayne/bosh2-errand-resource
+    YAML
+    YAML.safe_load(resource_types_yaml)
+  end
+  let(:groups) do
+    groups_yaml = [
+      { 'name' => 'My-root-depls',
+        'jobs' =>
+         ['approve-and-delete-disabled-deployments',
+          'cloud-config-and-runtime-config-for-my-root-depls',
+          'delete-deployments-review',
+          'deploy-bui',
+          'deploy-shield-expe',
+          'execute-deploy-script',
+          'recreate-all',
+          'recreate-bui',
+          'recreate-shield-expe',
+          'retrigger-all-jobs'] },
+      { 'name' => 'Deploy-b*', 'jobs' => ['deploy-bui'] },
+      { 'name' => 'Deploy-s*', 'jobs' => ['deploy-shield-expe'] },
+      { 'name' => 'Recreate',
+        'jobs' => ['recreate-all', 'recreate-bui', 'recreate-shield-expe'] },
+      { 'name' => 'Utils',
+        'jobs' =>
+        ['approve-and-delete-disabled-deployments',
+         'cloud-config-and-runtime-config-for-my-root-depls',
+         'delete-deployments-review',
+         'execute-deploy-script',
+         'recreate-all',
+         'retrigger-all-jobs'] }
+    ]
+  end
+
+  context 'when processing depls-pipeline.yml.erb' do
+    subject { TemplateProcessor.new root_deployment_name, config, processor_context }
+
+    before(:context) do
+      @output_dir = Dir.mktmpdir('generated-pipelines')
+      @pipelines_output_dir = File.join(@output_dir, 'pipelines')
+      @template_pipeline_name = 'depls-pipeline.yml.erb'
+      @pipelines_dir = Dir.mktmpdir('pipeline-templates')
+
+      FileUtils.copy("concourse/pipelines/template/#{@template_pipeline_name}", @pipelines_dir)
+    end
+
+    after(:context) do
+      FileUtils.rm_rf(@output_dir)
+      FileUtils.rm_rf(@pipelines_dir)
+    end
+
+    let(:config) { { dump_output: true, output_path: @output_dir } }
+    let(:generated_pipeline) do
+      pipeline_template = @processed_template[File.join(@pipelines_dir, @template_pipeline_name)]
+      generated_pipeline_path = File.join(@pipelines_output_dir, pipeline_template)
+      YAML.load_file(generated_pipeline_path)
+    end
+
+    before { @processed_template = subject.process(@pipelines_dir + '/*') }
+
+    context 'without ci deployment overview' do
+      it 'processes only one template' do
+        expect(@processed_template.length).to eq(1)
+      end
+
+      it 'processes is not empty' do
+        expect(@processed_template).not_to be_empty
+      end
+
+      it 'generates a valid yaml file' do
+        expect(generated_pipeline).not_to be_falsey
+      end
+
+      it 'generates all resource_types' do
+        expect(generated_pipeline['resource_types']).to match(expected_resource_types)
+      end
+
+      it 'generates all groups' do
+        expect(generated_pipeline['groups']).to match(groups)
+      end
+
+      it 'generates a group using root deployment name ' do
+        expected_group = generated_pipeline['groups'].select { |concourse_group| concourse_group['name'] == root_deployment_name.capitalize }
+        expect(expected_group).not_to be_empty
+      end
+    end
+
+    context 'when boshrelease offline mode is enabled' do
+      let(:expected_boshreleases) do
+        { 'cf-routing-release' => 'cloudfoundry-incubator',
+          'route-registrar-boshrelease' => 'cloudfoundry-community',
+          'haproxy-boshrelease' => 'cloudfoundry-community' }
+      end
+      let(:expected_s3_boshreleases) do
+        expected_yaml = expected_boshreleases.map do |br_name, br_repo|
+          fragment = <<~YAML
+            - name: #{br_name}
+              type: s3
+              source:
+                bucket: ((s3-br-bucket))
+                region_name: ((s3-br-region-name))
+                regexp: #{br_repo}/#{br_name}-(.*).tgz
+                access_key_id: ((s3-br-access-key-id))
+                secret_access_key: ((s3-br-secret-key))
+                endpoint: ((s3-br-endpoint))
+                skip_ssl_verification: ((s3-br-skip-ssl-verification))
+          YAML
+          YAML.safe_load fragment
+        end.flatten
+      end
+      let(:expected_boshrelease_get_version) do
+        expected_boshreleases.flat_map { |name, repo| { name => "#{repo}/#{name}-((#{name}-version)).tgz" } }
+      end
+      let(:expected_s3_deployment_put) do
+        expected_yaml = <<~YAML
+          - bui-deployment:
+            - #{expected_boshrelease_get_version.flat_map { |br| br['haproxy-boshrelease'] }.compact.first}
+            - #{expected_boshrelease_get_version.flat_map { |br| br['route-registrar-boshrelease'] }.compact.first}
+          - shield-expe-deployment:
+            - #{expected_boshrelease_get_version.flat_map { |br| br['cf-routing-release'] }.compact.first}
+        YAML
+        YAML.safe_load expected_yaml
+      end
+
+      it 'generates s3 bosh release resource' do
+        s3_boshreleases = generated_pipeline['resources'].select { |resource| resource['type'] == 's3' }
+        expect(s3_boshreleases).to include(*expected_s3_boshreleases)
+      end
+
+      it 'generates s3 version using path on get' do
+        boshrelease_get_version = generated_pipeline['jobs'].flat_map { |job| job['plan'] }
+                                                            .flat_map { |plan| plan['aggregate'] }
+                                                            .compact
+                                                            .select { |resource| expected_boshreleases.keys.include?(resource['get']) }
+                                                            .flat_map { |resource| { resource['get'] => resource['version']['path'] } }
+        expect(boshrelease_get_version).to include(*expected_boshrelease_get_version)
+      end
+
+      it 'generates s3 version using path on deployment put' do
+        s3_deployments = expected_s3_deployment_put.flat_map(&:keys)
+        deployment_put_version = generated_pipeline['jobs'].flat_map { |job| job['plan'] }
+                                                           .select { |resource| s3_deployments.include?(resource['put']) }
+                                                           .flat_map { |resource| { resource['put'] => resource['params']['releases'] } }
+        expect(deployment_put_version).to include(*expected_s3_deployment_put)
+      end
+    end
+    context 'with ci deployment overview without terraform' do
+      let(:all_ci_deployments) do
+        ci_deployments_yaml = <<~YAML
+          #{root_deployment_name}:
+            target_name: my-concourse-name
+            pipelines:
+              #{root_deployment_name}-generated:
+                config_file: path/located/in/secrets-repo/pipelines/#{root_deployment_name}-generated.yml
+                vars_files:
+                - another/path/located/in/secrets-repo/pipelines/credentials-iaas-specific.yml
+                - #{root_deployment_name}/#{root_deployment_name}-versions.yml
+              #{root_deployment_name}-cf-apps-generated:
+                config_file: path/located/in/secrets-repo/pipelines/#{root_deployment_name}-generated.yml
+                vars_files:
+                - another/path/located/in/secrets-repo/pipelines/credentials-iaas-specific.yml
+                - #{root_deployment_name}/#{root_deployment_name}-versions.yml
+        YAML
+        YAML.safe_load ci_deployments_yaml
+      end
+
+      it 'generates all resource_types' do
+        expect(generated_pipeline['resource_types']).to match_array(expected_resource_types)
+      end
+
+      it 'generates all groups' do
+        groups.select { |item| %w(Utils My-root-depls).include?(item['name']) }.each do |item|
+          item['jobs'] << 'init-concourse-boshrelease-and-stemcell-for-my-root-depls'
+          item['jobs'] << 'update-pipeline-my-root-depls-generated'
+          item['jobs'].sort!
+        end
+        expect(generated_pipeline['groups']).to match_array(groups)
+      end
+    end
+
+    context 'when terraform is enabled ' do
+      let(:all_ci_deployments) do
+        ci_deployments_yaml = <<~YAML
+          #{root_deployment_name}:
+            terraform_config:
+              state_file_path: my-tfstate-location
+            target_name: my-concourse-name
+            pipelines:
+              #{root_deployment_name}-generated:
+                config_file: path/located/in/secrets-repo/pipelines/#{root_deployment_name}-generated.yml
+                vars_files:
+                - another/path/located/in/secrets-repo/pipelines/credentials-iaas-specific.yml
+                - #{root_deployment_name}/#{root_deployment_name}-versions.yml
+              #{root_deployment_name}-cf-apps-generated:
+                config_file: path/located/in/secrets-repo/pipelines/#{root_deployment_name}-generated.yml
+                vars_files:
+                - another/path/located/in/secrets-repo/pipelines/credentials-iaas-specific.yml
+                - #{root_deployment_name}/#{root_deployment_name}-versions.yml
+
+        YAML
+        YAML.safe_load ci_deployments_yaml
+      end
+
+      it 'generates all resource_types' do
+        expect(generated_pipeline['resource_types']).to match(expected_resource_types)
+      end
+
+      it 'generates terraform group' do
+        expected_tf_group = { 'name' => 'Terraform',
+                              'jobs' =>
+                                     ['cf-manual-approval',
+                                      'check-terraform-cf-consistency',
+                                      'enforce-terraform-cf-consistency'] }
+        generated = generated_pipeline['groups'].select { |group| group['name'] == 'Terraform' }.pop
+        expect(generated).to match(expected_tf_group)
+      end
+    end
+  end
+end

--- a/spec/lib/template_processor_spec.rb
+++ b/spec/lib/template_processor_spec.rb
@@ -47,13 +47,13 @@ describe TemplateProcessor do
       subject { described_class.new(root_deployment_name) }
 
       it 'supports nil' do
-        count = subject.process nil
-        expect(count).to eq(0)
+        all_processed_template = subject.process nil
+        expect(all_processed_template.length).to eq(0)
       end
 
       it 'supports empty string' do
-        count = subject.process ''
-        expect(count).to eq(0)
+        all_processed_template = subject.process ''
+        expect(all_processed_template.length).to eq(0)
       end
     end
 
@@ -126,7 +126,7 @@ describe TemplateProcessor do
         }
 
 
-        before {@count=subject.process(@pipelines_dir + '/*') }
+        before {@processed_template = subject.process(@pipelines_dir + '/*') }
 
         # before do
         #   allow(Dir).to receive(:[]).and_return([@template_pipeline_name.to_s])
@@ -143,7 +143,7 @@ describe TemplateProcessor do
           expect(Dir).to receive(:[]).with(@pipelines_dir)
           expect(File).to receive(:read).with(File.join(@pipelines_output_dir, @template_pipeline_name))
 
-          expect(@count).to eq(1)
+          expect(@processed_template.length).to eq(1)
           expect(File.read(File.join(@pipelines_output_dir, @template_pipeline_name))).to eq(expected_yaml_file)
         end
 

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
@@ -368,19 +368,18 @@ jobs:
 groups:
   - name: Delete-depls
     jobs:
-      - delete-deployments-review
       - approve-and-delete-disabled-deployments
-      - execute-deploy-script
       - cloud-config-and-runtime-config-for-delete-depls
-      - recreate-all
+      - delete-deployments-review
+      - execute-deploy-script
       - recreate-all
   - name: Recreate
     jobs:
       - recreate-all
   - name: Utils
     jobs:
-      - delete-deployments-review
       - approve-and-delete-disabled-deployments
-      - execute-deploy-script
       - cloud-config-and-runtime-config-for-delete-depls
+      - delete-deployments-review
+      - execute-deploy-script
       - recreate-all

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -283,32 +283,16 @@ jobs:
 groups:
 - name: Dummy-depls
   jobs:
-  
-   
-    - execute-deploy-script
-   
     - cloud-config-and-runtime-config-for-dummy-depls
-   
+    - execute-deploy-script
     - recreate-all
-   
-  
-   
-    - recreate-all
-   
-  
-
 - name: Recreate
   jobs:
-   
     - recreate-all
-   
 - name: Utils
   jobs:
-   
-    - execute-deploy-script
-   
     - cloud-config-and-runtime-config-for-dummy-depls
-   
+    - execute-deploy-script
     - recreate-all
    
 

--- a/spec/scripts/generate-depls/fixtures/references/empty-s3-br-upload.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-s3-br-upload.yml
@@ -4,7 +4,17 @@ resource_types:
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource
 resources:
+- name: weekday-morning
+  type: cron-resource
+  source:
+    expression: 40 8 * * 1-5
+    location: Europe/Paris
+    fire_immediately: true
 - name: failure-alert
   type: slack-notification
   source:
@@ -36,6 +46,8 @@ jobs:
       params:
         submodules: none
       attempts: 3
+    - get: weekday-morning
+      trigger: true
   - task: generate-dummy-depls-flight-plan
     output_mapping:
       result-dir: init-dummy-depls-plan

--- a/spec/scripts/generate-depls/fixtures/references/empty-s3-stemcell-upload.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-s3-stemcell-upload.yml
@@ -4,7 +4,17 @@ resource_types:
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource
 resources:
+- name: weekday-morning
+  type: cron-resource
+  source:
+    expression: 50 8 * * 1-5
+    location: Europe/Paris
+    fire_immediately: true
 - name: failure-alert
   type: slack-notification
   source:
@@ -36,6 +46,8 @@ jobs:
       params:
         submodules: none
       attempts: 3
+    - get: weekday-morning
+      trigger: true
   - task: generate-dummy-depls-flight-plan
     output_mapping:
       result-dir: init-dummy-depls-plan

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -759,57 +759,29 @@ jobs:
 groups:
 - name: Simple-depls
   jobs:
-  
-   
-    - execute-deploy-script
-   
     - cloud-config-and-runtime-config-for-simple-depls
-   
-    - retrigger-all-jobs
-   
-    - recreate-all
-   
-    - init-concourse-boshrelease-and-stemcell-for-simple-depls
-   
-    - update-pipeline-simple-depls-generated
-   
-  
-   
     - deploy-ntp
-   
-  
-   
+    - execute-deploy-script
+    - init-concourse-boshrelease-and-stemcell-for-simple-depls
     - recreate-all
-   
     - recreate-ntp
-   
-  
+    - retrigger-all-jobs
+    - update-pipeline-simple-depls-generated
 
 - name: Deploy-n*
   jobs:
-   
     - deploy-ntp
    
 - name: Recreate
   jobs:
-   
     - recreate-all
-   
     - recreate-ntp
    
 - name: Utils
   jobs:
-   
-    - execute-deploy-script
-   
     - cloud-config-and-runtime-config-for-simple-depls
-   
-    - retrigger-all-jobs
-   
-    - recreate-all
-   
+    - execute-deploy-script
     - init-concourse-boshrelease-and-stemcell-for-simple-depls
-   
+    - recreate-all
+    - retrigger-all-jobs
     - update-pipeline-simple-depls-generated
-   
-

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
@@ -4,7 +4,17 @@ resource_types:
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource
 resources:
+- name: weekday-morning
+  type: cron-resource
+  source:
+    expression: 40 8 * * 1-5
+    location: Europe/Paris
+    fire_immediately: true
 - name: failure-alert
   type: slack-notification
   source:
@@ -30,7 +40,7 @@ resources:
   source:
     bucket: "((s3-br-bucket))"
     region_name: "((s3-br-region-name))"
-    regexp: ntp_boshrelease/ntp_boshrelease-(.*).tgz
+    regexp: cloudfoundry-community/ntp_boshrelease-(.*).tgz
     access_key_id: "((s3-br-access-key-id))"
     secret_access_key: "((s3-br-secret-key))"
     endpoint: "((s3-br-endpoint))"
@@ -50,6 +60,8 @@ jobs:
       params:
         submodules: none
       attempts: 3
+    - get: weekday-morning
+      trigger: true
   - task: generate-simple-depls-flight-plan
     output_mapping:
       result-dir: init-simple-depls-plan

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-stemcell-upload-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-stemcell-upload-ref.yml
@@ -4,7 +4,17 @@ resource_types:
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource
 resources:
+- name: weekday-morning
+  type: cron-resource
+  source:
+    expression: 50 8 * * 1-5
+    location: Europe/Paris
+    fire_immediately: true
 - name: failure-alert
   type: slack-notification
   source:
@@ -50,6 +60,8 @@ jobs:
       params:
         submodules: none
       attempts: 3
+    - get: weekday-morning
+      trigger: true
   - task: generate-simple-depls-flight-plan
     output_mapping:
       result-dir: init-simple-depls-plan


### PR DESCRIPTION
We use Boshrelease organisation as upload dir to avoid name collision.

We also triggers init step on creation and regularly for s3-br-upload.
Init step triggers each weekday morning, and this also bump cf-ops-automation
 to the latest used version once a day. Otherwise, cf-ops-automation is
 stick to an old revision.

Fixes duplicate job in groups.