### PR TITLE
support iaas-type for deployement-dependencies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -527,7 +527,7 @@ While developing new pipelines, it might be easier to generate them locally and 
 
 ```bash
 fly -t preprod login -u login -p password -c concourse-url
-./scripts/generate-depls.rb --depls cloudflare-depls -t ../paas-template/ -p ../bosh-cloudwatt-preprod-secrets/ --no-dump -i ./concourse/pipelines/template/tf-pipeline.yml.erb
+./scripts/generate-depls.rb --depls cloudflare-depls -t ../paas-template/ -p ../bosh-cloudwatt-preprod-secrets/ --no-dump -i ./concourse/pipelines/template/tf-pipeline.yml.erb --iaas openstack
 SECRETS=../bosh-cloudwatt-preprod-secrets/ TARGET_NAME=preprod ./scripts/concourse-manual-pipelines-update.rb -dcloudflare-depls
 ```
 

--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -68,6 +68,8 @@ jobs:
     input_mapping: {scripts-resource: cf-ops-automation,templates-resource: paas-templates-full,secrets-resource: secrets-full}
     output_mapping: {result-dir: all-pipelines}
     file: cf-ops-automation/concourse/tasks/generate-all-pipelines.yml
+    params:
+      IAAS_TYPE: ((iaas-type))
   - task: set-all-init-pipelines
     input_mapping: {scripts-resource: cf-ops-automation,templates-resource: paas-templates-full,secrets-resource: secrets-full, pipelines-resource: all-pipelines}
     file: cf-ops-automation/concourse/tasks/bootstrap_init_pipelines.yml

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -920,29 +920,10 @@ jobs:
   - task: generate-<%= depls %>-pipeline
     input_mapping: {scripts-resource: cf-ops-automation,templates: paas-templates-wip,secrets: secrets-<%= depls %>-trigger}
     output_mapping: {result-dir: concourse-<%= depls %>-pipeline}
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source: {repository: ruby, tag: 2.3.1-slim}
-      inputs:
-        - name: scripts-resource
-        - name: templates
-        - name: secrets
-      outputs:
-        - name: result-dir
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cp -r templates/. result-dir
-          cp -r scripts-resource/. result-dir
-          cp -rf secrets/. result-dir
-          cd result-dir/
-          ./scripts/generate-depls.rb --depls ${ROOT_DEPLOYMENT} -t ../templates -p . -o concourse
-      params:
-        ROOT_DEPLOYMENT: <%= depls %>
+    file: cf-ops-automation/concourse/tasks/generate_depls/task.yml
+    params:
+      ROOT_DEPLOYMENT: <%= depls %>
+      IAAS_TYPE: ((iaas-type))
   - put: <%= all_ci_deployments[depls]['target_name'] %>
     params:
       pipelines:

--- a/concourse/pipelines/template/init-pipeline.yml.erb
+++ b/concourse/pipelines/template/init-pipeline.yml.erb
@@ -86,27 +86,10 @@ jobs:
   - task: generate-<%= depls %>-pipelines
     input_mapping: {scripts-resource: cf-ops-automation,templates: paas-templates-full,secrets: secrets-full}
     output_mapping: {result-dir: concourse-<%= depls %>-pipeline}
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source: {repository: ruby, tag: 2.3.1-slim}
-      inputs:
-        - name: scripts-resource
-        - name: secrets
-        - name: templates
-      outputs:
-        - name: result-dir
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cp -r templates/. result-dir
-          cp -r scripts-resource/. result-dir
-          cp -rf secrets/. result-dir
-          cd result-dir/
-          ./scripts/generate-depls.rb --depls <%= depls %> -t ../templates -p . -o concourse
+    file: cf-ops-automation/concourse/tasks/generate_depls/task.yml
+    params:
+      ROOT_DEPLOYMENT: <%= depls %>
+      IAAS_TYPE: ((iaas-type))
 
   - put: <%= all_ci_deployments[depls]["target_name"] %>
     params:

--- a/concourse/tasks/coa-upgrade/run.rb
+++ b/concourse/tasks/coa-upgrade/run.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+require 'open3'
+
+# Upgrade scripts launcher: it executes all migration scripts present in a directory
+class CoaUpgrade
+  UNDEFINED = 'Undefined'.freeze
+  STDOUT_LOG_FILENAME = 'stdout.log'.freeze
+  STDERR_LOG_FILENAME = 'stderr.log'.freeze
+
+  def initialize(root_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..')))
+    @coa_root_dir = File.join(root_dir, 'cf-ops-automation')
+    @config_root_dir = File.join(root_dir, 'config')
+    @templates_root_dir = File.join(root_dir, 'templates')
+
+    init_output_dir(root_dir)
+  end
+
+  def self.write(filename, data)
+    File.open(filename, 'a') { |file| file.write data }
+  end
+
+  def self.list_migration_scripts(base_dir)
+    Dir[File.join(base_dir, '*')]&.sort
+  end
+
+  def self.format_result(script_name, header, data)
+    return '' if data.empty?
+    result = "##################\n"
+    result << "#{script_name} #{header}:\n"
+    result << data
+    result
+  end
+
+  def self.coa_version
+    version = ENV.fetch('COA_VERSION', UNDEFINED)
+    return UNDEFINED if version.empty?
+    version
+  end
+
+  def migrate
+    migration_scripts_path = locate_migration_scripts
+    puts "searching migration scripts at '#{migration_scripts_path}'"
+    migration_scripts = self.class.list_migration_scripts(migration_scripts_path)
+    migration_scripts&.each do |script|
+      puts "processing #{script.gsub(%r{^.*cf-ops-automation/}, '')}"
+      execute_and_display(script)
+    end
+    dump_outputs
+  end
+
+  def stdout_filename
+    File.join(@upgraded_results_dir, STDOUT_LOG_FILENAME)
+  end
+
+  def stderr_filename
+    File.join(@upgraded_results_dir, STDERR_LOG_FILENAME)
+  end
+
+  private
+
+  def write_stdout(data)
+    self.class.write(stdout_filename, data)
+  end
+
+  def write_stderr(data)
+    self.class.write(stderr_filename, data)
+  end
+
+  def execute_and_display(script)
+    out, err = execute_upgrade_command(script)
+    write_stdout(out)
+    write_stderr(err)
+  end
+
+  def dump_outputs
+    puts File.read(stdout_filename)
+  end
+
+  def locate_migration_scripts
+    location = File.join(@coa_root_dir, 'upgrade', "v#{self.class.coa_version}")
+    raise "No migration scripts found at #{location}" unless File.exist?(location)
+    location
+  end
+
+  def execute_upgrade_command(script)
+    upgrade_cmd = "#{script} -c #{@upgraded_config_root_dir} -t #{@upgraded_templates_root_dir}"
+    out, err = Open3.capture3(upgrade_cmd)
+    out_result = self.class.format_result(script, 'STDOUT', out)
+    err_result = self.class.format_result(script, 'STDERR', err)
+    [out_result, err_result]
+  end
+
+  def init_output_dir(root_dir)
+    @upgraded_results_dir = File.join(root_dir, 'upgrade-results')
+    @upgraded_config_root_dir = File.join(root_dir, 'upgraded-config')
+    @upgraded_templates_root_dir = File.join(root_dir, 'upgraded-templates')
+    FileUtils.cp_r(File.join(@config_root_dir, '.'), @upgraded_config_root_dir)
+    FileUtils.cp_r(File.join(@templates_root_dir, '.'), @upgraded_templates_root_dir)
+  end
+end
+
+CoaUpgrade.new.migrate

--- a/concourse/tasks/coa-upgrade/task.yml
+++ b/concourse/tasks/coa-upgrade/task.yml
@@ -1,0 +1,30 @@
+---
+#
+# Copyright (C) 2015-2018 Orange
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+platform: linux
+image_resource:
+  type: docker-image
+  source: {repository: ruby, tag: 2.3.5}
+inputs:
+  - name: cf-ops-automation
+  - name: templates
+  - name: config
+outputs:
+  - name: upgraded-templates
+  - name: upgraded-config
+  - name: upgrade-results
+run:
+  path: cf-ops-automation/concourse/tasks/coa-upgrade/run.rb
+params:
+  COA_VERSION:

--- a/concourse/tasks/generate-all-pipelines.yml
+++ b/concourse/tasks/generate-all-pipelines.yml
@@ -19,3 +19,5 @@ run:
     export OUTPUT_DIR=$(pwd)/result-dir
     cd scripts-resource
     ./scripts/concourse-generate-all-pipelines.sh
+param:
+  IAAS_TYPE:

--- a/concourse/tasks/generate_depls/run.sh
+++ b/concourse/tasks/generate_depls/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2015-2018 Orange
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -eC
+
+env
+if [ -z "${ROOT_DEPLOYMENT}" ]
+then
+    echo "ERROR: missing environment variable: ROOT_DEPLOYMENT" | tee -a result-dir/error.log
+fi
+
+if [ -z "${IAAS_TYPE}" ]
+then
+    echo "ERROR: missing environment variable: IAAS_TYPE" | tee -a result-dir/error.log
+fi
+
+if [ -s "result-dir/error.log" ]
+then
+    echo "errors detected - exiting"
+    exit 1
+fi
+
+cp -r templates/. result-dir
+cp -r scripts-resource/. result-dir
+cp -rf secrets/. result-dir
+cd result-dir
+./scripts/generate-depls.rb --depls "${ROOT_DEPLOYMENT}" -t ../templates -p . -o concourse --iaas "${IAAS_TYPE}"

--- a/concourse/tasks/generate_depls/task.yml
+++ b/concourse/tasks/generate_depls/task.yml
@@ -1,0 +1,29 @@
+---
+#
+# Copyright (C) 2015-2018 Orange
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+platform: linux
+image_resource:
+  type: docker-image
+  source: {repository: ruby, tag: 2.3.5-slim}
+inputs:
+  - name: scripts-resource
+  - name: templates
+  - name: secrets
+outputs:
+  - name: result-dir
+run:
+  path: scripts-resource/concourse/tasks/generate_depls/run.sh
+params:
+  ROOT_DEPLOYMENT:
+  IAAS_TYPE: ((iaas-type))

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/deployment-dependencies-openstack.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/deployment-dependencies-openstack.yml
@@ -1,0 +1,8 @@
+---
+deployment:
+  bosh-deployment:
+    releases:
+      # we can add a iaas-dependant bosh release
+      bosh-openstack-cpi-release:
+        base_location: https://bosh.io/d/github.com/
+        repository: cloudfoundry-incubator/bosh-openstack-cpi-release

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/hello-world-root-depls-versions.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/hello-world-root-depls-versions.yml
@@ -5,3 +5,4 @@ stemcell-version: "3586.25"
 
 nginx-version: "1.13.12"
 ntp-version: "4.2.8p11"
+bosh-openstack-cpi-release-version: "37"

--- a/lib/active_support_copy_deep_merge.rb
+++ b/lib/active_support_copy_deep_merge.rb
@@ -1,0 +1,55 @@
+# Copyright (c) 2005-2018 David Heinemeier Hansson
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+#                                  distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# frozen_string_literal: true
+
+class Hash
+  # Returns a new hash with +self+ and +other_hash+ merged recursively.
+  #
+  #   h1 = { a: true, b: { c: [1, 2, 3] } }
+  #   h2 = { a: false, b: { x: [3, 4, 5] } }
+  #
+  #   h1.deep_merge(h2) # => { a: false, b: { c: [1, 2, 3], x: [3, 4, 5] } }
+  #
+  # Like with Hash#merge in the standard library, a block can be provided
+  # to merge values:
+  #
+  #   h1 = { a: 100, b: 200, c: { c1: 100 } }
+  #   h2 = { b: 250, c: { c1: 200 } }
+  #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
+  #   # => { a: 100, b: 450, c: { c1: 300 } }
+  def deep_merge(other_hash, &block)
+    dup.deep_merge!(other_hash, &block)
+  end
+
+  # Same as +deep_merge+, but modifies +self+.
+  def deep_merge!(other_hash, &block)
+    merge!(other_hash) do |key, this_val, other_val|
+      if this_val.is_a?(Hash) && other_val.is_a?(Hash)
+        this_val.deep_merge(other_val, &block)
+      elsif block_given?
+        yield(key, this_val, other_val)
+      else
+        other_val
+      end
+    end
+  end
+end

--- a/lib/coa_upgrader.rb
+++ b/lib/coa_upgrader.rb
@@ -1,0 +1,5 @@
+
+# Set of feature to ease creation of upgrade scripts for COA
+module CoaUpgrader
+  require_relative 'coa_upgrader/command_line_parser'
+end

--- a/lib/coa_upgrader/command_line_parser.rb
+++ b/lib/coa_upgrader/command_line_parser.rb
@@ -1,0 +1,37 @@
+require 'optparse'
+
+module CoaUpgrader
+  # Common command line parsing for upgrade scripts
+  class CommandLineParser
+    OPTIONS = {
+      dump_output: true,
+      config_path: '',
+      templates_path: ''
+    }.freeze
+
+    def initialize(options = OPTIONS.dup)
+      @options = options
+    end
+
+    def parse
+      options = @options
+      opt_parser = OptionParser.new do |opts|
+        opts.banner = "Incomplete/wrong parameter(s): #{opts.default_argv}.\n Usage: ./#{opts.program_name} <options>"
+
+        opts.on('-c', '--config PATH', "config-path location (main git directory). Default: #{options[:config_path]}") do |cp_string|
+          options[:config_path] = cp_string
+        end
+
+        opts.on('-t', '--templates PATH', "paas-templates path location (main git directory). Default: #{options[:templates_path]}") do |tp_string|
+          options[:templates_path] = tp_string
+        end
+
+        opts.on('--[no-]dump', 'Dump genereted file on standart output') do |dump|
+          options[:dump_output] = dump
+        end
+      end
+      opt_parser.parse!
+      @options = options
+    end
+  end
+end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,14 +1,17 @@
 require 'yaml'
 require 'fileutils'
+require_relative 'active_support_copy_deep_merge'
+require_relative 'extended_config'
 
 class Config
   DEFAULT_STEMCELL = 'bosh-openstack-kvm-ubuntu-trusty-go_agent'.freeze
 
   attr_reader :loaded_config
 
-  def initialize(public_yaml_location = '', private_yaml_location = '')
+  def initialize(public_yaml_location = '', private_yaml_location = '', extended_config = ExtendedConfigBuilder.new.build)
     @public_yaml = public_yaml_location
     @private_yaml = private_yaml_location
+    @extended_config = extended_config
     @loaded_config = default_config
   end
 
@@ -22,14 +25,15 @@ class Config
       'default' => {
         'stemcell' => { 'name' => DEFAULT_STEMCELL }
       }
-    }
+    }.deep_merge(@extended_config.default_config)
   end
 
   def load_config
     public_config = YAML.load_file(@public_yaml) if File.exist?(@public_yaml)
     private_config = YAML.load_file(@private_yaml) if File.exist?(@private_yaml)
-    @loaded_config = @loaded_config.merge(public_config) unless public_config.nil?
-    @loaded_config = @loaded_config.merge(private_config) unless private_config.nil?
+    @loaded_config = @loaded_config.deep_merge(public_config) unless public_config.nil?
+    @loaded_config = @loaded_config.deep_merge(private_config) unless private_config.nil?
+    @loaded_config = @loaded_config.deep_merge(@extended_config.default_config)
     self
   end
 
@@ -38,5 +42,9 @@ class Config
     name.empty? ? DEFAULT_STEMCELL : name
   rescue NoMethodError
     DEFAULT_STEMCELL
+  end
+
+  def iaas_type
+    @loaded_config['default']['iaas']
   end
 end

--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require_relative 'active_support_copy_deep_merge'
 
 class Deployment
   attr_reader :name, :details
@@ -25,6 +26,10 @@ class Deployment
   def disable
     details['status'] = 'disabled'
     self
+  end
+
+  def merge(override)
+    Deployment.new(@name, @details&.deep_merge(override.details))
   end
 
   def self.default(deployment_name)

--- a/lib/deployment_deployers_config.rb
+++ b/lib/deployment_deployers_config.rb
@@ -41,7 +41,7 @@ class DeploymentDeployersConfig
     dependency_filename = File.join(@public_base_location, DEPLOYMENT_DEPENDENCIES_FILENAME)
     return unless File.exist?(dependency_filename)
 
-    @deployment_factory&.load_file(dependency_filename)&.each do |deployment|
+    @deployment_factory&.load_file_with_iaas(dependency_filename)&.each do |deployment|
       raise "#{@private_base_location} - Invalid deployment: expected <#{@deployment_name}> - Found <#{deployment.name}>" if deployment.name != @deployment_name
       deployment_details.merge! deployment.details
     end

--- a/lib/deployment_factory.rb
+++ b/lib/deployment_factory.rb
@@ -14,6 +14,16 @@ class DeploymentFactory
     validate_version_reference
   end
 
+  def load_file_with_iaas(filename = '')
+    deployment_dependencies_extension = File.extname(filename)
+    deployment_dependencies_basename = filename.gsub(deployment_dependencies_extension, '')
+    deployment_dependencies_loaded = load_file(filename)
+
+    iaas_filename = "#{deployment_dependencies_basename}-#{@config.iaas_type}.yml"
+    iaas_loaded = File.exist?(iaas_filename) ? load_file(iaas_filename) : [Deployment.new('empty-deployment')]
+    merge(deployment_dependencies_loaded.first, iaas_loaded.first)
+  end
+
   def load_file(filename = '')
     validate_file(filename)
     puts "DeploymentFactory - processing #{filename}"
@@ -78,6 +88,10 @@ class DeploymentFactory
       raise "Missing boshrelease version: expecting '#{a_release}-version' key in #{@root_deployment_name}-versions.yml" if version.nil?
       deployment_details['releases'][a_release]['version'] = version
     end
+  end
+
+  def merge(initial, override)
+    [initial.merge(override)]
   end
 
   def validate

--- a/lib/extended_config.rb
+++ b/lib/extended_config.rb
@@ -1,0 +1,49 @@
+require 'yaml'
+require 'fileutils'
+
+# Hold configuration retrieved from environment variable
+class ExtendedConfig
+  IAAS_TYPE_KEY = 'IAAS_TYPE'.freeze
+  DEFAULT_IAAS_TYPE = 'openstack'.freeze
+
+  attr_reader :extended_config
+
+  def default_config
+    {
+      'default' => {
+        'iaas' => default_iaas_type
+      }
+    }
+  end
+
+  def initialize(env = {})
+    @extended_config = env
+  end
+
+  def ==(other)
+    return false unless other.is_a?(ExtendedConfig)
+    @extended_config == other.extended_config
+  end
+
+  private
+
+  def default_iaas_type
+    @extended_config.fetch(IAAS_TYPE_KEY, DEFAULT_IAAS_TYPE)
+  end
+end
+
+# Ease creation of ExtendedConfig
+class ExtendedConfigBuilder
+  def initialize
+    @current_config = {}
+  end
+
+  def build
+    ExtendedConfig.new(@current_config)
+  end
+
+  def with_iaas_type(name)
+    @current_config[ExtendedConfig::IAAS_TYPE_KEY] = name
+    self
+  end
+end

--- a/lib/reference_dataset_documentation/helpers/file_list_writer_helpers.rb
+++ b/lib/reference_dataset_documentation/helpers/file_list_writer_helpers.rb
@@ -11,12 +11,12 @@ module ReferenceDatasetDocumentation
       end
 
       def extract_prefix(path)
-        path_items = path.strip.gsub(%r{^.\/}, "").split('/')
+        path_items = path.strip.gsub(%r{^./}, "").split('/')
         "  " * (path_items.size - 1)
       end
 
       def clean_path(path)
-        path.strip.gsub(%r{^.\/}, "")
+        path.strip.gsub(%r{^./}, "")
       end
     end
   end

--- a/scripts/concourse-bootstrap.sh
+++ b/scripts/concourse-bootstrap.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 set -e
-SECRETS=${SECRETS:-$(pwd)/../../preprod-secrets}
-FLY_TARGET=${FLY_TARGET:-cw-pp-micro}
+SECRETS=${SECRETS:-$(pwd)/../../int-secrets}
+FLY_TARGET=${FLY_TARGET:-fe-int}
 SKIP_TRIGGER=${SKIP_TRIGGER:=false}
 DEBUG=${DEBUG:=false}
-
 
 usage(){
     echo "$0" 1>&2
     echo -e "No parameter supported. Use environment variables:" 1>&2
-    echo -e "\t FLY_TARGET: fly target name to use. DEFAULT: $FLY_TARGET " 1>&2
-    echo -e "\t SECRETS: path to secrets directory. DEFAULT: $SECRETS " 1>&2
-    echo -e "\t SKIP_TRIGGER: skip job triggering after pipeline loading. DEFAULT: [$SKIP_TRIGGER] " 1>&2
-    echo -e "\t FLY_SET_PIPELINE_OPTION: set custom option like '--non-interactive'. DEFAULT: empty " 1>&2
+    echo -e "\t FLY_TARGET: fly target name to use. DEFAULT: $FLY_TARGET" 1>&2
+    echo -e "\t IAAS_TYPE: iaas type to use. NO DEFAULT VALUE" 1>&2
+    echo -e "\t SECRETS: path to secrets directory. DEFAULT: $SECRETS" 1>&2
+    echo -e "\t SKIP_TRIGGER: skip job triggering after pipeline loading. DEFAULT: [$SKIP_TRIGGER]" 1>&2
+    echo -e "\t FLY_SET_PIPELINE_OPTION: set custom option like '--non-interactive'. DEFAULT: empty" 1>&2
     exit 1
 }
 
@@ -44,13 +44,12 @@ PIPELINE="bootstrap-all-init-pipelines"
 echo "Load ${PIPELINE} on ${FLY_TARGET}"
 set +e
 fly -t ${FLY_TARGET} set-pipeline ${FLY_SET_PIPELINE_OPTION} -p ${PIPELINE} -c ${SCRIPT_DIR}/concourse/pipelines/${PIPELINE}.yml  \
-            -l ${SECRET_DIR}/micro-depls/concourse-micro/pipelines/credentials-auto-init.yml \
-            -l ${SECRET_DIR}/micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml \
-            -l ${SECRET_DIR}/micro-depls/concourse-micro/pipelines/credentials-git-config.yml
+            -l "${SECRET_DIR}/micro-depls/concourse-micro/pipelines/credentials-auto-init.yml" \
+            -l "${SECRET_DIR}/micro-depls/concourse-micro/pipelines/credentials-iaas-specific.yml" \
+            -l "${SECRET_DIR}/micro-depls/concourse-micro/pipelines/credentials-git-config.yml"
 set -e
 fly -t ${FLY_TARGET} unpause-pipeline -p ${PIPELINE}
 if [ "$SKIP_TRIGGER" != "true" ]
 then
     fly -t ${FLY_TARGET} trigger-job -j "${PIPELINE}/bootstrap-init-pipelines"
 fi
-

--- a/scripts/concourse-generate-all-pipelines.sh
+++ b/scripts/concourse-generate-all-pipelines.sh
@@ -14,6 +14,7 @@ DEBUG=${DEBUG:=false}
 usage(){
     echo "$0" 1>&2
     echo -e "No parameter supported. Use environment variables:" 1>&2
+    echo -e "\t IAAS_TYPE: iaas to target. NO DEFAULT VALUE" 1>&2
     echo -e "\t SECRETS: path to secrets directory. DEFAULT: $SECRETS " 1>&2
     echo -e "\t TEMPLATES: path to paas-templates directory. DEFAULT: $TEMPLATES " 1>&2
     echo -e "\t DEPLS_LIST: deployments to process. DEFAULT: [$DYNAMIC_DEPLS_LIST] " 1>&2
@@ -51,7 +52,7 @@ mkdir -p ${OUTPUT_DIR}/pipelines
 
 echo "Generating pipelines using secrets in $SECRET_DIR to ${OUTPUT_DIR}/pipelines"
 for depls in ${DEPLS_LIST};do
-    ${CURRENT_SCRIPT_DIR}/generate-depls.rb -d ${depls} -p ${SECRET_DIR} -o ${OUTPUT_DIR} -t ${TEMPLATES} --no-dump
+    "${CURRENT_SCRIPT_DIR}/generate-depls.rb" -d "${depls}" -p "${SECRET_DIR}" -o "${OUTPUT_DIR}" -t "${TEMPLATES}" --iaas "${IAAS_TYPE}" --no-dump
     PIPELINE="${depls}-init-generated"
     echo "${PIPELINE} generated  to ${OUTPUT_DIR}/pipelines"
 done

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -6,6 +6,7 @@ require 'config'
 
 describe Config do
   let(:config_dir) { Dir.mktmpdir }
+  let(:extended_config) { ExtendedConfigBuilder.new.with_iaas_type('my_custom_iaas').build }
   let(:default_config) do
     {
       'offline-mode' => {
@@ -14,6 +15,7 @@ describe Config do
         'docker-images' => false
       },
       'default' => {
+        'iaas' => 'my_custom_iaas',
         'stemcell' => {
           'name' => 'bosh-openstack-kvm-ubuntu-trusty-go_agent'
         }
@@ -30,14 +32,14 @@ describe Config do
   describe 'private-config.yml format validation'
 
   describe '#load_config' do
-    subject { described_class.new('not-existing-public-config.yml', 'not-existing-private-config.yml') }
+    subject { described_class.new('not-existing-public-config.yml', 'not-existing-private-config.yml', extended_config) }
 
     it 'generates a default config when no yaml detected' do
       expect(subject.load_config.loaded_config).to eq(default_config)
     end
 
     context 'when shared config exists' do
-      subject { described_class.new(shared_config_file, 'not-existing-private-config.yml') }
+      subject { described_class.new(shared_config_file, 'not-existing-private-config.yml', extended_config) }
 
       let(:shared_config_file) { File.join(config_dir, 'my-public-config.yml') }
       let(:shared_config_file_content) { { 'public-override' => true, 'offline-mode' => false } }
@@ -53,7 +55,7 @@ describe Config do
       end
 
       context 'when private config also exists' do
-        subject { described_class.new(shared_config_file, private_config_file) }
+        subject { described_class.new(shared_config_file, private_config_file, extended_config) }
 
         let(:private_config_file) { File.join(config_dir, 'my-private-config.yml') }
         let(:private_config_file_content) { { 'private-override' => true, 'offline-mode' => true } }

--- a/spec/lib/pipeline_generator_spec.rb
+++ b/spec/lib/pipeline_generator_spec.rb
@@ -19,12 +19,14 @@ describe PipelineGenerator do
     let(:secrets_path) { "secret/path" }
     let(:input_pipeline) { "ppln" }
     let(:git_submodule_path) { "git_submodule_path" }
+    let(:rspec_iaas_type) { "rspec-iaas-type" }
     let(:options) do
       {
         paas_templates_path: paas_templates_path,
         depls: depls,
         secrets_path: secrets_path,
         input_pipelines: [input_pipeline],
+        iaas_type: rspec_iaas_type,
         git_submodule_path: git_submodule_path
       }
     end
@@ -41,7 +43,8 @@ describe PipelineGenerator do
     end
     let(:shared_config) { File.join(paas_templates_path, 'shared-config.yml') }
     let(:private_config) { File.join(secrets_path, 'private-config.yml') }
-    let(:config) { Config.new(shared_config, private_config) }
+    let(:extended_config) { ExtendedConfigBuilder.new.with_iaas_type(rspec_iaas_type).build }
+    let(:config) { Config.new(shared_config, private_config, extended_config) }
     let(:deployment_factory) do
       DeploymentFactory.new(depls, root_deployment_versions.versions, config)
     end
@@ -89,12 +92,12 @@ describe PipelineGenerator do
         with("#{paas_templates_path}/#{depls}/#{depls}-versions.yml").
         and_return(root_deployment_versions)
 
-      expect(Config).to receive(:new).with(shared_config, private_config).
-        and_return(config)
-      expect(config).to receive(:load_config).
-        and_return(config)
-      expect(config).to receive(:loaded_config).
-        and_return(loaded_config)
+        expect(Config).to receive(:new).with(shared_config, private_config,extended_config).
+          and_return(config)
+        expect(config).to receive(:load_config).
+          and_return(config)
+        expect(config).to receive(:loaded_config).
+          and_return(loaded_config)
 
       expect(DeploymentFactory).to receive(:new).
         with(depls, root_deployment_versions.versions, config).

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-init-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-init-ref.yml
@@ -81,28 +81,10 @@ jobs:
   - task: generate-simple-depls-pipelines
     input_mapping: {scripts-resource: cf-ops-automation,templates: paas-templates-full,secrets: secrets-full}
     output_mapping: {result-dir: concourse-simple-depls-pipeline}
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source: {repository: ruby, tag: 2.3.1-slim}
-      inputs:
-        - name: scripts-resource
-        - name: secrets
-        - name: templates
-      outputs:
-        - name: result-dir
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cp -r templates/. result-dir
-          cp -r scripts-resource/. result-dir
-          cp -rf secrets/. result-dir
-          cd result-dir/
-          ./scripts/generate-depls.rb --depls simple-depls -t ../templates -p . -o concourse
-
+    file: cf-ops-automation/concourse/tasks/generate_depls/task.yml
+    params:
+      ROOT_DEPLOYMENT: simple-depls
+      IAAS_TYPE: ((iaas-type))
   - put: TO_BE_DEFINED
     params:
       pipelines:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -693,30 +693,10 @@ jobs:
   - task: generate-simple-depls-pipeline
     input_mapping: {scripts-resource: cf-ops-automation,templates: paas-templates-wip,secrets: secrets-simple-depls-trigger}
     output_mapping: {result-dir: concourse-simple-depls-pipeline}
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source: {repository: ruby, tag: 2.3.1-slim}
-      inputs:
-        - name: scripts-resource
-        - name: templates
-        - name: secrets
-      outputs:
-        - name: result-dir
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          cp -r templates/. result-dir
-          cp -r scripts-resource/. result-dir
-          cp -rf secrets/. result-dir
-          cd result-dir/
-          ./scripts/generate-depls.rb --depls ${ROOT_DEPLOYMENT} -t ../templates -p . -o concourse
-      params:
-        ROOT_DEPLOYMENT: simple-depls
-
+    file: cf-ops-automation/concourse/tasks/generate_depls/task.yml
+    params:
+      ROOT_DEPLOYMENT: simple-depls
+      IAAS_TYPE: ((iaas-type))
   - put: TO_BE_DEFINED
     params:
       pipelines:

--- a/spec/scripts/generate-depls/fixtures/templates/simple-depls/ntp/deployment-dependencies-openstack.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/simple-depls/ntp/deployment-dependencies-openstack.yml
@@ -1,0 +1,8 @@
+---
+deployment:
+  bosh-deployment:
+    releases:
+      # we can add a iaas-dependant bosh release
+      bosh-openstack-cpi-release:
+        base_location: https://bosh.io/d/github.com/
+        repository: cloudfoundry-incubator/bosh-openstack-cpi-release

--- a/spec/scripts/generate-depls/fixtures/templates/simple-depls/simple-depls-versions.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/simple-depls/simple-depls-versions.yml
@@ -1,5 +1,5 @@
 ---
 deployment-name: simple-depls
 ntp_boshrelease-version: "4"
-
+bosh-openstack-cpi-release-version: 37
 stemcell-version: "3468.1"

--- a/spec/scripts/generate-depls/generate_depls_for_cf_apps_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_cf_apps_pipeline_spec.rb
@@ -15,13 +15,14 @@ describe 'generate-depls for cf-apps pipeline' do
     let(:output_path) { Dir.mktmpdir }
     let(:templates_path) { "#{fixture_path}/templates" }
     let(:secrets_path) { "#{fixture_path}/secrets" }
+    let(:iaas_type) { 'my-custom-iaas' }
 
     after do
       # FileUtils.rm_rf(output_path) unless output_path.nil?
     end
 
     context 'when generate-depls is executed' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/cf-apps-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/cf-apps-pipeline.yml.erb" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_for_depls_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_depls_pipeline_spec.rb
@@ -11,9 +11,9 @@ describe 'generate-depls for depls pipeline' do
   let(:templates_path) { "#{fixture_path}/templates" }
   let(:secrets_path) { "#{fixture_path}/secrets" }
   let(:depls_name) { 'simple-depls' }
-  let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/depls-pipeline.yml.erb" }
+  let(:iaas_type) { 'my-custom-iaas' }
+  let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/depls-pipeline.yml.erb" }
   let(:pipeline) { TestHelper.load_generated_pipeline(output_path, "#{depls_name}-generated.yml") }
-
   let(:cleanup) { FileUtils.rm_rf(output_path) unless output_path.nil? }
 
   context 'when a simple deployment is used' do

--- a/spec/scripts/generate-depls/generate_depls_for_init_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_init_pipeline_spec.rb
@@ -11,6 +11,7 @@ describe 'generate-depls for init pipeline' do
     let(:output_path) { Dir.mktmpdir }
     let(:templates_path) { "#{fixture_path}/templates" }
     let(:secrets_path) { "#{fixture_path}/secrets" }
+    let(:iaas_type) { 'my-custom-iaas' }
 
     after do
       FileUtils.rm_rf(output_path) unless output_path.nil?
@@ -18,7 +19,7 @@ describe 'generate-depls for init pipeline' do
 
     context 'when valid' do
       let(:options) do
-        "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/init-pipeline.yml.erb"
+        "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/init-pipeline.yml.erb"
       end
 
       stdout_str = stderr_str = ''

--- a/spec/scripts/generate-depls/generate_depls_for_news_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_news_pipeline_spec.rb
@@ -11,13 +11,14 @@ describe 'generate-depls for news pipeline' do
     let(:output_path) { Dir.mktmpdir }
     let(:templates_path) { "#{fixture_path}/templates" }
     let(:secrets_path) { "#{fixture_path}/secrets" }
+    let(:iaas_type) { 'my-custom-iaas' }
 
     after do
       FileUtils.rm_rf(output_path) unless output_path.nil?
     end
 
     context 'when valid' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/news-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/news-pipeline.yml.erb" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_for_s3_br_upload_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_s3_br_upload_pipeline_spec.rb
@@ -21,13 +21,14 @@ describe 'generate-depls for s3 boshrelease upload pipeline' do
     let(:output_path) { Dir.mktmpdir }
     let(:templates_path) { "#{fixture_path}/templates" }
     let(:secrets_path) { "#{fixture_path}/secrets" }
+    let(:iaas_type) { 'my-custom-iaas' }
 
     after do
       FileUtils.rm_rf(output_path) unless output_path.nil?
     end
 
     context 'when valid' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/s3-br-upload-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/s3-br-upload-pipeline.yml.erb" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_for_s3_stemcell_upload_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_s3_stemcell_upload_pipeline_spec.rb
@@ -11,13 +11,14 @@ describe 'generate-depls for s3 stemcell upload pipeline' do
     let(:output_path) { Dir.mktmpdir }
     let(:templates_path) { "#{fixture_path}/templates" }
     let(:secrets_path) { "#{fixture_path}/secrets" }
+    let(:iaas_type) { 'my-custom-iaas' }
 
     after do
       FileUtils.rm_rf(output_path) unless output_path.nil?
     end
 
     context 'when valid' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/tasks/coa_upgrade/task_spec.rb
+++ b/spec/tasks/coa_upgrade/task_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'yaml'
+require_relative '../task_spec_helper'
+
+describe 'COA upgrade task' do
+  let(:yaml_files) { File.join('**', '*.yml') }
+  let(:stderr_path) { File.join(@upgrate_results, 'stderr.log') }
+  let(:stderr_loaded_file) do
+    content = File.read(stderr_path) if File.exist?(stderr_path)
+    content || ''
+  end
+
+  before(:context) do
+    @root_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..'))
+    reference_dataset = File.join(@root_dir, 'docs','reference_dataset')
+    reference_dataset_template = File.join(reference_dataset, 'template_repository')
+    reference_dataset_secrets = File.join(reference_dataset, 'config_repository')
+
+    @templates_dir =  Dir.mktmpdir
+    @config_dir = Dir.mktmpdir
+    @upgrated_templates_dir = Dir.mktmpdir
+    @upgrated_config_dir = Dir.mktmpdir
+    @upgrate_results = Dir.mktmpdir
+
+    FileUtils.cp_r(File.join(reference_dataset_template, '.'), @templates_dir)
+    FileUtils.cp_r(File.join(reference_dataset_secrets, '.'), @config_dir)
+    @fly_upgrade_cmd = '-c concourse/tasks/coa-upgrade/task.yml ' \
+        '-i cf-ops-automation=. ' \
+        "-i templates=#{@templates_dir} " \
+        "-i config=#{@config_dir} " \
+        "-o upgraded-config=#{@upgrated_config_dir} " \
+        "-o upgraded-templates=#{@upgrated_templates_dir} " \
+        "-o upgrade-results=#{@upgrate_results} "
+  end
+
+  after(:context) do
+    FileUtils.rm_rf @templates_dir
+    FileUtils.rm_rf @config_dir
+    FileUtils.rm_rf @upgrated_templates_dir
+    FileUtils.rm_rf @upgrated_config_dir
+    FileUtils.rm_rf @upgrate_results
+  end
+
+  context 'when upgrade version is not defined' do
+    before(:context) do
+      @output = execute(@fly_upgrade_cmd)
+    end
+
+    it 'generates files in config dir' do
+      expect(Dir[File.join(@upgrated_config_dir), yaml_files]&.length).to be > 1
+    end
+
+    it 'generates files in templates dir' do
+      expect(Dir[File.join(@upgrated_templates_dir), yaml_files]&.length).to be > 1
+    end
+
+    it 'contains error messages' do
+      error_message = @output.scan(/No migration scripts found at/)
+      expect(error_message).not_to be_empty
+    end
+  end
+
+  context 'when running v2.0.0 migration' do
+    before(:context) do
+      @output = execute(@fly_upgrade_cmd,
+                        'COA_VERSION' => '2.0.0')
+    end
+
+    it 'generates no errors' do
+      expect(stderr_loaded_file).to eq('')
+    end
+
+    it 'runs successfully' do
+      expect(@output).to end_with("succeeded\n")
+    end
+  end
+
+  context 'when running v2.2.0 migration' do
+    before(:context) do
+      @output = execute(@fly_upgrade_cmd,
+                        'COA_VERSION' => '2.2.0')
+    end
+
+    it 'generates no errors' do
+      expect(stderr_loaded_file).to eq('')
+    end
+
+    it 'runs successfully' do
+      expect(@output).to end_with("succeeded\n")
+    end
+  end
+
+  context 'when running v3.0.0 migration' do
+    before(:context) do
+      @output = execute(@fly_upgrade_cmd,
+                        'COA_VERSION' => '3.0.0')
+    end
+
+    it 'generates no errors' do
+      expect(stderr_loaded_file).to eq('')
+    end
+
+    it 'runs successfully' do
+      expect(@output).to end_with("succeeded\n")
+    end
+  end
+end

--- a/spec/tasks/generate_depls/task_spec.rb
+++ b/spec/tasks/generate_depls/task_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'yaml'
+require_relative '../task_spec_helper'
+
+describe 'generate_depls task' do
+  context 'when environment variables are valid' do
+    let(:static_pipelines) { Dir["#{@root_dir}/concourse/pipelines/*.yml"] }
+    let(:template_pipelines) { Dir["#{@root_dir}/concourse/pipelines/template/*.erb"] }
+    let(:expected_pipelines) { static_pipelines.concat(templated_pipelines).sort }
+    let(:generated_pipeline_filenames) { Dir["#{@result_dir}/concourse/pipelines/*.yml"] }
+
+    before(:context) do
+      @root_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..'))
+      reference_dataset = File.join(@root_dir, 'docs','reference_dataset')
+      reference_dataset_template = File.join(reference_dataset, 'template_repository')
+      reference_dataset_secrets = File.join(reference_dataset, 'config_repository')
+      @templates_dir =  Dir.mktmpdir
+      @secrets_dir = Dir.mktmpdir
+      @result_dir = Dir.mktmpdir
+
+      FileUtils.cp_r(File.join(reference_dataset_template, '.'), @templates_dir)
+      FileUtils.cp_r(File.join(reference_dataset_secrets, '.'), @secrets_dir)
+
+      @output = execute('-c concourse/tasks/generate_depls/task.yml ' \
+        '-i scripts-resource=. ' \
+        "-i templates=#{@templates_dir} " \
+        "-i secrets=#{@secrets_dir} " \
+        "-o result-dir=#{@result_dir} ",
+                        'ROOT_DEPLOYMENT' => 'hello-world-root-depls',
+                        'IAAS_TYPE' => 'task-iaas')
+    end
+
+    after(:context) do
+      FileUtils.rm_rf @templates_dir
+      FileUtils.rm_rf @secrets_dir
+      FileUtils.rm_rf @result_dir
+    end
+
+    it 'does not generate errors' do
+      expect(File).not_to exist(File.join(@result_dir, 'error.log'))
+    end
+
+    it 'generates expected pipelines' do
+      expect(@output.scan(/^processing ..concourse.pipelines.template.*\w+/).length).to eq(template_pipelines.length)
+    end
+
+    it 'runs successfully' do
+      expect(@output).to end_with("succeeded\n")
+    end
+  end
+
+  context 'when environment variables are missing' do
+
+    before(:context) do
+      @templates_dir =  Dir.mktmpdir
+      @secrets_dir = Dir.mktmpdir
+      @result_dir = Dir.mktmpdir
+      @output = execute('-c concourse/tasks/generate_depls/task.yml ' \
+        '-i scripts-resource=. ' \
+        "-i templates=#{@templates_dir} " \
+        "-i secrets=#{@secrets_dir} " \
+        "-o result-dir=#{@result_dir} ",
+                        'IAAS_TYPE' => '')
+    end
+
+    after(:context) do
+      FileUtils.rm_rf @templates_dir
+      FileUtils.rm_rf @secrets_dir
+      FileUtils.rm_rf @result_dir
+    end
+
+    it 'fails' do
+      expect(@output).to end_with("failed\n")
+    end
+
+    it 'contains error messages' do
+      missing_vars = @output.scan(/^ERROR: missing environment variable:.*\w+/)
+
+      expect(missing_vars).to include('ERROR: missing environment variable: ROOT_DEPLOYMENT').and \
+          include('ERROR: missing environment variable: IAAS_TYPE')
+    end
+  end
+end

--- a/spec/tasks/git_reset_wip/task_spec.rb
+++ b/spec/tasks/git_reset_wip/task_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 # require 'spec_helper.rb'
 require 'yaml'
 require 'tmpdir'
@@ -16,17 +17,15 @@ describe 'git_reset_wip task' do
     FileUtils.rm_rf @git_test_reference_repo
   end
 
-
   context 'when executed with develop as base branch' do
-
     before(:context) do
       @updated_git_resource = Dir.mktmpdir
 
       @output = execute('--include-ignored -c concourse/tasks/git_reset_wip.yml ' \
         '-i reference-resource=spec/tasks/git_reset_wip/reference-resource ' \
         "-o updated-git-resource=#{@updated_git_resource} ",
-        'SKIP_SSL_VERIFICATION' =>'true',
-        'GIT_BRANCH_FILTER' => '"WIP-* wip-* feature-* Feature-*"')
+                        'SKIP_SSL_VERIFICATION' => 'true',
+                        'GIT_BRANCH_FILTER' => '"WIP-* wip-* feature-* Feature-*"')
     end
 
     after(:context) do
@@ -36,17 +35,15 @@ describe 'git_reset_wip task' do
     it 'only merges branches matching filter' do
       expect(@output).to include('Processing wip-1').and \
         include('Processing WIP-2').and \
-        include('Processing feature-1').and \
-        include('Processing Feature-2').and \
-        include("Switched to a new branch 'develop'")
+          include('Processing feature-1').and \
+            include('Processing Feature-2').and \
+              include("Switched to a new branch 'develop'")
     end
 
     %w[develop feature-1 Feature-2 wip-1 WIP-2].each do |merged_file|
       it "contains #{merged_file} file" do
         expect(File).to exist(File.join(@updated_git_resource, "#{merged_file}.md"))
       end
-
-
     end
 
     it 'does not contain files from a-branch' do
@@ -62,11 +59,9 @@ describe 'git_reset_wip task' do
         expect(@output).to include('Skipping ssl verification')
       end
     end
-
   end
 
   context 'when executed with master as base branch' do
-
     before(:context) do
       @updated_git_resource = Dir.mktmpdir
 
@@ -88,7 +83,5 @@ describe 'git_reset_wip task' do
     it 'contains master.md file' do
       expect(File).to exist(File.join(@updated_git_resource, 'master.md'))
     end
-
   end
-
 end

--- a/spec/tasks/list_used_ci_team/task_spec.rb
+++ b/spec/tasks/list_used_ci_team/task_spec.rb
@@ -41,7 +41,7 @@ describe 'list_used_ci_team task' do
               team: my-custom-team-2
               vars_files:
               - micro-depls/concourse-micro/pipelines/credentials-git-config.yml
-              - micro-depls/concourse-micro/pipelines/credentials-mattermost-certs.yml
+              - micro-depls/concourse-micro/pipelines/credentials-iaas-specific.yml
             ops-depls-s3-br-upload-generated:
               team: my-custom-team-1
               vars_files:

--- a/upgrade/v2.0.0/01-upgrade-paas-template.rb
+++ b/upgrade/v2.0.0/01-upgrade-paas-template.rb
@@ -1,33 +1,16 @@
 #!/usr/bin/env ruby
 require 'yaml'
-require 'optparse'
 require_relative '../../lib/deployment_deployers_config'
+require_relative '../../lib/coa_upgrader'
 
-# Argument parsing
-options = {
-  ops_automation: '.',
+OPTIONS = {
   dump_output: true,
-  paas_template_root: '../paas-templates'
-}
+  config_path: '',
+  templates_path: '../paas-templates'
+}.freeze
 
-opt_parser = OptionParser.new do |opts|
-  opts.banner = "Incomplete/wrong parameter(s): #{opts.default_argv}.\n Usage: ./#{opts.program_name} <options>"
-
-  opts.on('-t', '--templates-path PATH', "paas-templates location (main git directory). Default: #{options[:paas_template_root]}") do |tp_string|
-    options[:paas_template_root] = tp_string
-  end
-
-  opts.on('-a', '--automation-path PATH', 'Base location for cf-ops-automation') do |ap_string|
-    options[:ops_automation] = ap_string
-  end
-
-  opts.on('--[no-]dump', 'Dump genereted file on standart output') do |dump|
-    options[:dump_output] = dump
-  end
-end
-opt_parser.parse!
-
-paas_template_root = options[:paas_template_root]
+options = CoaUpgrader::CommandLineParser.new(OPTIONS.dup).parse
+paas_template_root = options[:templates_path]
 
 raise "invalid paas_template_root: <#{paas_template_root}> does not exist" unless Dir.exist?(paas_template_root)
 

--- a/upgrade/v3.0.0/01-upgrade-config.rb
+++ b/upgrade/v3.0.0/01-upgrade-config.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require 'yaml'
+require_relative '../../lib/deployment_deployers_config'
+require_relative '../../lib/coa_upgrader'
+
+options = CoaUpgrader::CommandLineParser.new.parse
+
+config_path = options[:config_path]
+
+raise "invalid config_path: <#{config_path}> does not exist" unless Dir.exist?(config_path)
+
+def insert_iaas_specific_pipeline(ci_deployment_overview)
+  migrated = false
+  ci_deployment_overview['ci-deployment']&.each do |_, details|
+    details['pipelines']&.each do |name, pipeline_config|
+      if name.end_with?('-init-generated')
+        unless pipeline_config['vars_files'].include?('micro-depls/concourse-micro/pipelines/credentials-iaas-specific.yml')
+          pipeline_config['vars_files'] << 'micro-depls/concourse-micro/pipelines/credentials-iaas-specific.yml'
+          migrated = true
+        end
+      end
+    end
+  end
+  migrated
+end
+
+def insert_iaas_specific_into_init_pipeline_config(ci_deployment_overview_files)
+  migrated_counter = 0
+  ci_deployment_overview_files&.each do |ci_deployment_filename|
+    ci_deployment = YAML.load_file(ci_deployment_filename)
+    unless ci_deployment
+      puts "*** ignoring file: #{ci_deployment_filename} - invalid format"
+      next
+    end
+    # puts "original #{ci_deployment_filename}: #{deployment_dependencies}"
+
+    if insert_iaas_specific_pipeline(ci_deployment)
+      migrated_counter += 1
+      puts "migrated #{ci_deployment_filename}"
+    end
+    File.open(ci_deployment_filename, 'w') { |file| file.write ci_deployment.to_yaml }
+    puts '#########'
+  end
+  migrated_counter
+end
+
+puts "scanning for ci-deployment-overview in #{config_path}"
+
+selected_ci_deployment_overview_files = Dir["#{config_path}/**/ci-deployment-overview.yml"]
+
+migrated_ci_deployment_overview_counter = insert_iaas_specific_into_init_pipeline_config(selected_ci_deployment_overview_files)
+
+puts
+puts 'Summary:'
+puts "  #{migrated_ci_deployment_overview_counter}/#{selected_ci_deployment_overview_files.length} ci-deployment-overview.yml migrated"
+puts
+
+puts 'please review the changes applied and commit/push'
+puts 'Thanks, Orange CloudFoundry SKC'


### PR DESCRIPTION
Fixes #89.

Changes proposed in this pull-request:
    add coa-upgrade task to ease COA upgrade. We update migration scripts to
    support same parameters. We copy deep_merge function from active_support
    lib to avoid extra lib
    requirements for generate-depls script (no gem install required).
    update bootstrap scripts to handle `iaas-type`
    update generate-depls script to include an option to set iaas-type. By
    default, it scans for an 'openstack' iaas. We use the `((iaas-type))`
    and we inject it as script parameter.