### PR TITLE
task(git_reset_wip): create a commit after reset

### DIFF
--- a/concourse/tasks/git_reset_wip.yml
+++ b/concourse/tasks/git_reset_wip.yml
@@ -53,6 +53,9 @@ run:
 
     for i in $git_br; do echo ${DISPLAY_SEPARATOR};echo "Processing $i";git merge -m "Merge branch '$i' after WIP reset" origin/$i ;done
 
+    echo "$(date +'%Y-%m-%d-%H-%M-%S')" | tee .last-reset
+    git add .last-reset
+    git commit -m "Add reset timestamp"
 
 params:
     GIT_USER_NAME: "Orange Cloud Foundry SKC CI Server"

--- a/spec/tasks/git_reset_wip/task_spec.rb
+++ b/spec/tasks/git_reset_wip/task_spec.rb
@@ -53,6 +53,10 @@ describe 'git_reset_wip task' do
       expect(File).not_to exist(File.join(@updated_git_resource, 'a-branch.md'))
     end
 
+    it 'contains reset timestamp' do
+      expect(File).to exist(File.join(@updated_git_resource, ".last-reset"))
+    end
+
     context 'when skip_ssl is enabled' do
       it 'does not check ssl certificates' do
         expect(@output).to include('Skipping ssl verification')


### PR DESCRIPTION
Fixes #173.

Changes proposed in this pull-request:
- we ensure a new git history is created after reset (also when no feature branches exists)