### PR TITLE
task(terraform_*): bump providers (openstack, grafana, credhub and helm)

### DIFF
--- a/concourse/tasks/terraform_apply_cloudfoundry.yml
+++ b/concourse/tasks/terraform_apply_cloudfoundry.yml
@@ -16,7 +16,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: orangecloudfoundry/terraform, tag: ad445d6b34dffeadb3c2b26a40dd71de73ec0686}
+  source: {repository: orangecloudfoundry/terraform, tag: 74907a778ebecbd9e5d3ff27e210522bffad7047}
 
 inputs:
   - name: secret-state-resource

--- a/concourse/tasks/terraform_plan_cloudfoundry.yml
+++ b/concourse/tasks/terraform_plan_cloudfoundry.yml
@@ -16,7 +16,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: orangecloudfoundry/terraform, tag: ad445d6b34dffeadb3c2b26a40dd71de73ec0686}
+  source: {repository: orangecloudfoundry/terraform, tag: 74907a778ebecbd9e5d3ff27e210522bffad7047}
 
 inputs:
   - name: secret-state-resource

--- a/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
+++ b/spec/tasks/terraform_plan_cloudfoundry/task_spec.rb
@@ -3,7 +3,7 @@ require 'yaml'
 require 'tmpdir'
 
 describe 'terraform_plan_cloudfoundry task' do
-  EXPECTED_TERRAFORM_IMAGE_TAG = 'ad445d6b34dffeadb3c2b26a40dd71de73ec0686'.freeze
+  EXPECTED_TERRAFORM_IMAGE_TAG = '74907a778ebecbd9e5d3ff27e210522bffad7047'.freeze
   EXPECTED_TERRAFORM_VERSION = '0.11.7'.freeze
   EXPECTED_PROVIDER_CLOUDFOUNDRY_VERSION = 'v0.9.1'.freeze
   SKIP_TMP_FILE_CLEANUP = false


### PR DESCRIPTION
See [paas-docker-cloudfoundry-tools@74907a778ebecbd9e5d3ff27e210522bffad7047](https://github.com/orange-cloudfoundry/paas-docker-cloudfoundry-tools/commit/74907a778ebecbd9e5d3ff27e210522bffad7047)