### PR TITLE
pipeline(cf-apps): injects CF info as environment variable in post-cf-deploy

### DIFF
--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -38,6 +38,12 @@ resources:
     uri: ((secrets-uri))
     branch: ((secrets-branch))
     skip_ssl_verification: true
+- name: secrets-full-writer
+  type: git
+  source:
+    uri: ((secrets-uri))
+    branch: ((secrets-branch))
+    skip_ssl_verification: true
 
 - name: cf-ops-automation
   type: git
@@ -135,6 +141,8 @@ jobs:
       - get: secrets-<%= app_name %>
         params: { submodules: none}
         trigger: true
+      - get: secrets-full-writer
+        params: { submodules: none}
       - get: paas-template-<%= app_name %>
         trigger: true
         params: { submodules: none }
@@ -170,14 +178,14 @@ jobs:
         CF_PASSWORD: <%= cf_app_info["cf_password"] %>
 
     - task: update-<%= app_name %>-files
-      input_mapping: {reference-resource: secrets-<%= app_name %>, generated-resource: final-release-manifest}
+      input_mapping: {reference-resource: secrets-full-writer, generated-resource: final-release-manifest}
       output_mapping: {updated-git-resource: updated-<%= app_name %>-secrets}
       file: cf-ops-automation/concourse/tasks/git_update_a_file_from_generated.yml
       params:
         OLD_FILE: <%= cf_app_info["base-dir"] %>/<%= app_name %>_manifest.yml
         NEW_FILE: "<%= app_name %>_manifest.yml"
         COMMIT_MESSAGE: "<%= app_name %> generated CF manifest auto update - [skip ci]"
-    - put: secrets-<%= app_name %>
+    - put: secrets-full-writer
       get_params: {submodules: none}
       params:
         repository: updated-<%= app_name %>-secrets

--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -28,41 +28,41 @@ resources:
 - name: failure-alert
   type: slack-notification
   source:
-    url: {{slack-webhook}}
+    url: ((slack-webhook))
     ca_certs:
-    - domain: {{slack-custom-domain}}
-      cert: {{slack-custom-cert}}
+    - domain: ((slack-custom-domain))
+      cert: ((slack-custom-cert))
 - name: secrets-full
   type: git
   source:
-    uri: {{secrets-uri}}
-    branch: {{secrets-branch}}
+    uri: ((secrets-uri))
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: cf-ops-automation
   type: git
   source:
-    uri: {{cf-ops-automation-uri}}
-    branch: {{cf-ops-automation-branch}}
+    uri: ((cf-ops-automation-uri))
+    branch: ((cf-ops-automation-branch))
     skip_ssl_verification: true
-    tag_filter: {{cf-ops-automation-tag-filter}}
+    tag_filter: ((cf-ops-automation-tag-filter))
 <% end %>
 
 <% all_cf_apps.sort.each do |app_name,cf_app_info| %>
 - name: secrets-<%= app_name %>
   type: git
   source:
-    uri: {{secrets-uri}}
+    uri: ((secrets-uri))
     paths: ["<%= cf_app_info["base-dir"] %>", "shared"]
-    branch: {{secrets-branch}}
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-template-<%= app_name %>
   type: git
   source:
-    uri: {{paas-templates-uri}}
+    uri: ((paas-templates-uri))
     paths: ["<%= cf_app_info["base-dir"] %>"]
-    branch: {{paas-templates-branch}}
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 <% end %>
 
@@ -79,7 +79,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failure during [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -113,9 +113,9 @@ jobs:
       output_mapping: {flight-report: concourse-<%= depls %>-trigger-report}
       file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
       params:
-        ATC_EXTERNAL_URL: {{concourse-<%= depls %>-target}}
-        FLY_USERNAME: {{concourse-<%= depls %>-username}}
-        FLY_PASSWORD:  {{concourse-<%= depls %>-password}}
+        ATC_EXTERNAL_URL: ((concourse-<%= depls %>-target))
+        FLY_USERNAME: ((concourse-<%= depls %>-username))
+        FLY_PASSWORD:  ((concourse-<%= depls %>-password))
 
 <% end %>
 
@@ -126,7 +126,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failure during [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -189,6 +189,11 @@ jobs:
       params:
         CUSTOM_SCRIPT_DIR: template-resource/<%= cf_app_info["base-dir"] %>/template
         SECRETS_DIR: credentials-resource/<%= cf_app_info["base-dir"] %>
+        CF_API_URL: <%= cf_app_info["cf_api_url"] %>
+        CF_ORG: <%= cf_app_info["cf_organization"] %>
+        CF_SPACE: <%= cf_app_info["cf_space"] %>
+        CF_USERNAME: <%= cf_app_info["cf_username"] %>
+        CF_PASSWORD: <%= cf_app_info["cf_password"] %>
 
 <% end %>
 

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -31,7 +31,15 @@ resources:
     ca_certs:
     - domain: ((slack-custom-domain))
       cert: ((slack-custom-cert))
+
 - name: secrets-full
+  type: git
+  source:
+    uri: ((secrets-uri))
+    branch: ((secrets-branch))
+    skip_ssl_verification: true
+
+- name: secrets-full-writer
   type: git
   source:
     uri: ((secrets-uri))
@@ -96,7 +104,6 @@ jobs:
           - |
 
             echo "trigger-job -j $BUILD_PIPELINE_NAME/cf-push-test-app" >> result-dir/flight-plan
-
         params:
           BUILD_PIPELINE_NAME: apps-depls-cf-apps-generated
     - task: fly-into-concourse
@@ -123,6 +130,8 @@ jobs:
       - get: secrets-test-app
         params: { submodules: none}
         trigger: true
+      - get: secrets-full-writer
+        params: { submodules: none}
       - get: paas-template-test-app
         trigger: true
         params: { submodules: none }
@@ -158,14 +167,14 @@ jobs:
         CF_PASSWORD: a-test-Password
 
     - task: update-test-app-files
-      input_mapping: {reference-resource: secrets-test-app, generated-resource: final-release-manifest}
+      input_mapping: {reference-resource: secrets-full-writer, generated-resource: final-release-manifest}
       output_mapping: {updated-git-resource: updated-test-app-secrets}
       file: cf-ops-automation/concourse/tasks/git_update_a_file_from_generated.yml
       params:
         OLD_FILE: apps-depls/my_cf_app/test-app_manifest.yml
         NEW_FILE: "test-app_manifest.yml"
         COMMIT_MESSAGE: "test-app generated CF manifest auto update - [skip ci]"
-    - put: secrets-test-app
+    - put: secrets-full-writer
       get_params: {submodules: none}
       params:
         repository: updated-test-app-secrets

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -27,39 +27,39 @@ resources:
 - name: failure-alert
   type: slack-notification
   source:
-    url: {{slack-webhook}}
+    url: ((slack-webhook))
     ca_certs:
-    - domain: {{slack-custom-domain}}
-      cert: {{slack-custom-cert}}
+    - domain: ((slack-custom-domain))
+      cert: ((slack-custom-cert))
 - name: secrets-full
   type: git
   source:
-    uri: {{secrets-uri}}
-    branch: {{secrets-branch}}
+    uri: ((secrets-uri))
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: cf-ops-automation
   type: git
   source:
-    uri: {{cf-ops-automation-uri}}
-    branch: {{cf-ops-automation-branch}}
+    uri: ((cf-ops-automation-uri))
+    branch: ((cf-ops-automation-branch))
     skip_ssl_verification: true
-    tag_filter: {{cf-ops-automation-tag-filter}}
+    tag_filter: ((cf-ops-automation-tag-filter))
 
 - name: secrets-test-app
   type: git
   source:
-    uri: {{secrets-uri}}
+    uri: ((secrets-uri))
     paths: ["apps-depls/my_cf_app", "shared"]
-    branch: {{secrets-branch}}
+    branch: ((secrets-branch))
     skip_ssl_verification: true
 
 - name: paas-template-test-app
   type: git
   source:
-    uri: {{paas-templates-uri}}
+    uri: ((paas-templates-uri))
     paths: ["apps-depls/my_cf_app"]
-    branch: {{paas-templates-branch}}
+    branch: ((paas-templates-branch))
     skip_ssl_verification: true
 
 jobs:
@@ -70,7 +70,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failure during [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -104,9 +104,9 @@ jobs:
       output_mapping: {flight-report: concourse-apps-depls-trigger-report}
       file: cf-ops-automation/concourse/tasks/fly_execute_commands.yml
       params:
-        ATC_EXTERNAL_URL: {{concourse-apps-depls-target}}
-        FLY_USERNAME: {{concourse-apps-depls-username}}
-        FLY_PASSWORD:  {{concourse-apps-depls-password}}
+        ATC_EXTERNAL_URL: ((concourse-apps-depls-target))
+        FLY_USERNAME: ((concourse-apps-depls-username))
+        FLY_PASSWORD:  ((concourse-apps-depls-password))
 
 
 
@@ -114,7 +114,7 @@ jobs:
   on_failure:
     put: failure-alert
     params:
-      channel: {{slack-channel}}
+      channel: ((slack-channel))
       text: Failure during [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
       icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
       username: Concourse
@@ -177,7 +177,11 @@ jobs:
       params:
         CUSTOM_SCRIPT_DIR: template-resource/apps-depls/my_cf_app/template
         SECRETS_DIR: credentials-resource/apps-depls/my_cf_app
-
+        CF_API_URL: https://my-cloudfroundry.org
+        CF_ORG: my-test-org
+        CF_SPACE: my-test-space
+        CF_USERNAME: a-test-User
+        CF_PASSWORD: a-test-Password
 
 
 groups:

--- a/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
@@ -10,24 +10,9 @@ resource_types:
     source:
       repository: cftoolsmiths/cron-resource
 
-#  - name: maven-resource
-#    type: docker-image
-#    source:
-#      repository: patrickcrocker/maven-resource
-#      tag: latest
-
 resources:
-#- name: at-noon
-#  type: cron-resource
-#  source:
-#    expression: "15 12 * * 1-5"
-#    location: "Europe/Paris"
-#    fire_immediately: true
-
-
 
 jobs:
-
 - name: this-is-an-empty-pipeline
 
 


### PR DESCRIPTION
Adds CF info (Api url, org, space, user and password) to post-bosh-deploy
(this is the real name, not the logical one...). Switches to new concourse
pipeline variable declaration (ie ((xx)) instead of  {{xx}})