### PR TITLE
Fix bootstrap failure on update-pipeline

### DIFF
--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -82,12 +82,13 @@ jobs:
       params: { submodules: none}
       passed: [ create-teams ]
       trigger: true
-  - task: generate-all-pipelines
+  - task: generate-all-init-pipelines
     input_mapping: {scripts-resource: cf-ops-automation,templates-resource: paas-templates-full,secrets-resource: secrets-full}
     output_mapping: {result-dir: all-pipelines}
     file: cf-ops-automation/concourse/tasks/generate-all-pipelines.yml
     params:
       IAAS_TYPE: ((iaas-type))
+      PIPELINE_TYPES: init
   - task: set-all-init-pipelines
     input_mapping: {scripts-resource: cf-ops-automation,templates-resource: paas-templates-full,secrets-resource: secrets-full, pipelines-resource: all-pipelines}
     file: cf-ops-automation/concourse/tasks/bootstrap_init_pipelines.yml
@@ -95,6 +96,7 @@ jobs:
       ATC_EXTERNAL_URL: ((concourse-micro-depls-target))
       FLY_USERNAME: ((concourse-micro-depls-username))
       FLY_PASSWORD: "((concourse-micro-depls-password))"
+      COA_CONFIG_MODE: --no-use-coa-config
   - task: generate-flight-plan
     output_mapping: {result-dir: initialized-flight-plan}
     config:
@@ -113,11 +115,11 @@ jobs:
         - |
           DEST_DIR=$(pwd)/result-dir
           cd all-pipelines/pipelines
-          for aFile in $(ls *init-generated.yml)
-          do
-          PIPELINE=$(basename ${aFile} .yml)
-          DEPLS=${PIPELINE%%-init-generated}
-          echo "trigger-job -j ${PIPELINE}/update-pipeline-${DEPLS}"  >> ${DEST_DIR}/flight-plan
+          for aFile in $(ls *init-generated.yml);do
+            echo "Processing ${aFile}"
+            PIPELINE=$(basename ${aFile} .yml)
+            DEPLS=${PIPELINE%%-init-generated}
+            echo "trigger-job -j ${PIPELINE}/update-pipeline-${DEPLS}"  >> ${DEST_DIR}/flight-plan
           done
           echo "Flight plan:"
           cat ${DEST_DIR}/flight-plan
@@ -352,55 +354,21 @@ jobs:
       params: { submodules: none}
       passed: [ create-teams ]
       trigger: true
-  - task: generate-all-pipelines
+  - task: generate-all-update-pipelines
     input_mapping: {scripts-resource: cf-ops-automation,templates-resource: paas-templates-full,secrets-resource: secrets-full}
     output_mapping: {result-dir: all-pipelines}
     file: cf-ops-automation/concourse/tasks/generate-all-pipelines.yml
     params:
       IAAS_TYPE: ((iaas-type))
+      PIPELINE_TYPES: update
   - task: set-all-update-pipelines
     input_mapping: {scripts-resource: cf-ops-automation,templates-resource: paas-templates-full,secrets-resource: secrets-full, pipelines-resource: all-pipelines}
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source: {repository: ruby, tag: 2.3.1}
-      inputs:
-      - name: scripts-resource
-      - name: pipelines-resource
-      - name: secrets-resource
-      - name: templates-resource
-      run:
-        path: sh
-        args:
-        - -ec
-        - |
-          mkdir -p /usr/local/bin
-          FLY=/usr/local/bin/fly
-
-          echo "Fetching fly...";
-          curl -SsL -u "$FLY_USERNAME:$FLY_PASSWORD" "$ATC_EXTERNAL_URL/api/v1/cli?arch=amd64&platform=linux" -k > $FLY;
-          chmod +x $FLY;
-
-          fly login -t main -c "$ATC_EXTERNAL_URL" --username="$FLY_USERNAME" --password="$FLY_PASSWORD" -k 2>&1
-          export TARGET_NAME=main
-          export SECRETS=$(pwd)/secrets-resource
-          export PAAS_TEMPLATES=$(pwd)/templates-resource
-          export PIPELINES_DIR=$(pwd)/pipelines-resource/pipelines
-          cd scripts-resource
-          DYNAMIC_DEPLS_FILE_LIST=$(cd $SECRETS && find . -maxdepth 1 -type d -name "*-depls")
-          for i in $DYNAMIC_DEPLS_FILE_LIST;
-          do
-          export DYNAMIC_DEPLS_LIST="$DYNAMIC_DEPLS_LIST $(basename $i)"
-          done
-          export DEPLS_LIST="${DEPLS_LIST:-${DYNAMIC_DEPLS_LIST}}"
-          for depls in ${DEPLS_LIST};do
-          ./scripts/concourse-manual-pipelines-update.rb -d ${depls} --no-interactive -t update
-          done
+    file: cf-ops-automation/concourse/tasks/bootstrap_init_pipelines.yml
     params:
       ATC_EXTERNAL_URL: ((concourse-micro-depls-target))
       FLY_USERNAME: ((concourse-micro-depls-username))
       FLY_PASSWORD: "((concourse-micro-depls-password))"
+      PIPELINE_TYPE: update
   - task: generate-flight-plan
     output_mapping: {result-dir: initialized-flight-plan}
     config:
@@ -419,12 +387,11 @@ jobs:
         - |
           DEST_DIR=$(pwd)/result-dir
           cd all-pipelines/pipelines
-          for aFile in $(ls *update-generated.yml)
-          do
-          echo "Processing ${aFile}"
-          PIPELINE=$(basename ${aFile} .yml)
-          DEPLS=${PIPELINE%%-init-generated}
-          echo "trigger-job -j ${PIPELINE}/update-pipeline-${DEPLS}"  >> ${DEST_DIR}/flight-plan
+          for aFile in $(ls *update-generated.yml);do
+            echo "Processing ${aFile}"
+            PIPELINE=$(basename ${aFile} .yml)
+            DEPLS=${PIPELINE%%-update-generated}
+            echo "trigger-job -j ${PIPELINE}/update-pipeline-${DEPLS}"  >> ${DEST_DIR}/flight-plan
           done
           cat ${DEST_DIR}/flight-plan
       params:

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -905,11 +905,6 @@ jobs:
 <% end %>
 
 <% if all_ci_deployments.any? %>
-  <% current_depls_generated = all_ci_deployments[depls]["pipelines"]["#{depls}-generated"] || all_ci_deployments[depls]["pipelines"].to_a[0][1] %>
-  <% raise "invalid ci-deployment-overview.yml. Missing key [#{depls}][pipelines][#{depls}-generated]" unless current_depls_generated %>
-  <% current_cf_apps_generated= all_ci_deployments[depls]["pipelines"]["#{depls}-cf-apps-generated"] || all_ci_deployments[depls]["pipelines"].to_a[1][1] %>
-  <% raise "invalid ci-deployment-overview.yml. Missing key [#{depls}][pipelines][#{depls}-cf-apps-generated]" unless current_cf_apps_generated %>
-
   <% if all_ci_deployments[depls][PipelineHelpers::TERRAFORM_CONFIG_DIRNAME_KEY] %>
     <% raise "invalid ci-deployment-overview.yml. Missing key [#{depls}][#{PipelineHelpers::TERRAFORM_CONFIG_DIRNAME_KEY}][state_file_path] or delete terraform-config key." if terraform_config_path.nil? %>
 - name: check-terraform-consistency

--- a/concourse/pipelines/template/init-pipeline.yml.erb
+++ b/concourse/pipelines/template/init-pipeline.yml.erb
@@ -97,10 +97,11 @@ jobs:
       pipelines:
       <% all_ci_deployments[depls]["pipelines"].each do |pipeline_name,pipeline_details| %>
       - name: <%= pipeline_name %>
-        team: <%= pipeline_details['team'] || 'main' %>
+        team: <%= (pipeline_details && pipeline_details['team']) || 'main' %>
         config_file: concourse-<%= depls %>-pipeline/concourse/pipelines/<%= pipeline_name %>.yml
         vars_files:
-        <% pipeline_details["vars_files"].each do |vars_file| %>
+        <% next unless pipeline_details %>
+        <% pipeline_details["vars_files"]&.each do |vars_file| %>
         # trick to manage <depls>-versions.yml (not included in secrets)
         <%= "- secrets-full/#{vars_file}" unless vars_file.end_with?("-versions.yml") %>
         <%= "- paas-templates-full/#{vars_file}" if vars_file.end_with?("-versions.yml") %>

--- a/concourse/pipelines/template/update-pipeline.yml.erb
+++ b/concourse/pipelines/template/update-pipeline.yml.erb
@@ -96,6 +96,7 @@ jobs:
     params:
       ROOT_DEPLOYMENT: <%= depls %>
       IAAS_TYPE: ((iaas-type))
+      EXCLUDE_PIPELINES: depls
   - task: copy-and-filter-generated-pipeline
     input_mapping: {templates: paas-templates-<%= depls %>,config: secrets-<%= depls %>-for-pipeline}
     config:
@@ -114,7 +115,7 @@ jobs:
         args:
         - -ec
         - |
-          ruby -ryaml -rfileutils -e 'depls = ENV["ROOT_DEPLOYMENT"]; ci_overview_file = File.join("config",depls ,"ci-deployment-overview.yml"); raise "ERROR - Missing file : #{ci_overview_file}" unless File.exist?(ci_overview_file); ci_overview=YAML.load_file(ci_overview_file);ci_overview["ci-deployment"][depls]["pipelines"].each { |pipeline_name,pipeline_details| team = pipeline_details["team"] || "main"; pipeline_dest_dir = File.join("selected-pipelines", team, depls);FileUtils.mkdir_p(pipeline_dest_dir); pipeline_filename = File.join("concourse-generated-pipeline","concourse","pipelines","#{pipeline_name}.yml"); FileUtils.cp(pipeline_filename, pipeline_dest_dir)}'
+          ruby -ryaml -rfileutils -e 'depls = ENV["ROOT_DEPLOYMENT"]; ci_overview_file = File.join("config",depls ,"ci-deployment-overview.yml"); raise "ERROR - Missing file : #{ci_overview_file}" unless File.exist?(ci_overview_file); ci_overview=YAML.load_file(ci_overview_file);ci_overview["ci-deployment"][depls]["pipelines"].each { |pipeline_name,pipeline_details| team = (pipeline_details && pipeline_details["team"]) || "main"; pipeline_dest_dir = File.join("selected-pipelines", team, depls);FileUtils.mkdir_p(pipeline_dest_dir); pipeline_filename = File.join("concourse-generated-pipeline","concourse","pipelines","#{pipeline_name}.yml"); FileUtils.cp(pipeline_filename, pipeline_dest_dir)}'
           echo "Filtering pipelines:"
           ruby -ryaml -rfileutils -e 'Dir[File.join("selected-pipelines","**","*.yml")].each { |file_path| file_content = YAML.load_file(file_path); if file_content["jobs"]&.fetch(0)&.fetch("name") == "this-is-an-empty-pipeline"; puts " deleting empty pipeline: #{file_path}";FileUtils.rm(file_path);else puts " keeping #{file_path}";end}'
 

--- a/concourse/tasks/bootstrap_init_pipelines.yml
+++ b/concourse/tasks/bootstrap_init_pipelines.yml
@@ -27,7 +27,7 @@ inputs:
 run:
   path: sh
   args:
-  - -exc
+  - -ec
   - |
     mkdir -p /usr/local/bin
     FLY=/usr/local/bin/fly
@@ -49,7 +49,7 @@ run:
     done
     export DEPLS_LIST="${DEPLS_LIST:-${DYNAMIC_DEPLS_LIST}}"
     for depls in ${DEPLS_LIST};do
-    ./scripts/concourse-manual-pipelines-update.rb -d ${depls} --no-interactive -t ${PIPELINE_TYPE}
+    ./scripts/concourse-manual-pipelines-update.rb -d ${depls} --no-interactive -t ${PIPELINE_TYPE} ${COA_CONFIG_MODE}
     done
 
 params:
@@ -58,6 +58,7 @@ params:
   FLY_PASSWORD:
   DEPLS_LIST:
   PIPELINE_TYPE: init
+  COA_CONFIG_MODE:
 
 
 

--- a/concourse/tasks/generate-all-pipelines.yml
+++ b/concourse/tasks/generate-all-pipelines.yml
@@ -23,3 +23,4 @@ run:
     du -a ../result-dir
 params:
   IAAS_TYPE:
+  PIPELINE_TYPE:

--- a/concourse/tasks/generate_depls/run.sh
+++ b/concourse/tasks/generate_depls/run.sh
@@ -33,11 +33,18 @@ then
     exit 1
 fi
 
+if [ -n "${EXCLUDE_PIPELINES}" ]
+then
+   echo "Excluding pipeline templates matching ${EXCLUDE_PIPELINES}"
+   PIPELINES_RESTRICTIONS="--exclude ${EXCLUDE_PIPELINES}"
+fi
+
+
 cp -r templates/. result-dir
 cp -r scripts-resource/. result-dir
 cp -rf secrets/. result-dir
 cd result-dir
-./scripts/generate-depls.rb --depls "${ROOT_DEPLOYMENT}" -t ../templates -p . -o concourse --iaas "${IAAS_TYPE}" > >(tee generate-depls.log) 2> >(tee -a error.log >&2) # tee generate-depls.log
+./scripts/generate-depls.rb --depls "${ROOT_DEPLOYMENT}" -t ../templates -p . -o concourse --iaas "${IAAS_TYPE}" $PIPELINES_RESTRICTIONS > >(tee generate-depls.log) 2> >(tee -a error.log >&2) # tee generate-depls.log
 if [ -s 'error.log' ]; then
     cat error.log
     exit 1

--- a/concourse/tasks/generate_depls/task.yml
+++ b/concourse/tasks/generate_depls/task.yml
@@ -27,3 +27,4 @@ run:
 params:
   ROOT_DEPLOYMENT:
   IAAS_TYPE: ((iaas-type))
+  EXCLUDE_PIPELINES:

--- a/concourse/tasks/list_used_ci_team/run.rb
+++ b/concourse/tasks/list_used_ci_team/run.rb
@@ -4,7 +4,6 @@
 task_root_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..'))
 require "#{task_root_dir}/cf-ops-automation/lib/ci_deployment"
 ci_overview = CiDeployment.new(File.join(ENV.fetch('SECRETS_PATH', 'secrets'), '*-depls')).overview
-
 result = CiDeployment.teams(ci_overview)
 
 output_dir = 'ci-deployment-overview'.freeze

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -9,6 +9,7 @@ class Config
   DEFAULT_STEMCELL = 'bosh-openstack-kvm-ubuntu-trusty-go_agent'.freeze
   CONFIG_DEFAULT_KEY = 'default'.freeze
   CONFIG_CONCOURSE_KEY = 'concourse'.freeze
+  CONFIG_STEMCELL_KEY = 'stemcell'.freeze
   CONFIG_PARALLEL_EXECUTION_LIMIT_KEY = 'parallel_execution_limit'.freeze
   DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT = 5
   attr_reader :loaded_config
@@ -27,9 +28,9 @@ class Config
         'stemcells' => true,
         'docker-images' => false
       },
-      'default' => {
-        'stemcell' => { 'name' => DEFAULT_STEMCELL },
-        'concourse' => { 'parallel_execution_limit' => DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT }
+      CONFIG_DEFAULT_KEY => {
+        CONFIG_STEMCELL_KEY => { 'name' => DEFAULT_STEMCELL },
+        CONFIG_CONCOURSE_KEY => { CONFIG_PARALLEL_EXECUTION_LIMIT_KEY => DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT }
       }
     }.deep_merge(@extended_config.default_config)
   end

--- a/lib/pipeline_helpers.rb
+++ b/lib/pipeline_helpers.rb
@@ -20,10 +20,31 @@ module PipelineHelpers
       parallel_execution_limit(config, root_deployment_name) != UNLIMITED_EXECUTION
     end
 
+    def generate_vars_files(templates_dir, config_dir, pipeline_name, root_deployment)
+      vars_files = Dir[File.join(config_dir, 'credentials-*.yml')].reject { |file_path| filter_credentials_file(file_path) }
+      current_pipeline_config_file = generate_pipeline_credentials_filename(config_dir, pipeline_name)
+      puts "INFO - checking existence of #{current_pipeline_config_file}"
+      vars_files << current_pipeline_config_file if File.exist?(current_pipeline_config_file)
+      versions_file = File.join(templates_dir, root_deployment, "#{root_deployment}-versions.yml")
+      raise "Missing version file: #{versions_file}" unless File.exist?(versions_file)
+      vars_files << versions_file
+      vars_files
+    end
+
     private
+
+    def generate_pipeline_credentials_filename(config_dir, pipeline_name)
+      config_file_suffix = pipeline_name.gsub('-generated', '')
+      config_file_suffix += '-pipeline' unless config_file_suffix.end_with?('-pipeline')
+      File.join(config_dir, "credentials-#{config_file_suffix}.yml")
+    end
 
     def extract_parallel_execution_limit(config, root_deployment_name)
       config.fetch(root_deployment_name, nil)&.fetch(Config::CONFIG_CONCOURSE_KEY, nil)&.fetch(Config::CONFIG_PARALLEL_EXECUTION_LIMIT_KEY, UNLIMITED_EXECUTION)
+    end
+
+    def filter_credentials_file(file_path)
+      File.basename(file_path).include?('pipeline') || File.basename(file_path).include?('generated')
     end
   end
 end

--- a/scripts/concourse-generate-all-pipelines.sh
+++ b/scripts/concourse-generate-all-pipelines.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
-SECRETS=${SECRETS:-../preprod-secrets}
+SECRETS=${SECRETS:-../int-secrets}
 TEMPLATES=${TEMPLATES:-../paas-templates}
 DYNAMIC_DEPLS_FILE_LIST=$(cd $SECRETS && find . -maxdepth 1 -type d -name "*-depls")
-for i in $DYNAMIC_DEPLS_FILE_LIST;
+for i in ${DYNAMIC_DEPLS_FILE_LIST};
 do
  export DYNAMIC_DEPLS_LIST="$DYNAMIC_DEPLS_LIST $(basename $i)"
 done
@@ -19,6 +19,7 @@ usage(){
     echo -e "\t TEMPLATES: path to paas-templates directory. DEFAULT: $TEMPLATES " 1>&2
     echo -e "\t DEPLS_LIST: deployments to process. DEFAULT: [$DYNAMIC_DEPLS_LIST] " 1>&2
     echo -e "\t OUTPUT_DIR: pipeline generation directory. DEFAULT: [./bootstrap-generated] " 1>&2
+    echo -e "\t PIPELINE_TYPES: only generate this pipeline. DEFAULT: ALL_PIPELINES " 1>&2
     exit 1
 }
 
@@ -50,10 +51,18 @@ then
 fi
 mkdir -p ${OUTPUT_DIR}/pipelines
 
+if [ -n "${PIPELINE_TYPES}" ]
+then
+   echo "Only generating pipelines matching ${PIPELINE_TYPES}"
+   PIPELINES_RESTRICTION="--input ${PIPELINE_TYPES}"
+else
+    echo "No PIPELINE_TYPES detected"
+fi
+
 echo "Generating pipelines using secrets in $SECRET_DIR to ${OUTPUT_DIR}/pipelines for ${IAAS_TYPE} (Iaas Type)"
 for depls in ${DEPLS_LIST};do
-    "${CURRENT_SCRIPT_DIR}/generate-depls.rb" -d "${depls}" -p "${SECRET_DIR}" -o "${OUTPUT_DIR}" -t "${TEMPLATES}" --iaas "${IAAS_TYPE}" --no-dump
-    PIPELINE="${depls}-init-generated"
+    "${CURRENT_SCRIPT_DIR}/generate-depls.rb" -d "${depls}" -p "${SECRET_DIR}" -o "${OUTPUT_DIR}" -t "${TEMPLATES}" --iaas "${IAAS_TYPE}" --no-dump ${PIPELINES_RESTRICTION}
+    PIPELINE="${depls}-${PIPELINE_TYPES}-generated"
     echo "${PIPELINE} generated  to ${OUTPUT_DIR}/pipelines"
 done
 

--- a/scripts/concourse-manual-pipelines-update.rb
+++ b/scripts/concourse-manual-pipelines-update.rb
@@ -2,14 +2,17 @@
 
 require 'yaml'
 require 'optparse'
+require_relative '../lib/../lib/pipeline_helpers'
 
 # Argument parsing
 OPTIONS = {
   depls: 'ops-depls',
   no_interactive: false,
   fail_fast: false,
-  fail_on_error: false
+  fail_on_error: true,
+  coa_config: true
 }
+
 opt_parser = OptionParser.new do |opts|
   opts.banner = 'Usage: ./scripts/concourse-manual-pipelines-update.sh [options]
 Customization using ENVIRONMENT_VARIABLE:
@@ -36,27 +39,28 @@ Customization using ENVIRONMENT_VARIABLE:
     OPTIONS[:depls] = depls_string
   end
 
-  opts.on('--no-interactive', 'Do not ask for confirmation on pipeline load') do |_|
+  opts.on('--no-interactive', 'Do not ask for confirmation on pipeline load') do
     OPTIONS[:no_interactive] = true
   end
 
-  opts.on('--fail-fast', 'Fail on first loading error') do |_|
-    OPTIONS[:fail_fast] = true
+  opts.on('--[no-]fail-fast', "Fail on first loading error - Default: #{OPTIONS[:fail_fast]}") do |boolean_option|
+    OPTIONS[:fail_fast] = boolean_option
   end
 
-  opts.on('--fail-on-error', 'Fail on loading error') do |_|
-    OPTIONS[:fail_on_error] = true
+  opts.on('--[no-]fail-on-error', "Fail on loading error - Default: #{OPTIONS[:fail_on_error]}") do |boolean_option|
+    OPTIONS[:fail_on_error] = boolean_option
+  end
+  opts.on('--[no-]use-coa-config', "Use configuration - Default: #{OPTIONS[:coa_config]}") do |boolean_option|
+    OPTIONS[:coa_config] = boolean_option
   end
 end
 opt_parser.parse!
 
-SECRETS = ENV['SECRETS'] || "../preprod-secrets"
+SECRETS = ENV['SECRETS'] || "../int-secrets"
 PAAS_TEMPLATES = ENV['PAAS_TEMPLATES'] || '../paas-templates'
 DEBUG = ENV['DEBUG'] || false
 PIPELINES_DIR = ENV['PIPELINES_DIR'] || 'bootstrap-generated/pipelines'
-
-target_name = ENV['TARGET_NAME'] || 'fe-int'
-
+TARGET_NAME = ENV['TARGET_NAME'] || 'fe-int'
 PIPELINE_PREFIX = ENV['PIPELINE_PREFIX'] || ''
 
 def header(msg)
@@ -92,6 +96,7 @@ end
 
 def generate_full_path_for_concourse_vars_files(vars_files)
   vars_files_with_path = []
+  return vars_files_with_path if vars_files.nil?
   vars_files.each do |var_file|
     vars_files_with_path << if var_file =~ /versions.yml/
                               "#{PAAS_TEMPLATES}/#{var_file}"
@@ -102,38 +107,81 @@ def generate_full_path_for_concourse_vars_files(vars_files)
   vars_files_with_path
 end
 
-def update_pipelines(target_name)
-  header("For pipelines in #{PIPELINES_DIR}")
-  loaded_pipelines_status = {}
-  depls = OPTIONS[:depls]
-  Dir["#{PIPELINES_DIR}/*.yml"].each do |filename|
-    # puts "Found #{filename}"
-    next if OPTIONS.key?(:depls) && !filename.include?(OPTIONS[:depls])
-    next if OPTIONS.key?(:template) && !filename.include?(OPTIONS[:template])
-    puts "Starting processing of #{filename}"
-    deployment_name = File.basename(filename, '.yml')
-    ci_deployment_overview = YAML.load_file("#{SECRETS}/#{depls}/ci-deployment-overview.yml")
+def get_vars_files_with_path(pipeline_options, pipeline_name, root_depls)
+  coa_config_dir = File.join(SECRETS, "coa", "config")
+  if OPTIONS[:coa_config]
+    puts "Use vars_files dynamic detection located in <#{coa_config_dir}>"
+    PipelineHelpers.generate_vars_files(PAAS_TEMPLATES, coa_config_dir, pipeline_name, root_depls)
+  else
+    puts 'Use vars_files listed in ci-deployment-overview.yml files'
+    generate_full_path_for_concourse_vars_files(pipeline_options['vars_files'])
+  end
+end
 
-    pipelines = ci_deployment_overview['ci-deployment'][depls]['pipelines']
-    current_pipeline = pipelines[deployment_name]
-    if current_pipeline.nil?
-      puts "invalid config #{SECRETS}/#{depls}/ci-deployment-overview.yml should contains a key ...[pipelines][#{deployment_name}][vars_files]"
-      puts "ignoring pipeline #{filename} (invalid config #{SECRETS}/#{depls}/ci-deployment-overview.yml)"
+def concourse_additional_options
+  additional_config = []
+  additional_config << "--non-interactive" if OPTIONS[:no_interactive]
+  additional_config
+end
+
+def load_pipeline_into_concourse(pipeline_name, pipeline_vars_files, pipeline_definition_filename, concourse_target_name)
+  raise "No vars_files detected. Please ensure coa-config option is #{OPTIONS[:coa_config]}" if pipeline_vars_files&.empty?
+  set_pipeline(
+    target_name: concourse_target_name,
+    name: pipeline_name,
+    config: pipeline_definition_filename,
+    load: pipeline_vars_files,
+    options: concourse_additional_options
+  )
+end
+
+def load_pipeline_configuration(root_deployment, pipeline_name)
+  ci_deployment_overview = YAML.load_file(File.join(SECRETS, root_deployment, 'ci-deployment-overview.yml'))
+
+  pipelines = ci_deployment_overview['ci-deployment'][root_deployment]['pipelines']
+  pipelines[pipeline_name]
+end
+
+def filter_root_deployment_pipelines(root_deployment)
+  header("For pipelines in #{PIPELINES_DIR}")
+  Dir["#{PIPELINES_DIR}/*.yml"]
+    .reject { |filename| OPTIONS.key?(:depls) && !filename.include?(root_deployment) }
+    .reject { |filename| OPTIONS.key?(:template) && !filename.include?(OPTIONS[:template]) }
+end
+
+def display_invalid_config_error_message(pipeline_filename, root_deployment)
+  pipeline_name = pipeline_name(pipeline_filename)
+  puts "invalid config #{SECRETS}/#{root_deployment}/ci-deployment-overview.yml should contains a key ...[pipelines][#{pipeline_name}][vars_files]"
+  puts "ignoring pipeline #{pipeline_filename} (invalid config #{SECRETS}/#{root_deployment}/ci-deployment-overview.yml)"
+end
+
+def pipeline_name(pipeline_filename)
+  File.basename(pipeline_filename, '.yml')
+end
+
+def pipeline_config_valid?(current_pipeline)
+  !OPTIONS[:coa_config] && current_pipeline.nil?
+end
+
+def update_pipelines(target_name)
+  loaded_pipelines_status = {}
+  root_deployment = OPTIONS[:depls]
+
+  root_deployment_pipelines = filter_root_deployment_pipelines(root_deployment)
+
+  root_deployment_pipelines.each do |pipeline_filename|
+    puts "Starting processing of #{pipeline_filename}"
+    pipeline_name = pipeline_name(pipeline_filename)
+    current_pipeline_options = load_pipeline_configuration(root_deployment, pipeline_name)
+
+    if pipeline_config_valid?(current_pipeline_options)
+      display_invalid_config_error_message(pipeline_filename, root_deployment)
       next
     end
+    vars_files_with_path = get_vars_files_with_path(current_pipeline_options, pipeline_name, root_deployment)
 
-    additional_config = []
-    additional_config << "--non-interactive" if OPTIONS[:no_interactive]
-
-    vars_files_with_path = generate_full_path_for_concourse_vars_files(current_pipeline['vars_files'])
-    result = set_pipeline(
-      target_name: target_name,
-      name: deployment_name,
-      config: filename,
-      load: vars_files_with_path,
-      options: additional_config
-    )
-    loaded_pipelines_status[deployment_name] = result
+    pipeline_loading_status = load_pipeline_into_concourse(pipeline_name, vars_files_with_path, pipeline_filename, target_name)
+    loaded_pipelines_status[pipeline_name] = pipeline_loading_status
   end
 
   if OPTIONS[:fail_on_error]
@@ -141,4 +189,4 @@ def update_pipelines(target_name)
   end
 end
 
-update_pipelines target_name
+update_pipelines TARGET_NAME

--- a/spec/lib/pipeline_helpers_spec.rb
+++ b/spec/lib/pipeline_helpers_spec.rb
@@ -1,0 +1,118 @@
+require 'rspec'
+require_relative '../../lib/pipeline_helpers'
+require_relative '../../lib/config'
+require_relative '../../lib/directory_initializer'
+
+describe PipelineHelpers do
+  describe '#bosh_io_hosted?' do
+    let(:bosh_io_hosted?) { described_class.bosh_io_hosted?(info) }
+    let(:shield_overview) do
+      deps_yaml = <<~YAML
+        stemcells:
+        bosh-openstack-kvm-ubuntu-trusty-go_agent:
+        releases:
+          cf-routing-release:
+            base_location: https://bosh.io/d/github.com/
+            repository: cloudfoundry-incubator/cf-routing-release
+            version: 0.169.0
+          route-registrar-boshrelease:
+            base_location: https://bosh.io/d/github.com/
+            repository: cloudfoundry-community/route-registrar-boshrelease
+            version: '3'
+          my-boshrelease:
+            base_location: https://github.com/
+            repository: cloudfoundry-community/haproxy-boshrelease
+            version: 8.0.12
+        bosh-deployment:
+          active: true
+        status: enabled
+      YAML
+      YAML.safe_load(deps_yaml)
+    end
+
+    context 'when a bosh release is hosted on bosh.io' do
+      let(:info) { shield_overview['releases']['cf-routing-release'] }
+
+      it 'returns true' do
+        expect(bosh_io_hosted?).to be_truthy
+      end
+    end
+
+    context 'when a bosh release is NOT hosted on bosh.io' do
+      let(:info) {  shield_overview['releases']['my-boshrelease'] }
+
+      it 'returns false' do
+        expect(bosh_io_hosted?).to be_falsey
+      end
+    end
+  end
+
+  describe '#parallel_execution_limit' do
+    let(:config) { Config.new.default_config }
+    let(:root_deployment_name) { 'my_root_deployment' }
+    let(:expected_default_value) { Config::DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT }
+    let(:parallel_execution_limit) { described_class.parallel_execution_limit(config, root_deployment_name) }
+
+    context 'when parallel execution limit is overridden per root_deployment' do
+      let(:expected_root_deployment_override_value) { 8 }
+      let(:config) do
+        override = { Config::CONFIG_DEFAULT_KEY => {
+          Config::CONFIG_CONCOURSE_KEY => { Config::CONFIG_PARALLEL_EXECUTION_LIMIT_KEY => 8 }
+        } }
+        Config.new.default_config.merge(override)
+      end
+
+      it 'generates a list of vars_files for concourse pipelines' do
+        expect(parallel_execution_limit).to eq(expected_root_deployment_override_value)
+      end
+    end
+
+    context 'when default value is used' do
+      let(:config) { Config.new.default_config }
+
+      it 'generates a list of vars_files for concourse pipelines' do
+        expect(parallel_execution_limit).to eq(expected_default_value)
+      end
+    end
+
+    context 'when parallel execution limit is disabled' do
+      let(:config) do
+        Config.new.default_config.reject { |key, value| key == Config::CONFIG_DEFAULT_KEY }
+      end
+      let(:expected_disabled_parallel_execution_limit) { PipelineHelpers::UNLIMITED_EXECUTION }
+
+      it 'generates a list of vars_files for concourse pipelines' do
+        expect(parallel_execution_limit).to eq(expected_disabled_parallel_execution_limit)
+      end
+    end
+  end
+
+  describe '#enabled_parallel_execution_limit?' do
+  end
+
+  describe '#generate_vars_files' do
+    let(:templates_dir) { Dir.mktmpdir }
+    let(:config_dir) { Dir.mktmpdir }
+    let(:pipeline_name) { 'my-pipeline' }
+    let(:root_deployment) { 'my_root_deployment' }
+    let(:setup_templates_dir) { DirectoryInitializer.new(root_deployment, config_dir, templates_dir).setup_templates! }
+    let(:setup_config_dir) { config_file_list.each { |filename| FileUtils.touch(File.join(config_dir, filename)) } }
+    let(:config_file_list) { %w[credentials-a.yml credentials-my-pipeline.yml credentials-another-pipeline.yml xxx.yml credentials-b.yml] }
+    let(:expected_vars_files) do
+      result = [File.join(config_dir, 'credentials-a.yml')]
+      result << File.join(config_dir, 'credentials-b.yml')
+      result << File.join(config_dir, 'credentials-my-pipeline.yml')
+      result << File.join(templates_dir, root_deployment, "#{root_deployment}-versions.yml")
+    end
+    let(:generate_vars_files) { described_class.generate_vars_files(templates_dir, config_dir, pipeline_name, root_deployment) }
+
+    before do
+      setup_templates_dir
+      setup_config_dir
+    end
+
+    it 'generates a list of vars_files for concourse pipelines' do
+      expect(generate_vars_files).to eq expected_vars_files
+    end
+  end
+end

--- a/spec/scripts/generate-depls/generate_depls_for_cf_apps_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_cf_apps_pipeline_spec.rb
@@ -22,7 +22,7 @@ describe 'generate-depls for cf-apps pipeline' do
     end
 
     context 'when generate-depls is executed' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/cf-apps-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i cf-apps" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_for_depls_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_depls_pipeline_spec.rb
@@ -12,7 +12,7 @@ describe 'generate-depls for depls pipeline' do
   let(:secrets_path) { "#{fixture_path}/secrets" }
   let(:depls_name) { 'simple-depls' }
   let(:iaas_type) { 'my-custom-iaas' }
-  let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/depls-pipeline.yml.erb" }
+  let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i depls" }
   let(:pipeline) { TestHelper.load_generated_pipeline(output_path, "#{depls_name}-generated.yml") }
   let(:cleanup) { FileUtils.rm_rf(output_path) unless output_path.nil? }
 

--- a/spec/scripts/generate-depls/generate_depls_for_init_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_init_pipeline_spec.rb
@@ -19,7 +19,7 @@ describe 'generate-depls for init pipeline' do
 
     context 'when valid' do
       let(:options) do
-        "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/init-pipeline.yml.erb"
+        "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i init"
       end
 
       stdout_str = stderr_str = ''

--- a/spec/scripts/generate-depls/generate_depls_for_news_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_news_pipeline_spec.rb
@@ -18,7 +18,7 @@ describe 'generate-depls for news pipeline' do
     end
 
     context 'when valid' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/news-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i news" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_for_s3_br_upload_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_s3_br_upload_pipeline_spec.rb
@@ -22,7 +22,7 @@ describe 'generate-depls for s3 boshrelease upload pipeline' do
     end
 
     context 'when valid' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/s3-br-upload-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i s3-br-upload" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_for_s3_stemcell_upload_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_s3_stemcell_upload_pipeline_spec.rb
@@ -18,7 +18,7 @@ describe 'generate-depls for s3 stemcell upload pipeline' do
     end
 
     context 'when valid' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i ./concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --iaas #{iaas_type} --no-dump -i s3-stemcell-upload" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_for_sync_helper_pipeline_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_for_sync_helper_pipeline_spec.rb
@@ -27,7 +27,7 @@ describe 'generate-depls for sync-help pipeline' do
     end
 
     context 'when valid' do
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i ./concourse/pipelines/template/sync-helper-pipeline.yml.erb" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} --no-dump -i sync-helper" }
 
       stdout_str = stderr_str = ''
       before do

--- a/spec/scripts/generate-depls/generate_depls_spec.rb
+++ b/spec/scripts/generate-depls/generate_depls_spec.rb
@@ -41,8 +41,13 @@ describe 'generate-depls' do
           include('-p, --secrets-path PATH          Base secrets dir (i.e. enable-deployment.yml, enable-cf-app.yml, etc.)').and \
           include('-o, --output-path PATH           Output dir for generated pipelines.').and \
           include('-a, --automation-path PATH       Base location for cf-ops-automation').and \
-          include('-i, --input PIPELINE1,PIPELINE2, List of pipelines to process').and \
+          include('-i, --input PIPELINE1,PIPELINE2  List of pipelines to process').and \
           include('--[no-]dump                  Dump genereted file on standart output')
+          include('-e PIPELINE1,PIPELINE2,          List of pipelines to exclude).and').and \
+          include('--exclude').and \
+          include('--[no-]dump            Dump genereted file on standart output').and \
+          include('--iaas IAAS_TYPE             Target a specific iaas for pipeline generation')
+
         expect(stdout_str).to be_empty
       end
     end
@@ -59,7 +64,7 @@ describe 'generate-depls' do
 
     context 'when only a pipeline is selected' do
       let(:depls_name) { 'dummy-depls' }
-      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} -i ./concourse/pipelines/template/depls-pipeline.yml.erb --no-dump" }
+      let(:options) { "-d #{depls_name} -o #{output_path} -t #{templates_path} -p #{secrets_path} -i depls --no-dump" }
 
       stdout_str, stderr_str, = ''
       before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,8 +117,8 @@ RSpec.configure do |config|
   config.tty = true
 
   config.before do
-    $stdout = StringIO.new
-    $stderr = StringIO.new
+    # $stdout = StringIO.new
+    # $stderr = StringIO.new
   end
   config.after(:all) do
     $stdout = STDOUT

--- a/spec/tasks/all_tasks_spec.rb
+++ b/spec/tasks/all_tasks_spec.rb
@@ -13,7 +13,11 @@ describe 'all tasks' do
       tasks.each do |task_filename|
         puts "processing file #{task_filename}"
         task = YAML.load_file (task_filename)
-        docker_image = task['image_resource']['source']['repository'].to_s
+        docker_image = task['image_resource']&.fetch('source',[])&.fetch('repository',[]).to_s
+        if docker_image.empty?
+          puts "No image detected, ignoring #{task_filename}"
+          next
+        end
         docker_image = "library/#{docker_image}" unless docker_image.include?('/')
         docker_image_tag = task['image_resource']['source']['tag'] || 'latest'
         name = "#{docker_image}:#{docker_image_tag}"

--- a/spec/tasks/list_used_ci_team/task_spec.rb
+++ b/spec/tasks/list_used_ci_team/task_spec.rb
@@ -7,7 +7,7 @@ describe 'list_used_ci_team task' do
   let(:teams_file) { File.join(@ci_deployment_overview, 'teams.yml') }
 
   def setup_secrets
-    ops_depls_ci_deployment_yaml= <<~YAML
+    ops_depls_ci_deployment_yaml = <<~YAML
       ---
       ci-deployment:
         ops-depls:
@@ -44,13 +44,7 @@ describe 'list_used_ci_team task' do
               - micro-depls/concourse-micro/pipelines/credentials-iaas-specific.yml
             ops-depls-s3-br-upload-generated:
               team: my-custom-team-1
-              vars_files:
-              - ops-depls/ops-depls-versions.yml
             ops-depls-s3-stemcell-upload-generated:
-              team: my-custom-team-2
-              vars_files:
-              - micro-depls/concourse-micro/pipelines/credentials-s3-stemcell.yml
-              - ops-depls/ops-depls-versions.yml
     YAML
     master_depls_ci_deployment_yaml = <<~YAML
       ---
@@ -71,6 +65,8 @@ describe 'list_used_ci_team task' do
               vars_files:
               - micro-depls/concourse-micro/pipelines/credentials-git-config.yml
     YAML
+
+
     @temp_dir = Dir.mktmpdir
     @ops_depls_file = File.join(@temp_dir, 'ops-depls')
     @ops_depls_dir = Dir.mkdir(@ops_depls_file)


### PR DESCRIPTION
Fixes #213.

Changes proposed in this pull-request:
 - we share the same task for init-pipelines and update-pipelines.
 - we only generate init or update pipeline in bootstrap instead of all  pipelines. As we support empty vars_files in pipeline definition (ci-deployment-overview.yml) depls-pipeline template is not compatible with this syntax. So we can  generate all pipelines each times.
