### PR TITLE
Upgrade script for config repo for upcoming release 2.2.0

### DIFF
--- a/upgrade/v2.2.0/01-upgrade-config.sh
+++ b/upgrade/v2.2.0/01-upgrade-config.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# tune shell check rules: SC2164 https://github.com/koalaman/shellcheck/wiki/SC2164
+# shellcheck disable=SC2038
+# Warning:(12, 5) Shellcheck find: Use -print0/-0 or -exec + to allow for non-alphanumeric filenames. [SC2038]
+
+
+#set -o xtrace # debug mode
+set -o errexit # exit on errors
+
+CONFIG_REPO="$1"
+echo "Migrating config repo clone at ${CONFIG_REPO}"
+
+function need_upgrade() {
+    echo "checking whether upgrade is needed"
+    find "${CONFIG_REPO}" -name "ci-deployment-overview.yml" | xargs grep -n mattermost
+    return $?
+}
+if ! need_upgrade ; then
+    echo "No need to apply upgrade."
+    exit 0
+fi
+
+echo "removing deprecated mattermost certs from ci-deployment overview:"
+find "${CONFIG_REPO}" -name "ci-deployment-overview.yml" | xargs -n 1 sed -i -e '/^.*credentials-mattermost-certs.yml/d'
+
+echo "expecting no more mattermost in following list:"
+set +o errexit # don't exit on grep finding no file
+find "${CONFIG_REPO}" -name "ci-deployment-overview.yml" | xargs grep -n mattermost
+
+echo "please review the changes applied and commit/push"


### PR DESCRIPTION
 w.r.t. mattermost clean up in config repo

Sample idempotent usage:

```
$ ../cf-ops-automation/scripts/upgrade-2-2.0-config.sh ../int-secrets/
Migrating config repo clone at ../int-secrets/
checking whether upgrade is needed
../int-secrets/kubo-depls/ci-deployment-overview.yml:13:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/kubo-depls/ci-deployment-overview.yml:25:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/kubo-depls/ci-deployment-overview.yml:32:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/kubo-depls/ci-deployment-overview.yml:39:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/kubo-depls/ci-deployment-overview.yml:48:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/master-depls/ci-deployment-overview.yml:14:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/master-depls/ci-deployment-overview.yml:26:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/master-depls/ci-deployment-overview.yml:33:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/master-depls/ci-deployment-overview.yml:40:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/master-depls/ci-deployment-overview.yml:49:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/master-depls/ci-deployment-overview.yml:57:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/cloudflare-depls/ci-deployment-overview.yml:18:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/cloudflare-depls/ci-deployment-overview.yml:26:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/ops-depls/ci-deployment-overview.yml:12:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/ops-depls/ci-deployment-overview.yml:23:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/ops-depls/ci-deployment-overview.yml:31:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/ops-depls/ci-deployment-overview.yml:39:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/ops-depls/ci-deployment-overview.yml:47:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/ops-depls/ci-deployment-overview.yml:52:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/ops-depls/ci-deployment-overview.yml:60:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/expe-depls/ci-deployment-overview.yml:11:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/expe-depls/ci-deployment-overview.yml:23:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/expe-depls/ci-deployment-overview.yml:31:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/expe-depls/ci-deployment-overview.yml:38:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/expe-depls/ci-deployment-overview.yml:45:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/expe-depls/ci-deployment-overview.yml:54:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/micro-depls/ci-deployment-overview.yml:13:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/micro-depls/ci-deployment-overview.yml:25:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/micro-depls/ci-deployment-overview.yml:32:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/micro-depls/ci-deployment-overview.yml:38:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/micro-depls/ci-deployment-overview.yml:43:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/micro-depls/ci-deployment-overview.yml:50:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
../int-secrets/micro-depls/ci-deployment-overview.yml:59:        - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
removing deprecated mattermost certs from ci-deployment overview:
expecting no more mattermost in following list:
please review the changes applied and commit/push

$ ../cf-ops-automation/scripts/upgrade-2-2.0-config.sh ../int-secrets/
Migrating config repo clone at ../int-secrets/
checking whether upgrade is needed
No need to apply upgrade.
```

---
name: Upgrade script for config repo for upcoming release 2.2.0
about: Operators should launch this script when upgrading to 2.2.0

---

Changes proposed in this pull-request:
- Upgrade script for config repo for upcoming release 2.2.0
