### PR TITLE
220 github-release resource type

### DIFF
--- a/ci/bootstrap_coa_env/virtualbox/pipeline-vars-prereqs.yml
+++ b/ci/bootstrap_coa_env/virtualbox/pipeline-vars-prereqs.yml
@@ -1,6 +1,7 @@
 pipeline-vars:
   slack-webhook: https://example.slack.com/webhook
   slack-channel: channel
+  slack-disable-it: true
   secrets-branch: master
   cf-ops-automation-branch: master
   cf-ops-automation-tag-filter: ""
@@ -10,7 +11,7 @@ pipeline-vars:
   s3-stemcell-secret-key: ""
   s3-stemcell-bucket: bosh-core-stemcells
   stemcell-name-prefix: ""
-  stemcell-main-name: warden-boshlite-ubuntu-trusty-go_agent
+  stemcell-main-name: bosh-warden-boshlite-ubuntu-trusty-go_agent
   stemcell-version: "3586.25"
   s3-stemcell-endpoint: https://s3.amazonaws.com
   s3-stemcell-skip-ssl-verification: false

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -245,6 +245,7 @@ resources:
   source:
     user: <%= info['repository'].split('/').first %>
     repository: <%= info['repository'].split('/').last %>
+    access_token: ((bot-github-access-token))
     <% end %>
   <% end %>
 <% end %>
@@ -641,11 +642,7 @@ jobs:
       <% end %>
       releases: <%= '[]' if boshrelease['releases']&.empty? %>
   <% boshrelease['releases']&.sort&.each do |release, info| %>
-    <% if config['offline-mode'] && config['offline-mode']['boshreleases'] %>
-      - <%= release %>/<%= release %>-((<%= release %>-version)).tgz
-    <% else %>
-      - <%= release %>/release.tgz
-    <% end %>
+      - "<%= release %>/*.tgz"
   <% end %>
   <% if boshrelease['cli_version'] != 'v1' %>
       ops_files:

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -257,6 +257,7 @@ resources:
   source:
     user: <%= info['repository'].split('/').first %>
     repository: <%= info['repository'].split('/').last %>
+    access_token: ((bot-github-access-token))
     <% end %>
   <% end %>
 <% end %>
@@ -661,13 +662,9 @@ jobs:
       <% else %>
       - ((stemcell-main-name))/stemcell.tgz
       <% end %>
-      releases:<%= ' []' if boshrelease['releases']&.empty? %>
+      releases: <%= '[]' if boshrelease['releases']&.empty? %>
   <% boshrelease['releases']&.sort&.each do |release, info| %>
-    <% if config['offline-mode'] && config['offline-mode']['boshreleases'] %>
-      - <%= release %>/<%= release %>-((<%= release %>-version)).tgz
-    <% else %>
-      - <%= release %>/release.tgz
-    <% end %>
+      - "<%= release %>/*.tgz"
   <% end %>
   <% if boshrelease['cli_version'] != 'v1' %>
       ops_files:

--- a/concourse/pipelines/template/news-pipeline.yml.erb
+++ b/concourse/pipelines/template/news-pipeline.yml.erb
@@ -91,6 +91,7 @@ resources:
   source:
     user: <%= info["repository"].split('/').first %>
     repository: <%= info["repository"].split('/').last %>
+    access_token: ((bot-github-access-token))
   <% end %>
 <% end %>
 

--- a/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
@@ -60,7 +60,7 @@ resources:
   source:
     user: <%= info["repository"].split('/').first %>
     repository: <%= info["repository"].split('/').last %>
-    access_token: ((github-access-token)) # this is neeed to avoid getting limited by GitHub. See https://github.com/concourse/github-release-resource/blob/master/README.md#github-releases-resource
+    access_token: ((bot-github-access-token))
   <% end %>
 
 - name: <%= release %>-s3

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/deployment-dependencies.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/deployment-dependencies.yml
@@ -17,8 +17,6 @@ deployment:
       ntp:
         base_location: https://bosh.io/d/github.com/
         repository: cloudfoundry-community/ntp-release
-      # NOTE: this resource is not working ATM, see https://github.com/orange-cloudfoundry/cf-ops-automation/issues/220
-      # vault:
-      #   base_location: http://github.com/
-      #   repository: cloudfoundry-community/vault-boshrelease
-
+      vault:
+        base_location: http://github.com/
+        repository: cloudfoundry-community/vault-boshrelease

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/adding-vault-release-operators.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/adding-vault-release-operators.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /releases/-
+  value: {name: vault, version: ((vault_release_version))}

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/bosh-deployment-sample-tpl.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/bosh-deployment-sample-tpl.yml
@@ -24,7 +24,7 @@ instance_groups:
   persistent_disk: 0
   stemcell: trusty
   networks:
-  - name: concourse-bucc #default
+  - name: concourse-bucc
   jobs:
   - name: nginx
     release: nginx

--- a/lib/coa_env_bootstrapper/base.rb
+++ b/lib/coa_env_bootstrapper/base.rb
@@ -11,11 +11,6 @@ module CoaEnvBootstrapper
     SECRETS_REPO_DIR   = "#{PROJECT_ROOT_DIR}/docs/reference_dataset/config_repository".freeze
     TEMPLATES_REPO_DIR = "#{PROJECT_ROOT_DIR}/docs/reference_dataset/template_repository".freeze
 
-    def extract_from_prereqs(prereqs, prereqs_key, additional_info = {})
-      keys_prereqs = prereqs[prereqs_key] || {}
-      keys_prereqs&.merge(additional_info) || {}
-    end
-
     def run_cmd(command, options = {})
       CoaCommandRunner.new(command, options).execute
     end

--- a/lib/coa_env_bootstrapper/git.rb
+++ b/lib/coa_env_bootstrapper/git.rb
@@ -89,7 +89,7 @@ module CoaEnvBootstrapper
       [CREDENTIALS_AUTO_INIT_PATH, CONCOURSE_CREDENTIALS_PATH].each do |path|
         File.open(path, 'w') do |file|
           generated_creds = generated_concouse_credentials(concourse_config)
-          crendentials_auto_init = extract_from_prereqs(prereqs, "pipeline-vars", generated_creds)
+          crendentials_auto_init = generated_creds.merge(prereqs["pipeline-vars"].to_h)
           file.write crendentials_auto_init.to_yaml
         end
       end

--- a/spec/lib/reference_dataset_documentation/tree_writer_spec.rb
+++ b/spec/lib/reference_dataset_documentation/tree_writer_spec.rb
@@ -34,15 +34,11 @@ describe ReferenceDatasetDocumentation::TreeWriter do
       expect(generator).to receive(:add).
         with("## The config repo", "", "### root level overview", "", "```bash", tree_root_level_answer, "```", "")
 
-
       expect(generator).to receive(:add).
           with("### #{root_deployment_name} overview", "", "```bash", tree_answer, "```", "").twice
 
-
-
       expect(generator).to receive(:add).
           with("## The template repo", "", "### root level overview", "", "```bash", tree_root_level_answer, "```", "")
-
 
       tree_writer.perform
     end

--- a/spec/lib/template_processor/template_processor_for_depls_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_depls_pipeline_spec.rb
@@ -284,7 +284,7 @@ describe 'DeplsPipelineTemplateProcessing' do
         expected_boshreleases.flat_map { |name, repo| { name => "#{repo}/#{name}-((#{name}-version)).tgz" } }
       end
       let(:expected_boshrelease_put_version) do
-        expected_boshreleases.flat_map { |name, _repo| { name => "#{name}/#{name}-((#{name}-version)).tgz" } }
+        expected_boshreleases.flat_map { |name, _repo| { name => "#{name}/*.tgz" } }
       end
       let(:expected_s3_deployment_put) do
         expected_yaml = <<~YAML
@@ -345,7 +345,7 @@ describe 'DeplsPipelineTemplateProcessing' do
           - name: ((stemcell-main-name))
             type: bosh-io-stemcell
             source:
-              name:  ((stemcell-main-name))
+              name: ((stemcell-main-name))
         YAML
         YAML.safe_load expected_yaml
       end

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -485,7 +485,7 @@ jobs:
         - ((stemcell-main-name))/bosh-stemcell-((stemcell-version))-((stemcell-main-name)).tgz
         releases: 
         
-        - ntp_boshrelease/release.tgz
+        - ntp_boshrelease/*.tgz
         ops_files:
           - ops-and-vars-files/operators/*
         vars_files:


### PR DESCRIPTION
Fixes #219, #220 .

Changes proposed in this pull-request:
- allow user to pass their github token in order the extend the possibility of using the github-release resource without hitting the API requests limit
- fix issue (i.e. make it more consistent) with the way we're using the bosh-io-releases resource.

This PR is still a WIP, since I am still currently testing the second part.