### PR TITLE
pipeline(*): support proxy for slack-notification

### DIFF
--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -17,6 +17,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: weekday-morning
   type: cron-resource

--- a/concourse/pipelines/micro-bosh-init-pipeline.yml
+++ b/concourse/pipelines/micro-bosh-init-pipeline.yml
@@ -49,6 +49,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 jobs:
 

--- a/concourse/pipelines/micro-depls-auto-init.yml
+++ b/concourse/pipelines/micro-depls-auto-init.yml
@@ -76,6 +76,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 #- name: auto-init-pipeline
 #  type: git

--- a/concourse/pipelines/micro-depls-terraform-pipeline.yml
+++ b/concourse/pipelines/micro-depls-terraform-pipeline.yml
@@ -61,6 +61,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 #- name: bosh-stemcell
 #  type: bosh-io-stemcell

--- a/concourse/pipelines/sync-feature-branches.yml
+++ b/concourse/pipelines/sync-feature-branches.yml
@@ -16,6 +16,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: features-or-wip-merged
   type: git

--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -20,6 +20,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 - name: secrets-full
   type: git
   source:

--- a/concourse/pipelines/template/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/template/concourse-pipeline.yml.erb
@@ -30,6 +30,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: concourse-for-<%= depls %>
   type: concourse-pipeline

--- a/concourse/pipelines/template/depls-pipeline.yml.erb
+++ b/concourse/pipelines/template/depls-pipeline.yml.erb
@@ -81,6 +81,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: secrets-<%= depls %>-limited
   type: git

--- a/concourse/pipelines/template/init-pipeline.yml.erb
+++ b/concourse/pipelines/template/init-pipeline.yml.erb
@@ -18,6 +18,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: <%= all_ci_deployments[depls]["target_name"] %>
   type: concourse-pipeline

--- a/concourse/pipelines/template/news-pipeline.yml.erb
+++ b/concourse/pipelines/template/news-pipeline.yml.erb
@@ -43,11 +43,17 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: new-version-alert
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 #- name: secrets-complete
 #  type: git

--- a/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
@@ -40,6 +40,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: cf-ops-automation
   type: git

--- a/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-stemcell-upload-pipeline.yml.erb
@@ -24,6 +24,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: cf-ops-automation
   type: git

--- a/concourse/pipelines/template/sync-helper-pipeline.yml.erb
+++ b/concourse/pipelines/template/sync-helper-pipeline.yml.erb
@@ -25,6 +25,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: anonymized-secrets
   type: git

--- a/concourse/pipelines/template/tf-pipeline.yml.erb
+++ b/concourse/pipelines/template/tf-pipeline.yml.erb
@@ -12,6 +12,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 # Scan the whole subdeployment from its root, not only the secret part
 - name: secrets-<%=depls %>

--- a/spec/lib/template_processor/template_processor_for_concourse_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_concourse_pipeline_spec.rb
@@ -147,6 +147,9 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
             type: slack-notification
             source:
               url: ((slack-webhook))
+              proxy: ((slack-proxy))
+              proxy_https_tunnel: ((slack-proxy-https-tunnel))
+              disable: ((slack-disable))
         YAML
         YAML.safe_load my_yaml
       end

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -18,6 +18,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: secrets-full
   type: git

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-ref.yml
@@ -40,6 +40,9 @@ resources:
     type: slack-notification
     source:
       url: ((slack-webhook))
+      proxy: ((slack-proxy))
+      proxy_https_tunnel: ((slack-proxy-https-tunnel))
+      disable: ((slack-disable))
 
   - name: secrets-delete-depls-limited
     type: git

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -43,6 +43,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: secrets-dummy-depls-limited
   type: git

--- a/spec/scripts/generate-depls/fixtures/references/empty-s3-br-upload.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-s3-br-upload.yml
@@ -20,6 +20,10 @@ resources:
   type: slack-notification
   source:
     url: "((slack-webhook))"
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
+
 - name: cf-ops-automation
   type: git
   source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-s3-stemcell-upload.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-s3-stemcell-upload.yml
@@ -20,6 +20,9 @@ resources:
   type: slack-notification
   source:
     url: "((slack-webhook))"
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 - name: cf-ops-automation
   type: git
   source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-init-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-init-ref.yml
@@ -18,6 +18,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: TO_BE_DEFINED
   type: concourse-pipeline

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
@@ -17,11 +17,17 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: new-version-alert
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: paas-templates-full
   type: git

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-ref.yml
@@ -46,6 +46,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: secrets-simple-depls-limited
   type: git

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-br-upload-ref.yml
@@ -20,6 +20,9 @@ resources:
   type: slack-notification
   source:
     url: "((slack-webhook))"
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 - name: cf-ops-automation
   type: git
   source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-stemcell-upload-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-s3-stemcell-upload-ref.yml
@@ -20,6 +20,9 @@ resources:
   type: slack-notification
   source:
     url: "((slack-webhook))"
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 - name: cf-ops-automation
   type: git
   source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-sync-helper-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-sync-helper-ref.yml
@@ -24,6 +24,9 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook))
+    proxy: ((slack-proxy))
+    proxy_https_tunnel: ((slack-proxy-https-tunnel))
+    disable: ((slack-disable))
 
 - name: anonymized-secrets
   type: git


### PR DESCRIPTION
We generalize proxy support as now we don't need to update each `ci-deployment-overview.yml`
to take into account credentials file

close #148