### PR TITLE
Add task displaying manifest before it gets deployed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,4 +28,4 @@ Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
 Layout/DotPosition:
-  Enable: false
+  Enabled: false

--- a/concourse/pipelines/template/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/template/concourse-pipeline.yml.erb
@@ -126,7 +126,11 @@ jobs:
       SECRETS_DIR: credentials-resource/<%= depls %>/<%= name %>
       MANIFEST_NAME: <%= name %>.yml
   - task: bosh-interpolate-pipeline-with-ops-and-vars-files
-    input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-<%= name %>}
+    input_mapping:
+      bosh-inputs: bosh-inputs
+      manifest-dir: bosh-inputs
+      scripts-resource: cf-ops-automation
+      secrets: secrets-<%= name %>
     output_mapping: {result-dir: final-<%= name %>-pipeline}
     file: cf-ops-automation/concourse/tasks/bosh_interpolate/task.yml
     params:

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -615,6 +615,19 @@ jobs:
           echo '---' > result-dir/operators/0-empty-operators.yml
           echo '---' > result-dir/vars/0-empty-vars.yml
   <% end %>
+  <% if boshrelease['cli_version'] != 'v1' %>
+  - task: display-<%= name %>-manifest
+    input_mapping:
+      bosh-inputs: ops-and-vars-files
+      manifest-dir: final-release-manifest
+      secrets: secrets<%= name %>
+      scripts-resource: cf-ops-automation}
+    file: cf-ops-automation/concourse/tasks/bosh_interpolate/task.yml
+    params:
+       VARS_FILES_SUFFIX: "*/*vars.yml"
+       OPS_FILES_SUFFIX:  "*/*operators.yml"
+       BOSH_YAML_FILE: <%= name %>.yml
+  <% end %>
   - put: <%= name %>-deployment
     attempts: 2
     params:

--- a/concourse/tasks/bosh_interpolate/run.sh
+++ b/concourse/tasks/bosh_interpolate/run.sh
@@ -35,4 +35,7 @@ echo "Operators detected: <${OPS_FILES}>"
 echo "Vars files detected: <${VARS_FILES}>"
 
 INTERPOLATED_FILE="interpolated-${BOSH_YAML_FILE}"
-bosh -n int ${VARS_FILES} ${OPS_FILES} bosh-inputs/${BOSH_YAML_FILE} > result-dir/${INTERPOLATED_FILE}
+bosh -n int ${VARS_FILES} ${OPS_FILES} "manifest-dir/${BOSH_YAML_FILE}" > "result-dir/${INTERPOLATED_FILE}"
+
+echo "Generated manifest:"
+cat "result-dir/${INTERPOLATED_FILE}"

--- a/concourse/tasks/bosh_interpolate/task.yml
+++ b/concourse/tasks/bosh_interpolate/task.yml
@@ -20,6 +20,7 @@ image_resource:
     tag: 4aff7d1fd0fa27ff9910a77b39cbcaedb4455f0c
 inputs:
   - name: bosh-inputs
+  - name: manifest-dir
   - name: secrets
   - name: scripts-resource
 outputs:

--- a/docs/reference_dataset/template_repository/hello-world/bosh-sample/nginx/template/adding-ntp-release-operators.yml
+++ b/docs/reference_dataset/template_repository/hello-world/bosh-sample/nginx/template/adding-ntp-release-operators.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /releases/-
-  value: {name: ntp, version: (( ntp_release_version ))}
+  value: {name: ntp, version: ((ntp_release_version))}

--- a/spec/reference_dataset/reference_dataset_spec.rb
+++ b/spec/reference_dataset/reference_dataset_spec.rb
@@ -15,7 +15,7 @@ describe 'reference_dataset' do
 
     # Since the generation happening in the first part of the test is needed
     # to do the validation, we merge this two specs in one
-    it "generate a valid pipeline for each pipeline template with no error message" do
+    it "generates a valid pipeline for each pipeline template with no error message" do
       # 1. generation
       templates_count = Dir["#{ci_path}/concourse/pipelines/template/*.erb"].count
       stdout_str, stderr_str, = Open3.capture3("#{ci_path}/scripts/generate-depls.rb #{options}")

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -278,6 +278,7 @@ jobs:
           BOSH_CLIENT: ((bosh-username))
           BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
+
         ensure:
           task: update-cloud-config
           input_mapping: {reference-resource: secrets-full-writer, generated-resource: config-manifest}
@@ -312,6 +313,7 @@ jobs:
           BOSH_CLIENT: ((bosh-username))
           BOSH_CLIENT_SECRET: ((bosh-password))
           BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
+
         ensure:
           task: update-runtime-config
           input_mapping: {reference-resource: secrets-full-writer, generated-resource: config-manifest}
@@ -334,8 +336,6 @@ jobs:
             params:
               repository: updated-runtime-config
               rebase: true
-
-
 
 - name: deploy-ntp
   serial: true
@@ -451,7 +451,17 @@ jobs:
             find final-release-manifest/ -name "*-vars.yml" -type f -exec cp {} result-dir/vars \;
             echo '---' > result-dir/operators/0-empty-operators.yml
             echo '---' > result-dir/vars/0-empty-vars.yml
-
+    - task: display-ntp-manifest
+      input_mapping:
+        bosh-inputs: ops-and-vars-files
+        manifest-dir: final-release-manifest
+        secrets: secretsntp
+        scripts-resource: cf-ops-automation}
+      file: cf-ops-automation/concourse/tasks/bosh_interpolate/task.yml
+      params:
+        VARS_FILES_SUFFIX: "*/*vars.yml"
+        OPS_FILES_SUFFIX: "*/*operators.yml"
+        BOSH_YAML_FILE: ntp.yml
     - put: ntp-deployment
       attempts: 2
       params:

--- a/spec/scripts/generate-depls/generate_depls_for_depls_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_depls_pipeline_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tmpdir'
 require_relative 'test_helper'
 
 describe 'generate-depls for depls pipeline' do

--- a/spec/tasks/bosh_interpolate/task_spec.rb
+++ b/spec/tasks/bosh_interpolate/task_spec.rb
@@ -1,5 +1,5 @@
-
-# require 'spec_helper.rb'
+require 'spec_helper'
+require 'tmpdir'
 require 'yaml'
 require_relative '../task_spec_helper'
 
@@ -7,6 +7,7 @@ describe 'bosh_interpolate task' do
   context 'when missing required BOSH_YAML_FILE env var' do
     before(:context) do
       @bosh_inputs = Dir.mktmpdir
+      @manifest_dir = Dir.mktmpdir
       @secrets = Dir.mktmpdir
       @result_dir = Dir.mktmpdir
 
@@ -14,6 +15,7 @@ describe 'bosh_interpolate task' do
         '-i scripts-resource=. ' \
         "-i secrets=#{@secrets} " \
         "-i bosh-inputs=#{@bosh_inputs} " \
+        "-i manifest-dir=#{@manifest_dir} " \
         "-o result-dir=#{@result_dir} ")
     end
 
@@ -21,6 +23,7 @@ describe 'bosh_interpolate task' do
       FileUtils.rm_rf @bosh_inputs if File.exist?(@bosh_inputs)
       FileUtils.rm_rf @secrets if File.exist?(@secrets)
       FileUtils.rm_rf @result_dir if File.exist?(@result_dir)
+      FileUtils.rm_rf @manifest_dir if File.exist?(@manifest_dir)
     end
 
     it 'displays an error message' do
@@ -35,6 +38,7 @@ describe 'bosh_interpolate task' do
 
     before(:context) do
       @bosh_inputs = Dir.mktmpdir
+      @manifest_dir = Dir.mktmpdir
       @secrets = Dir.mktmpdir
       @result_dir = Dir.mktmpdir
 
@@ -67,12 +71,13 @@ describe 'bosh_interpolate task' do
 
       File.open(File.join(@bosh_inputs, 'my-custom-vars.yml'), 'w') { |file| file.write(YAML.safe_load(@vars_yaml).to_yaml) }
       File.open(File.join(@bosh_inputs, 'my-custom-operators.yml'), 'w') { |file| file.write(YAML.safe_load(@operator_yaml).to_yaml) }
-      File.open(File.join(@bosh_inputs, 'my_base_yaml_file.yml'), 'w') { |file| file.write(YAML.safe_load(@bosh_yaml).to_yaml) }
+      File.open(File.join(@manifest_dir, 'my_base_yaml_file.yml'), 'w') { |file| file.write(YAML.safe_load(@bosh_yaml).to_yaml) }
 
       @output = execute('-c concourse/tasks/bosh_interpolate/task.yml ' \
             '-i scripts-resource=. ' \
             "-i secrets=#{@secrets} " \
             "-i bosh-inputs=#{@bosh_inputs} " \
+            "-i manifest-dir=#{@manifest_dir} " \
             "-o result-dir=#{@result_dir} ", \
                         'BOSH_YAML_FILE' => 'my_base_yaml_file.yml')
     end
@@ -81,6 +86,7 @@ describe 'bosh_interpolate task' do
       FileUtils.rm_rf @bosh_inputs if File.exist?(@bosh_inputs)
       FileUtils.rm_rf @secrets if File.exist?(@secrets)
       FileUtils.rm_rf @result_dir if File.exist?(@result_dir)
+      FileUtils.rm_rf @manifest_dir if File.exist?(@manifest_dir)
     end
 
     it 'generates a file as result' do


### PR DESCRIPTION
This PR solves the issue #52  by adding a task for BOSH CLI v2 deployments that will display the manifest with all the operators and vars files included.