### PR TITLE
pipeline(*): introduce concurrent update limitations

### DIFF
--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -24,6 +24,8 @@
 
   offline_stemcells_enabled = config['offline-mode'] && config['offline-mode']['stemcells'] && true
   jobs = Hash.new {|h,k| h[k]=[]}
+  parallel_execution_limit= config['default']&.fetch('concourse', nil)&.fetch('parallel_execution_limit',0)
+  enabled_parallel_execution_limit = !(parallel_execution_limit.nil? || parallel_execution_limit == 0)
 %>
 
 ---
@@ -461,11 +463,12 @@ jobs:
               rebase: true
 
 <% enabled_deployments.sort.each do |name, boshrelease| %>
-
+<% current_serial_group = "concurrent-group-#{enabled_deployments.length % parallel_execution_limit}" %>
 
 - name: deploy-<%= name %>
   <% jobs["deploy-#{name[0]}*"] << "deploy-#{name}" %>
   serial: true
+  <%= "serial_groups: [#{current_serial_group}]" if enabled_parallel_execution_limit%>
   on_failure:
     put: failure-alert
     params:

--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -1,3 +1,9 @@
+<%
+  require './lib/pipeline_helpers'
+
+  parallel_execution_limit = PipelineHelpers.parallel_execution_limit(config)
+  enabled_parallel_execution_limit = PipelineHelpers.enabled_parallel_execution_limit?(config)
+%>
 ---
 resource_types:
   - name: slack-notification
@@ -103,9 +109,12 @@ jobs:
 <% end %>
 
 <% all_cf_apps.sort.each do |app_name,cf_app_info| %>
+<% current_serial_group = "concurrent-group-#{all_cf_apps.length % parallel_execution_limit}" %>
+
 - name: cf-push-<%= app_name %>
 <% jobs["app-#{app_name[0]}*"] << "cf-push-#{app_name}" %>
   serial: true
+  <%= "serial_groups: [#{current_serial_group}]" if enabled_parallel_execution_limit%>
   on_failure:
     put: failure-alert
     params:

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -24,6 +24,9 @@
 
   offline_stemcells_enabled = config['offline-mode'] && config['offline-mode']['stemcells'] && true
   jobs = Hash.new {|h,k| h[k]=[]}
+
+  parallel_execution_limit = PipelineHelpers.parallel_execution_limit(config)
+  enabled_parallel_execution_limit = PipelineHelpers.enabled_parallel_execution_limit?(config)
 %>
 
 ---
@@ -481,9 +484,11 @@ jobs:
               rebase: true
 
 <% enabled_deployments.sort.each do |name, boshrelease| %>
+  <% current_serial_group = "concurrent-group-#{enabled_deployments.length % parallel_execution_limit}" %>
 - name: deploy-<%= name %>
   <% jobs["deploy-#{name[0]}*"] << "deploy-#{name}" %>
   serial: true
+  <%= "serial_groups: [#{current_serial_group}]" if enabled_parallel_execution_limit%>
   on_failure:
     put: failure-alert
     params:

--- a/concourse/pipelines/template/news-pipeline.yml.erb
+++ b/concourse/pipelines/template/news-pipeline.yml.erb
@@ -1,4 +1,6 @@
 <%
+  require './lib/pipeline_helpers'
+
   enabled_deployments = all_dependencies.select do |_,deployment_infos|
     deployment_infos['status'] == 'enabled'
   end
@@ -8,7 +10,11 @@
     boshrelease["releases"]&.each do |release, info|
       uniq_releases[release] = info
     end
+
   end
+
+  parallel_execution_limit = PipelineHelpers.parallel_execution_limit(config)
+  enabled_parallel_execution_limit = PipelineHelpers.enabled_parallel_execution_limit?(config)
 %>
 ---
 resource_types:
@@ -95,7 +101,9 @@ jobs:
 - name: this-is-an-empty-pipeline
 <% else %>
   <% uniq_releases.sort.each do |release, info| %>
+  <% current_serial_group = "concurrent-group-#{uniq_releases.length % parallel_execution_limit}" %>
 - name: check-<%= release %>
+  <%= "serial_groups: [#{current_serial_group}]" if enabled_parallel_execution_limit%>
   on_failure:
     put: failure-alert
     params:

--- a/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
@@ -7,6 +7,9 @@
       uniq_releases[release] = info
     end
   end
+
+  parallel_execution_limit = PipelineHelpers.parallel_execution_limit(config)
+  enabled_parallel_execution_limit = PipelineHelpers.enabled_parallel_execution_limit?(config)
 %>
 
 ---
@@ -120,8 +123,10 @@ jobs:
       FLY_TEAM: <%= current_team || 'main' %>
 
 <% uniq_releases.sort.each do |release, info|  %>
+
+  <% current_serial_group = "concurrent-group-#{uniq_releases.length % parallel_execution_limit}" %>
 - name: upload-current-<%= release %>
-  serial_groups: [<%= release %>]
+  serial_groups: [<%= release %><%= ",#{current_serial_group}" if enabled_parallel_execution_limit%>]
   on_failure:
     put: failure-alert
     params:
@@ -175,7 +180,7 @@ jobs:
         acl: public-read
 
 - name: upload-latest-<%= release %>
-  serial_groups: [<%= release %>]
+  serial_groups: [<%= release %><%= ",#{current_serial_group}" if enabled_parallel_execution_limit%>]
   on_failure:
     put: failure-alert
     params:

--- a/docs/reference_dataset/config_repository/private-config.yml
+++ b/docs/reference_dataset/config_repository/private-config.yml
@@ -7,3 +7,5 @@
 #default:
 #  stemcell:
 #    name: bosh-openstack-kvm-ubuntu-trusty-go_agent  # Default: bosh-openstack-kvm-ubuntu-trusty-go_agent
+#  concourse:
+#    parrallel_execution_limit: 5 # Default: -1, ie unlimited

--- a/docs/reference_dataset/template_repository/shared-config.yml
+++ b/docs/reference_dataset/template_repository/shared-config.yml
@@ -7,3 +7,5 @@ offline-mode:
 default:
   stemcell:
     name: bosh-openstack-kvm-ubuntu-trusty-go_agent  # Default: bosh-openstack-kvm-ubuntu-trusty-go_agent
+  concourse:
+    parrallel_execution_limit: 5 # Default: -1, ie unlimited

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -7,7 +7,10 @@ require_relative 'extended_config'
 # an extended configuration (based on environment variables)
 class Config
   DEFAULT_STEMCELL = 'bosh-openstack-kvm-ubuntu-trusty-go_agent'.freeze
-
+  CONFIG_DEFAULT_KEY = 'default'.freeze
+  CONFIG_CONCOURSE_KEY = 'concourse'.freeze
+  CONFIG_PARALLEL_EXECUTION_LIMIT_KEY = 'parallel_execution_limit'.freeze
+  DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT = 5
   attr_reader :loaded_config
 
   def initialize(public_yaml_location = '', private_yaml_location = '', extended_config = ExtendedConfigBuilder.new.build)
@@ -25,7 +28,8 @@ class Config
         'docker-images' => false
       },
       'default' => {
-        'stemcell' => { 'name' => DEFAULT_STEMCELL }
+        'stemcell' => { 'name' => DEFAULT_STEMCELL },
+        'concourse' => { 'parallel_execution_limit' => DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT }
       }
     }.deep_merge(@extended_config.default_config)
   end

--- a/lib/pipeline_helpers.rb
+++ b/lib/pipeline_helpers.rb
@@ -1,9 +1,22 @@
 module PipelineHelpers
+  require_relative 'config'
+
   TERRAFORM_CONFIG_DIRNAME_KEY = 'terraform_config'.freeze
 
   class << self
     def bosh_io_hosted?(info)
       info["base_location"]&.include?("bosh.io")
+    end
+
+    def parallel_execution_limit(config)
+      unlimited_execution = -1
+      result = config.fetch(Config::CONFIG_DEFAULT_KEY, nil)&.fetch(Config::CONFIG_CONCOURSE_KEY, nil)&.fetch(Config::CONFIG_PARALLEL_EXECUTION_LIMIT_KEY, unlimited_execution)
+      result = unlimited_execution if result.nil?
+      result
+    end
+
+    def enabled_parallel_execution_limit?(config)
+      parallel_execution_limit(config) != -1
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -18,6 +18,9 @@ describe Config do
         'iaas' => 'my_custom_iaas',
         'stemcell' => {
           'name' => 'bosh-openstack-kvm-ubuntu-trusty-go_agent'
+        },
+        'concourse' => {
+          'parallel_execution_limit' => 5
         }
       }
     }

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -105,6 +105,7 @@ jobs:
 
 - name: cf-push-test-app
   serial: true
+  serial_groups: [concurrent-group-1]
   on_failure:
     put: failure-alert
     params:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
@@ -54,6 +54,7 @@ resources:
 jobs:
 
 - name: check-ntp_boshrelease
+  serial_groups: [concurrent-group-1]
   on_failure:
     put: failure-alert
     params:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -351,6 +351,7 @@ jobs:
 
 - name: deploy-ntp
   serial: true
+  serial_groups: [concurrent-group-1]
   on_failure:
     put: failure-alert
     params:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
@@ -92,6 +92,7 @@ jobs:
 - name: upload-current-ntp_boshrelease
   serial_groups:
   - ntp_boshrelease
+  - concurrent-group-1
   on_failure:
     put: failure-alert
     params:
@@ -146,6 +147,7 @@ jobs:
 - name: upload-latest-ntp_boshrelease
   serial_groups:
   - ntp_boshrelease
+  - concurrent-group-1
   on_failure:
     put: failure-alert
     params:


### PR DESCRIPTION
Fixes #184 

Changes proposed in this pull-request:
to reduce overload and cascading failures on main changes, we split jobs
 in serials group. The number of serials group is the maximum job
 concurrency we can have. Two jobs in the same serial group cannot be
 run in parralel.Set it to -1 to be 'unlimited'. Update 'shared-config.yml'
 or 'private-config.yml' to adjust the value.