### PR TITLE
Update terraform dev env to enable use of docker images used by COA

### DIFF
--- a/scripts/setUpTfDevEnv.sh
+++ b/scripts/setUpTfDevEnv.sh
@@ -4,18 +4,19 @@
 # - Easy local execution allowing direct edition of files in git repos, and their terraform execution in IDE and local.
 #   As currently merging of paas-template and paas-secret specs is done by concourse scripts
 # Pbs with pure local execution approach
-# - may slightly differ from concourse execution (poetential mismatch in number & version of providers)
+# - may slightly differ from concourse execution (potential mismatch in number & version of providers)
 
 function setUpDevEnv {
     DEV_ENV=$1
     SECRET_REPO=$2
     DEPLOYMENT_PATH=$3
 
-    cd $WORKDIR
+    cd ${WORKDIR}
 
     mkdir -p $DEV_ENV
     cd $DEV_ENV
-    echo "preparing dev env into $(pwd)"
+    echo "Prerequisite: have a local copy of paas-template, paas-secret and cf-ops-automation (only for fly interactions)"
+    echo "Preparing dev env into $(pwd)"
 
     # Set up git so that we can version our local dev env changes
     if [ ! -d ".git" ]; then
@@ -38,31 +39,34 @@ function setUpDevEnv {
     mkdir -p generated-files
     mkdir -p spec-applied
     # Skipping secret resource not used by terraform
-    #ln -nf ${WORKDIR}/${SECRET_REPO} secret-state-resource
-    cd generated-files/
+    #ln -nf "${WORKDIR}/${SECRET_REPO}" secret-state-resource
 
+    cd generated-files/
     echo "setting up $(pwd) with hardlinks"
 
-    ln -nfv  ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/terraform.tfstate terraform.tfstate
+    ln -nfv  "${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/terraform.tfstate" terraform.tfstate
+    TEMPLATE_FILES=$(find "${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec" -type f )
+    SECRET_FILES=$(find "${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec"  -type f )
 
-
-    TEMPLATE_FILES=$(find ${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec -type f )
-    SECRET_FILES=$(find ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec  -type f )
     cd ../spec-applied/
     echo "setting up $(pwd) with hardlinks"
 
-
     #set -x
-    for f in $TEMPLATE_FILES; do createLink $f ${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec; done
-    for f in $SECRET_FILES;   do createLink $f ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec; done
+    for f in $TEMPLATE_FILES; do createLink "$f" "${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec"; done
+    for f in $SECRET_FILES;   do createLink "$f" "${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec"; done
     #set +x
 
-    echo "Result of set up is:"
-    tree ${WORKDIR}/${DEV_ENV}
+    printf "\n Local dev env set up in ${WORKDIR}/${DEV_ENV}, ready to edit tf files there using your favorite IDE with TF HCL syntax support:\n"
+    tree --noreport "${WORKDIR}/${DEV_ENV}"
 
-    echo
-    echo "DEV_ENV=${DEV_ENV}"
-    echo "$MSG2"
+    # You may still have to manually fetch generated terraform.tfvars.json using fly hijack
+    # and save it into ${WORKDIR}/${DEV_ENV}/generated-files/terraform.tfvars.json (beware of removing linefeeds)
+    # An alternative is to ask concourse to run the generate-manifest.yml tasks through fly execute (see below)
+
+    setup_fly_and_printout_cmds
+
+    display_docker_tf_commands
+    display_local_tf_commands
 }
 
 
@@ -73,12 +77,142 @@ function createLink() {
     absolute_path=$1
     relative_to_dir=$2
 
-    relative_path=$(realpath --relative-to=${relative_to_dir} ${absolute_path})
+    relative_path=$(realpath "--relative-to=${relative_to_dir}" "${absolute_path}")
 
-    mkdir -p $(dirname $relative_path)
-    ln -nfv $f $relative_path;
+    mkdir -p $(dirname "${relative_path}")
+    ln -nfv "$f" "${relative_path}";
 }
 
+
+
+function display_local_tf_commands() {
+    printf "\nYou may now then use TF locally with:"
+    echo "DEV_ENV=${DEV_ENV}"
+
+
+    echo "cd ${WORKDIR}/${DEV_ENV}/generated-files"
+    echo 'bash -c "\$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"'
+    echo "terraform init -input=false -upgrade -get-plugins=false -plugin-dir=/.terraform/plugins/linux_amd64 ../spec-applied/"
+    echo "terraform plan -input=false ../spec-applied/"
+}
+
+function display_docker_tf_commands() {
+
+    printf "\nYou may use the docker image with providers configured:\n"
+
+    #echo "# Check current version of image into cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml"
+    #echo "TF_DOCKER_TAG=ad445d6b34dffeadb3c2b26a40dd71de73ec0686"
+    export TF_DOCKER_TAG=latest
+    #echo "docker pull orangecloudfoundry/terraform:${TF_DOCKER_TAG}"
+
+    echo "docker run     -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} terraform init -input=false -upgrade -get-plugins=false -plugin-dir=/.terraform/plugins/linux_amd64 ../spec-applied/"
+    echo "docker run     -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} terraform plan -input=false ../spec-applied/"
+    echo "# debug if needed using shell"
+    echo "docker run -it -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} /bin/ash"
+    echo "docker run     -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} terraform apply -input=false -auto-approve ../spec-applied/"
+
+}
+
+
+# An alternative is to ask concourse to run the generate-manifest.yml and terraform_plan_cloudfoundry.yml tasks through fly execute,
+# using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
+# This would be slower than fully local development but enables testing in conditions closer to production without requiring git push delays.
+
+function setup_fly_and_printout_cmds() {
+
+    printf "\nYou may still have to fetch generated terraform.tfvars.json. Below are steps to ask concourse to do so with local copies of your paas-template and paas-secret repos.\n\n"
+    echo "The following fly commands can be run within the current shell into which the proper env vars have been defined"
+    # This is how to ask concourse to run the generate-manifest.yml tasks through fly execute (see below)
+    # using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
+
+    #Concourse task invocation extract from concourse/pipelines/template/depls-pipeline.yml.erb:
+    #
+    #    - task: generate-terraform-tfvars
+    #      input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-<%= depls %>, additional-resource: paas-template-<%=depls %>}
+    #      output_mapping: {generated-files: terraform-tfvars}
+    #      file: cf-ops-automation/concourse/tasks/generate-manifest.yml
+    #      params:
+    #        YML_FILES: |
+    #          ./credentials-resource/shared/secrets.yml
+    #          ./credentials-resource/<%= terraform_config_path %>/secrets/meta.yml
+    #          ./credentials-resource/<%= terraform_config_path %>/secrets/secrets.yml
+    #        YML_TEMPLATE_DIR: additional-resource/<%= terraform_config_path %>/template
+    #        CUSTOM_SCRIPT_DIR: additional-resource/<%= terraform_config_path %>/template
+    #        SUFFIX: -tpl.tfvars.yml
+    #        IAAS_TYPE: ((iaas-type))
+
+
+    # Corresponding fly execute command (still missing some args)
+
+    DEPLOYMENT_PATH=ops-depls/cloudfoundry/terraform-config
+    SECRET_REPO=int-secrets
+
+
+    export IAAS_TYPE='openstack'
+    export CUSTOM_SCRIPT_DIR=additional-resource/${DEPLOYMENT_PATH}/template
+    export  YML_TEMPLATE_DIR=additional-resource/${DEPLOYMENT_PATH}/template
+    #export SPRUCE_FILE_BASE_PATH=
+    export YML_FILES="./credentials-resource/shared/secrets.yml"
+    export SUFFIX="-tpl.tfvars.yml"
+
+    echo "---- Fly cmd for the tf vars generation (should take close to 3 mins)---"
+    echo fly -t int.micro execute \
+            -c ${WORKDIR}/cf-ops-automation/concourse/tasks/generate-manifest.yml  \
+            -i scripts-resource=${WORKDIR}/cf-ops-automation  \
+            -i credentials-resource=${WORKDIR}/${SECRET_REPO}  \
+            -i additional-resource=${WORKDIR}/paas-template \
+            -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files
+
+    printf "\nYou may also ask concourse to execute the tf plan/apply using your local spec files:\n"
+    echo "--- Fly cmd for the TF plan ---"
+
+    #    - task: terraform-plan
+    #      input_mapping: {secret-state-resource: secrets-<%= depls %>,spec-resource: paas-template-<%=depls %>}
+    #      file: cf-ops-automation/concourse/tasks/terraform_plan_cloudfoundry.yml
+    #      params:
+    #        SPEC_PATH: "<%= terraform_config_path %>/spec"
+    #        SECRET_STATE_FILE_PATH: "<%= terraform_config_path %>"
+    #        IAAS_SPEC_PATH: "<%= terraform_config_path %>/spec-((iaas-type))"
+    #
+
+    export SPEC_PATH=${DEPLOYMENT_PATH}/spec
+    export SECRET_STATE_FILE_PATH=${DEPLOYMENT_PATH}
+    export IAAS_SPEC_PATH=${DEPLOYMENT_PATH}/spec-${IAAS_TYPE}
+
+    mkdir -p ${WORKDIR}/${DEV_ENV}/tf-plan-generated-files
+    mkdir -p ${WORKDIR}/${DEV_ENV}/tf-plan-spec-applied
+
+    echo fly -t int.micro execute \
+            -c ${WORKDIR}/cf-ops-automation/concourse/tasks/terraform_plan_cloudfoundry.yml  \
+            -i secret-state-resource=${WORKDIR}/${SECRET_REPO} \
+            -i spec-resource=${WORKDIR}/paas-template \
+            -i terraform-tfvars=${WORKDIR}/${DEV_ENV}/generated-files \
+            -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files \
+            -o spec-applied=${WORKDIR}/${DEV_ENV}/spec-applied
+
+    echo
+    echo "Note: this may override your paas-template and paas-secret files. To avoid this, don't use the hardlinks set up"
+    echo "rm -rfi ${WORKDIR}/${DEV_ENV}/generated-files ${WORKDIR}/${DEV_ENV}/spec-applied"
+
+    echo "--- Fly cmd for the TF apply ---"
+
+    #    - task: terraform-apply
+    #      input_mapping: {secret-state-resource: secrets-<%= depls %>,spec-resource: paas-template-<%=depls %>}
+    #      output_mapping: {generated-files: terraform-cf}
+    #      file: cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml
+    #      params:
+    #        SPEC_PATH: "<%= terraform_config_path %>/spec"
+    #        SECRET_STATE_FILE_PATH: "<%= terraform_config_path %>"
+    #        IAAS_SPEC_PATH: "<%= terraform_config_path %>/spec-((iaas-type))"
+
+    echo fly -t int.micro execute \
+        -c ${WORKDIR}/cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml  \
+        -i secret-state-resource=${WORKDIR}/${SECRET_REPO} \
+        -i spec-resource=${WORKDIR}/paas-template \
+        -i terraform-tfvars=${WORKDIR}/${DEV_ENV}/generated-files \
+        -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files \
+        -o spec-applied=${WORKDIR}/${DEV_ENV}/spec-applied
+}
 
 #Intellij fails to recognize heredoc within functions
 #As a workaround, define them within variables using this trick
@@ -86,7 +220,7 @@ function createLink() {
 
 MSG1=$(cat << 'EOF1'
 
-you may proceed with setting up your env with the following commands:
+you may proceed with setting up your env with the following commands, eg. for Guillaume's env:
 WORKDIR=/home/guillaume/code/workspaceElPaasov14
 
 setUpDevEnv terraform-prod-micro-deps-env    bosh-cloudwatt-secrets          micro-depls/terraform-config
@@ -97,76 +231,5 @@ setUpDevEnv terraform-prod-ops-deps-env      bosh-cloudwatt-secrets          ops
 setUpDevEnv terraform-int-ops-deps-env       int-secrets                     ops-depls/cloudfoundry/terraform-config
 EOF1
 )
-
-MSG2=$(cat << 'EOF2'
-# TODO: You may still have to manually fetch generated terraform.tfvars.json using fly hijack
-# and save it into ${WORKDIR}/${DEV_ENV}/generated-files/terraform.tfvars.json (beware of removing linefeeds)
-# An alternative is to ask concourse to run the generate-manifest.yml tasks through fly execute (see below)
-
-# You may now then use TF locally with:
-
-cd ${WORKDIR}/${DEV_ENV}/generated-files
-bash -c "\$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
-terraform init -input=false -upgrade -get-plugins=false -plugin-dir=/.terraform/plugins/linux_amd64 ../spec-applied/
-terraform plan -input=false ../spec-applied/
-
-# or using the docker image with providers configured
-
-# Check current version of image into cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml
-TF_DOCKER_TAG=ad445d6b34dffeadb3c2b26a40dd71de73ec0686
-docker pull orangecloudfoundry/terraform:${TF_DOCKER_TAG}
-
-docker run     -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} terraform init -input=false -upgrade -get-plugins=false -plugin-dir=/.terraform/plugins/linux_amd64 ../spec-applied/
-docker run     -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} terraform plan -input=false ../spec-applied/
-# debug if needed using shell
-docker run -it -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} /bin/ash
-EOF2
-)
-
-# An alternative is to ask concourse to run the generate-manifest.yml and terraform_plan_cloudfoundry.yml tasks through fly execute,
-# using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
-# This would be slower than fully local development but enables testing in conditions closer to production without requiring git push delays.
-
-
-MSG3=$(cat << 'EOF3'
-# Asking concourse to run the generate-manifest.yml tasks through fly execute (see below)
-# using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
-
-#Concourse task invocation extract from concourse/pipelines/template/depls-pipeline.yml.erb:
-
-    - task: generate-terraform-tfvars
-      input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-<%= depls %>, additional-resource: paas-template-<%=depls %>}
-      output_mapping: {generated-files: terraform-tfvars}
-      file: cf-ops-automation/concourse/tasks/generate-manifest.yml
-      params:
-        YML_FILES: |
-          ./credentials-resource/shared/secrets.yml
-          ./credentials-resource/<%= terraform_config_path %>/secrets/meta.yml
-          ./credentials-resource/<%= terraform_config_path %>/secrets/secrets.yml
-        YML_TEMPLATE_DIR: additional-resource/<%= terraform_config_path %>/template
-        CUSTOM_SCRIPT_DIR: additional-resource/<%= terraform_config_path %>/template
-        SUFFIX: -tpl.tfvars.yml
-        IAAS_TYPE: ((iaas-type))
-
-# Corresponding fly execute command (still missing some args)
-
-fly -t micro execute \
-        -c concourse/tasks/generate-manifest.yml  \
-        -i scripts-resource=${WORKDIR}/cf-ops-automation  \
-        -i credentials-resource=${SECRET_REPO}  \
-        -i additional-resource=${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec \
-        -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files
-
-        -i IAAS_TYPE='openstack'
-        -i CUSTOM_SCRIPT_DIR=
-        -i YML_TEMPLATE_DIR=
-        -i SPRUCE_FILE_BASE_PATH=
-        -i YML_FILES=
-        -i SUFFIX=
-EOF3
-)
-
-
-
 
 echo "$MSG1"

--- a/scripts/setUpTfDevEnv.sh
+++ b/scripts/setUpTfDevEnv.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# tune shell check rules: SC2164 https://github.com/koalaman/shellcheck/wiki/SC2164
+# shellcheck disable=SC2164
+
 # Goals:
 # - Easy local execution allowing direct edition of files in git repos, and their terraform execution in IDE and local.
 #   As currently merging of paas-template and paas-secret specs is done by concourse scripts
@@ -11,10 +14,11 @@ function setUpDevEnv {
     SECRET_REPO=$2
     DEPLOYMENT_PATH=$3
 
-    cd ${WORKDIR}
+    cd "${WORKDIR}"
 
-    mkdir -p $DEV_ENV
-    cd $DEV_ENV
+    mkdir -p "${DEV_ENV}"
+    cd "${DEV_ENV}"
+
     echo "Prerequisite: have a local copy of paas-template, paas-secret and cf-ops-automation (only for fly interactions)"
     echo "Preparing dev env into $(pwd)"
 
@@ -157,11 +161,11 @@ function setup_fly_and_printout_cmds() {
 
     echo "---- Fly cmd for the tf vars generation (should take close to 3 mins)---"
     echo fly -t int.micro execute \
-            -c ${WORKDIR}/cf-ops-automation/concourse/tasks/generate-manifest.yml  \
-            -i scripts-resource=${WORKDIR}/cf-ops-automation  \
-            -i credentials-resource=${WORKDIR}/${SECRET_REPO}  \
-            -i additional-resource=${WORKDIR}/paas-template \
-            -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files
+            -c "${WORKDIR}/cf-ops-automation/concourse/tasks/generate-manifest.yml"  \
+            -i "scripts-resource=${WORKDIR}/cf-ops-automation"  \
+            -i "credentials-resource=${WORKDIR}/${SECRET_REPO}"  \
+            -i "additional-resource=${WORKDIR}/paas-template" \
+            -o "generated-files=${WORKDIR}/${DEV_ENV}/generated-files"
 
     printf "\nYou may also ask concourse to execute the tf plan/apply using your local spec files:\n"
     echo "--- Fly cmd for the TF plan ---"
@@ -183,12 +187,12 @@ function setup_fly_and_printout_cmds() {
     mkdir -p ${WORKDIR}/${DEV_ENV}/tf-plan-spec-applied
 
     echo fly -t int.micro execute \
-            -c ${WORKDIR}/cf-ops-automation/concourse/tasks/terraform_plan_cloudfoundry.yml  \
-            -i secret-state-resource=${WORKDIR}/${SECRET_REPO} \
-            -i spec-resource=${WORKDIR}/paas-template \
-            -i terraform-tfvars=${WORKDIR}/${DEV_ENV}/generated-files \
-            -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files \
-            -o spec-applied=${WORKDIR}/${DEV_ENV}/spec-applied
+            -c "${WORKDIR}/cf-ops-automation/concourse/tasks/terraform_plan_cloudfoundry.yml" \
+            -i "secret-state-resource=${WORKDIR}/${SECRET_REPO}" \
+            -i "spec-resource=${WORKDIR}/paas-template" \
+            -i "terraform-tfvars=${WORKDIR}/${DEV_ENV}/generated-files" \
+            -o "generated-files=${WORKDIR}/${DEV_ENV}/generated-files" \
+            -o "spec-applied=${WORKDIR}/${DEV_ENV}/spec-applied"
 
     echo
     echo "Note: this may override your paas-template and paas-secret files. To avoid this, don't use the hardlinks set up"
@@ -206,12 +210,12 @@ function setup_fly_and_printout_cmds() {
     #        IAAS_SPEC_PATH: "<%= terraform_config_path %>/spec-((iaas-type))"
 
     echo fly -t int.micro execute \
-        -c ${WORKDIR}/cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml  \
-        -i secret-state-resource=${WORKDIR}/${SECRET_REPO} \
-        -i spec-resource=${WORKDIR}/paas-template \
-        -i terraform-tfvars=${WORKDIR}/${DEV_ENV}/generated-files \
-        -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files \
-        -o spec-applied=${WORKDIR}/${DEV_ENV}/spec-applied
+        -c "${WORKDIR}/cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml" \
+        -i "secret-state-resource=${WORKDIR}/${SECRET_REPO}" \
+        -i "spec-resource=${WORKDIR}/paas-template" \
+        -i "terraform-tfvars=${WORKDIR}/${DEV_ENV}/generated-files" \
+        -o "generated-files=${WORKDIR}/${DEV_ENV}/generated-files" \
+        -o "spec-applied=${WORKDIR}/${DEV_ENV}/spec-applied"
 }
 
 #Intellij fails to recognize heredoc within functions

--- a/scripts/setUpTfDevEnv.sh
+++ b/scripts/setUpTfDevEnv.sh
@@ -9,10 +9,21 @@
 # Pbs with pure local execution approach
 # - may slightly differ from concourse execution (potential mismatch in number & version of providers)
 
+
 function setUpDevEnv {
     DEV_ENV=$1
     SECRET_REPO=$2
     DEPLOYMENT_PATH=$3
+
+    #Avoid intellij warnings about undefined variable that users should set
+    WORKDIR=${WORKDIR}
+
+    if ! [ -d "${WORKDIR}" ]
+    then
+        echo "Missing WORKDIR env file pointing to the dir where your git clones are"
+        return
+    fi
+
 
     cd "${WORKDIR}"
 
@@ -60,7 +71,8 @@ function setUpDevEnv {
     for f in $SECRET_FILES;   do createLink "$f" "${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec"; done
     #set +x
 
-    printf "\n Local dev env set up in ${WORKDIR}/${DEV_ENV}, ready to edit tf files there using your favorite IDE with TF HCL syntax support:\n"
+    echo
+    echo "Local dev env set up in ${WORKDIR}/${DEV_ENV}, ready to edit tf files there using your favorite IDE with TF HCL syntax support:"
     tree --noreport "${WORKDIR}/${DEV_ENV}"
 
     # You may still have to manually fetch generated terraform.tfvars.json using fly hijack
@@ -83,14 +95,14 @@ function createLink() {
 
     relative_path=$(realpath "--relative-to=${relative_to_dir}" "${absolute_path}")
 
-    mkdir -p $(dirname "${relative_path}")
+    mkdir -p "$(dirname "${relative_path}")"
     ln -nfv "$f" "${relative_path}";
 }
 
 
 
 function display_local_tf_commands() {
-    printf "\nYou may now then use TF locally with:"
+    echo "You may now then use TF locally with:"
     echo "DEV_ENV=${DEV_ENV}"
 
 
@@ -102,7 +114,8 @@ function display_local_tf_commands() {
 
 function display_docker_tf_commands() {
 
-    printf "\nYou may use the docker image with providers configured:\n"
+    echo
+    echo "You may use the docker image with providers configured:"
 
     #echo "# Check current version of image into cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml"
     #echo "TF_DOCKER_TAG=ad445d6b34dffeadb3c2b26a40dd71de73ec0686"
@@ -124,7 +137,8 @@ function display_docker_tf_commands() {
 
 function setup_fly_and_printout_cmds() {
 
-    printf "\nYou may still have to fetch generated terraform.tfvars.json. Below are steps to ask concourse to do so with local copies of your paas-template and paas-secret repos.\n\n"
+    echo "You may still have to fetch generated terraform.tfvars.json. Below are steps to ask concourse to do so with local copies of your paas-template and paas-secret repos."
+    echo
     echo "The following fly commands can be run within the current shell into which the proper env vars have been defined"
     # This is how to ask concourse to run the generate-manifest.yml tasks through fly execute (see below)
     # using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
@@ -167,7 +181,8 @@ function setup_fly_and_printout_cmds() {
             -i "additional-resource=${WORKDIR}/paas-template" \
             -o "generated-files=${WORKDIR}/${DEV_ENV}/generated-files"
 
-    printf "\nYou may also ask concourse to execute the tf plan/apply using your local spec files:\n"
+    echo
+    echo "You may also ask concourse to execute the tf plan/apply using your local spec files:"
     echo "--- Fly cmd for the TF plan ---"
 
     #    - task: terraform-plan

--- a/scripts/setUpTfDevEnv.sh
+++ b/scripts/setUpTfDevEnv.sh
@@ -103,11 +103,8 @@ function createLink() {
 
 function display_local_tf_commands() {
     echo "You may now then use TF locally with:"
-    echo "DEV_ENV=${DEV_ENV}"
-
-
     echo "cd ${WORKDIR}/${DEV_ENV}/generated-files"
-    echo 'bash -c "\$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"'
+    echo '#install providers locally, then'
     echo "terraform init -input=false -upgrade -get-plugins=false -plugin-dir=/.terraform/plugins/linux_amd64 ../spec-applied/"
     echo "terraform plan -input=false ../spec-applied/"
 }
@@ -198,8 +195,8 @@ function setup_fly_and_printout_cmds() {
     export SECRET_STATE_FILE_PATH=${DEPLOYMENT_PATH}
     export IAAS_SPEC_PATH=${DEPLOYMENT_PATH}/spec-${IAAS_TYPE}
 
-    mkdir -p ${WORKDIR}/${DEV_ENV}/tf-plan-generated-files
-    mkdir -p ${WORKDIR}/${DEV_ENV}/tf-plan-spec-applied
+    mkdir -p "${WORKDIR}/${DEV_ENV}/tf-plan-generated-files"
+    mkdir -p "${WORKDIR}/${DEV_ENV}/tf-plan-spec-applied"
 
     echo fly -t int.micro execute \
             -c "${WORKDIR}/cf-ops-automation/concourse/tasks/terraform_plan_cloudfoundry.yml" \

--- a/scripts/setUpTfDevEnv.sh
+++ b/scripts/setUpTfDevEnv.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Goals:
+# - Easy local execution allowing direct edition of files in git repos, and their terraform execution in IDE and local.
+#   As currently merging of paas-template and paas-secret specs is done by concourse scripts
+# Pbs with pure local execution approach
+# - may slightly differ from concourse execution (poetential mismatch in number & version of providers)
+
 function setUpDevEnv {
     DEV_ENV=$1
     SECRET_REPO=$2
@@ -31,30 +37,54 @@ function setUpDevEnv {
 
     mkdir -p generated-files
     mkdir -p spec-applied
-    ln -snf ${WORKDIR}/${SECRET_REPO} secret-state-resource
+    # Skipping secret resource not used by terraform
+    #ln -nf ${WORKDIR}/${SECRET_REPO} secret-state-resource
     cd generated-files/
 
-    echo "setting up $(pwd)"
+    echo "setting up $(pwd) with hardlinks"
 
-    ln -snfv  ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/terraform.tfstate terraform.tfstate
-
-    #TODO: Manually fetch terraform.tfvars.json vi terraform.tfvars.json
-    # An alternative is to ask concourse to run the generate-manifest.yml tasks through fly execute,
-    # using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
+    ln -nfv  ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/terraform.tfstate terraform.tfstate
 
 
-    TEMPLATE_FILES=$(find ${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec -mindepth 1 -maxdepth 1 )
-    SECRET_FILES=$(find ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec  -mindepth 1 -maxdepth 1 )
+    TEMPLATE_FILES=$(find ${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec -type f )
+    SECRET_FILES=$(find ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec  -type f )
     cd ../spec-applied/
-    echo "setting up $(pwd)"
-
-    for f in $TEMPLATE_FILES; do name=$(basename $f); ln -nsfv $f $name ; done;
-    for f in $SECRET_FILES; do name=$(basename $f); ln -nsfv $f $name ; done;
+    echo "setting up $(pwd) with hardlinks"
 
 
+    #set -x
+    for f in $TEMPLATE_FILES; do createLink $f ${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec; done
+    for f in $SECRET_FILES;   do createLink $f ${WORKDIR}/${SECRET_REPO}/${DEPLOYMENT_PATH}/spec; done
+    #set +x
+
+    echo "Result of set up is:"
+    tree ${WORKDIR}/${DEV_ENV}
+
+    echo
+    echo "DEV_ENV=${DEV_ENV}"
+    echo "$MSG2"
 }
 
-cat << EOF
+
+
+
+# Creates hard link. Since hardlinks don't support directories, we create an emty directory tree first
+function createLink() {
+    absolute_path=$1
+    relative_to_dir=$2
+
+    relative_path=$(realpath --relative-to=${relative_to_dir} ${absolute_path})
+
+    mkdir -p $(dirname $relative_path)
+    ln -nfv $f $relative_path;
+}
+
+
+#Intellij fails to recognize heredoc within functions
+#As a workaround, define them within variables using this trick
+# https://stackoverflow.com/questions/1167746/how-to-assign-a-heredoc-value-to-a-variable-in-bash
+
+MSG1=$(cat << 'EOF1'
 
 you may proceed with setting up your env with the following commands:
 WORKDIR=/home/guillaume/code/workspaceElPaasov14
@@ -64,15 +94,79 @@ setUpDevEnv terraform-preprod-micro-deps-env bosh-cloudwatt-preprod-secrets  mic
 setUpDevEnv terraform-preprod-env            bosh-cloudwatt-preprod-secrets  ops-depls/cloudfoundry/terraform-config
 setUpDevEnv terraform-preprod-ops-deps-env   bosh-cloudwatt-preprod-secrets  ops-depls/cloudfoundry/terraform-config
 setUpDevEnv terraform-prod-ops-deps-env      bosh-cloudwatt-secrets          ops-depls/cloudfoundry/terraform-config
+setUpDevEnv terraform-int-ops-deps-env       int-secrets                     ops-depls/cloudfoundry/terraform-config
+EOF1
+)
+
+MSG2=$(cat << 'EOF2'
+# TODO: You may still have to manually fetch generated terraform.tfvars.json using fly hijack
+# and save it into ${WORKDIR}/${DEV_ENV}/generated-files/terraform.tfvars.json (beware of removing linefeeds)
+# An alternative is to ask concourse to run the generate-manifest.yml tasks through fly execute (see below)
 
 # You may now then use TF locally with:
 
-cd \${WORKDIR}/terraform-preprod-env/generated-files
+cd ${WORKDIR}/${DEV_ENV}/generated-files
 bash -c "\$(curl -fsSL https://raw.github.com/orange-cloudfoundry/terraform-provider-cloudfoundry/master/bin/install.sh)"
 terraform init -input=false -upgrade -get-plugins=false -plugin-dir=/.terraform/plugins/linux_amd64 ../spec-applied/
 terraform plan -input=false ../spec-applied/
-EOF
+
+# or using the docker image with providers configured
+
+# Check current version of image into cf-ops-automation/concourse/tasks/terraform_apply_cloudfoundry.yml
+TF_DOCKER_TAG=ad445d6b34dffeadb3c2b26a40dd71de73ec0686
+docker pull orangecloudfoundry/terraform:${TF_DOCKER_TAG}
+
+docker run     -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} terraform init -input=false -upgrade -get-plugins=false -plugin-dir=/.terraform/plugins/linux_amd64 ../spec-applied/
+docker run     -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} terraform plan -input=false ../spec-applied/
+# debug if needed using shell
+docker run -it -v ${WORKDIR}/${DEV_ENV}:/mnt/workdir -w /mnt/workdir/generated-files orangecloudfoundry/terraform:${TF_DOCKER_TAG} /bin/ash
+EOF2
+)
 
 # An alternative is to ask concourse to run the generate-manifest.yml and terraform_plan_cloudfoundry.yml tasks through fly execute,
 # using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
 # This would be slower than fully local development but enables testing in conditions closer to production without requiring git push delays.
+
+
+MSG3=$(cat << 'EOF3'
+# Asking concourse to run the generate-manifest.yml tasks through fly execute (see below)
+# using local version of these tasks (from cf-ops-automation) and local copies of paas-template and paas-secret
+
+#Concourse task invocation extract from concourse/pipelines/template/depls-pipeline.yml.erb:
+
+    - task: generate-terraform-tfvars
+      input_mapping: {scripts-resource: cf-ops-automation, credentials-resource: secrets-<%= depls %>, additional-resource: paas-template-<%=depls %>}
+      output_mapping: {generated-files: terraform-tfvars}
+      file: cf-ops-automation/concourse/tasks/generate-manifest.yml
+      params:
+        YML_FILES: |
+          ./credentials-resource/shared/secrets.yml
+          ./credentials-resource/<%= terraform_config_path %>/secrets/meta.yml
+          ./credentials-resource/<%= terraform_config_path %>/secrets/secrets.yml
+        YML_TEMPLATE_DIR: additional-resource/<%= terraform_config_path %>/template
+        CUSTOM_SCRIPT_DIR: additional-resource/<%= terraform_config_path %>/template
+        SUFFIX: -tpl.tfvars.yml
+        IAAS_TYPE: ((iaas-type))
+
+# Corresponding fly execute command (still missing some args)
+
+fly -t micro execute \
+        -c concourse/tasks/generate-manifest.yml  \
+        -i scripts-resource=${WORKDIR}/cf-ops-automation  \
+        -i credentials-resource=${SECRET_REPO}  \
+        -i additional-resource=${WORKDIR}/paas-template/${DEPLOYMENT_PATH}/spec \
+        -o generated-files=${WORKDIR}/${DEV_ENV}/generated-files
+
+        -i IAAS_TYPE='openstack'
+        -i CUSTOM_SCRIPT_DIR=
+        -i YML_TEMPLATE_DIR=
+        -i SPRUCE_FILE_BASE_PATH=
+        -i YML_FILES=
+        -i SUFFIX=
+EOF3
+)
+
+
+
+
+echo "$MSG1"


### PR DESCRIPTION
The local dirs that replicate some concourse preprocessing are now done
using hardlinks instead of softlink as docker volumes don't follow
softlinks.

Also illustrated more clearly how to fetch the terraform.tfvars.yml and
draft skeleton to have concourse generate it on the fly.