### PR TITLE
pipeline(sync-feature-branches): add hard reset job

### DIFF
--- a/concourse/pipelines/sync-feature-branches.yml
+++ b/concourse/pipelines/sync-feature-branches.yml
@@ -104,3 +104,33 @@ jobs:
       params:
         repository: paas-templates-features-reseted
         force: true
+
+- name: hard-reset-features-merged
+  serial_groups: [git]
+  on_failure:
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/main/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+    - aggregate:
+        - get: paas-templates-reference
+          params: { submodules: none }
+        - get: cf-ops-automation
+          params: { submodules: none }
+    - task: reset-wip
+      file: cf-ops-automation/concourse/tasks/git_hard_reset_wip/task.yml
+      input_mapping: {reference-resource: paas-templates-reference}
+      output_mapping: {updated-git-resource: paas-templates-features-hard-reseted}
+      params:
+        GIT_BRANCH_FILTER: WIP-* wip-* feature-* Feature-*
+        SKIP_SSL_VERIFICATION: true
+        GIT_CHECKOUT_BRANCH: ((paas-templates-reference-branch))
+
+    - put: features-or-wip-merged
+      get_params: {submodules: none}
+      params:
+        repository: paas-templates-features-hard-reseted
+        force: true

--- a/concourse/tasks/git_hard_reset_wip/run.sh
+++ b/concourse/tasks/git_hard_reset_wip/run.sh
@@ -1,0 +1,70 @@
+#!/bin/ash
+# shellcheck shell=dash
+# Ash scripts will be checked as Dash.
+
+set -o pipefail
+set -e
+
+git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "$GIT_USER_NAME"
+
+FINAL_RELEASE_REPO=updated-git-resource
+
+if [ "$SKIP_SSL_VERIFICATION" = "true" ]; then
+  export GIT_SSL_NO_VERIFY=true
+  echo "Skipping ssl verification"
+fi
+
+cd reference-resource || exit 1
+URI=$(git remote get-url origin)
+
+# shellcheck disable=SC2086
+# we need GIT_BRANCH_FILTER to be expanded with spaces
+current_heads=$(git ls-remote -h "$URI" ${GIT_BRANCH_FILTER} | sed 's/refs\/heads\///' | awk '{print $2, $1}' | sort)
+cd ..
+
+echo "selected branches list with associated commit id:"
+DISPLAY_SEPARATOR="=================="
+echo ${DISPLAY_SEPARATOR}
+echo "${current_heads}"
+echo ${DISPLAY_SEPARATOR}
+git clone "${URI}" "${FINAL_RELEASE_REPO}"
+cd ${FINAL_RELEASE_REPO} || exit 1
+git checkout -B "${GIT_CHECKOUT_BRANCH}" -t "origin/${GIT_CHECKOUT_BRANCH}"
+
+git_br=$(echo "${current_heads}" |awk '{ for (i=2;i<=NF;i+=2) $i=""; print}' )
+echo "WIP Reset Complete" > .git/reset_branches
+{
+    echo ""
+    echo "Restored branches:"
+    echo "${current_heads}"
+} >> .git/reset_branches
+
+for branch_name in ${git_br}; do
+  echo ${DISPLAY_SEPARATOR}
+  echo "Processing $branch_name"
+  git merge -m "Merge branch '$branch_name' after WIP reset [skip ci]" "origin/${branch_name}"
+done
+
+find . -maxdepth 5 -not \( -path "*.git" -prune \) -type d > .git/all_changed_dirs
+echo "Changed dirs:"
+cat .git/all_changed_dirs
+
+
+# add timestamp to force triggering
+cat .git/all_changed_dirs|sort |uniq > .git/changed_dirs
+echo "Changed detected in the following dirs:"
+cat .git/changed_dirs
+echo ${DISPLAY_SEPARATOR}
+
+date +'%Y-%m-%d-%H-%M-%S'|tee .git/.last-reset
+while IFS= read -r aDir
+do
+  if [ -d "${aDir}" ]; then
+    cp .git/.last-reset "${aDir}"
+  fi
+done < .git/changed_dirs
+
+echo "Adding changes to git"
+git add .
+git commit --file .git/reset_branches

--- a/concourse/tasks/git_hard_reset_wip/task.yml
+++ b/concourse/tasks/git_hard_reset_wip/task.yml
@@ -1,0 +1,34 @@
+---
+#
+# Copyright (C) 2015-2019 Orange
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+platform: linux
+image_resource:
+  type: docker-image
+  source: {repository: concourse/busyboxplus, tag: "git"}
+inputs:
+  - name: reference-resource
+  - name: cf-ops-automation
+outputs:
+  - name: updated-git-resource
+run:
+  path: sh
+  args:
+    - -c
+    - cf-ops-automation/concourse/tasks/git_hard_reset_wip/run.sh
+params:
+    GIT_USER_NAME: "Orange Cloud Foundry SKC CI Server"
+    GIT_USER_EMAIL: "codex.clara-cloud-ops@orange.com"
+    GIT_BRANCH_FILTER: WIP-* wip-* feature-* Feature-*
+    GIT_CHECKOUT_BRANCH: develop
+    SKIP_SSL_VERIFICATION:

--- a/spec/tasks/git_hard_reset_wip/task_spec.rb
+++ b/spec/tasks/git_hard_reset_wip/task_spec.rb
@@ -1,0 +1,90 @@
+# encoding: utf-8
+
+# require 'spec_helper.rb'
+require 'yaml'
+require 'tmpdir'
+
+describe 'git_hard reset_wip task' do
+  before(:context) do
+    @git_test_reference_repo = 'https://github.com/orange-cloudfoundry/cf-ops-automation-git-reset-wip-it'
+    dest_dir = 'spec/tasks/git_hard_reset_wip/reference-resource'
+    FileUtils.rm_rf dest_dir if Dir.exist? dest_dir
+    out, err, status = Open3.capture3("git clone #{@git_test_reference_repo} #{dest_dir}")
+    expect(err).to eq("Cloning into 'spec/tasks/git_hard_reset_wip/reference-resource'...\n")
+  end
+
+  after(:context) do
+    FileUtils.rm_rf @git_test_reference_repo
+  end
+
+  context 'when executed with develop as base branch' do
+    before(:context) do
+      @updated_git_resource = Dir.mktmpdir
+
+      @output = execute('--include-ignored -c concourse/tasks/git_hard_reset_wip/task.yml ' \
+        '-i reference-resource=spec/tasks/git_hard_reset_wip/reference-resource ' \
+        '-i cf-ops-automation=. ' \
+        "-o updated-git-resource=#{@updated_git_resource} ",
+                        'SKIP_SSL_VERIFICATION' => 'true',
+                        'GIT_BRANCH_FILTER' => '"WIP-* wip-* feature-* Feature-*"')
+    end
+
+    after(:context) do
+      FileUtils.rm_rf @updated_git_resource
+    end
+
+    it 'only merges branches matching filter' do
+      expect(@output).to include('Processing wip-1').and \
+        include('Processing WIP-2').and \
+          include('Processing feature-1').and \
+            include('Processing Feature-2').and \
+              include("Switched to a new branch 'develop'")
+    end
+
+    %w[develop feature-1 Feature-2 wip-1 WIP-2].each do |merged_file|
+      it "contains #{merged_file} file" do
+        expect(File).to exist(File.join(@updated_git_resource, "#{merged_file}.md"))
+      end
+    end
+
+    it 'does not contain files from a-branch' do
+      expect(File).not_to exist(File.join(@updated_git_resource, 'a-branch.md'))
+    end
+
+    it 'contains reset timestamps' do
+      expect(File).to exist(File.join(@updated_git_resource, ".last-reset")).and \
+        exist(File.join(@updated_git_resource, "Feature-2", ".last-reset"))
+    end
+
+    context 'when skip_ssl is enabled' do
+      it 'does not check ssl certificates' do
+        expect(@output).to include('Skipping ssl verification')
+      end
+    end
+  end
+
+  context 'when executed with master as base branch' do
+    before(:context) do
+      @updated_git_resource = Dir.mktmpdir
+
+      @output = execute('--include-ignored -c concourse/tasks/git_hard_reset_wip/task.yml ' \
+        '-i reference-resource=spec/tasks/git_hard_reset_wip/reference-resource ' \
+        '-i cf-ops-automation=. ' \
+        "-o updated-git-resource=#{@updated_git_resource} ",
+                        'GIT_BRANCH_FILTER' => '"unknown-branch"',
+                        'GIT_CHECKOUT_BRANCH' => 'master')
+    end
+
+    after(:context) do
+      FileUtils.rm_rf @updated_git_resource
+    end
+
+    it 'reset master branch' do
+      expect(@output).to include("Reset branch 'master'", "Your branch is up-to-date with 'origin/master'")
+    end
+
+    it 'contains master.md file' do
+      expect(File).to exist(File.join(@updated_git_resource, 'master.md'))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #218.

Changes proposed in this pull-request:
- add a job to perform a "hard" reset, ie retriggering without change detected.

A simple reset, is not able to detect branch deletion.