### PR TITLE
Fix invalid relative path in reference documentation

### DIFF
--- a/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/generic-app_manifest-tpl.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/generic-app_manifest-tpl.yml
@@ -10,10 +10,12 @@ disk_quota: (( file "spruce-file-sample-from-secrets.txt" ))
 
 # To reference spruce-generated files use the path : "../../../../generated-files"
 # To access paas-templates directory, it is possible to use one of the following:
-#   - direct reference, quite similar, like  "../../../../additional-resource/hello-world-root-depls/cf-apps-deployments/generic-app/template"
+#   - direct reference, quite similar, like  "../../../additional-resource/hello-world-root-depls/cf-apps-deployments/generic-app/template"
 
-#### Below a NOT RECOMMENDED and subject to change option. See https://github.com/orange-cloudfoundry/cf-ops-automation/issues/259
-#   - use a variable see sample with timeout and path_to_my_file $CUSTOM_SCRIPT_DIR: (( grab $CUSTOM_SCRIPT_DIR )), in this sample, CUSTOM_SCRIPT_DIR=additional-resource/hello-world-root-depls/cf-apps-deployments/generic-app/template
+#### Below is a NOT RECOMMENDED and subject to change option to access paas-templates directory.
+# See https://github.com/orange-cloudfoundry/cf-ops-automation/issues/259
+#   - use a variable see sample with timeout and path_to_my_file $CUSTOM_SCRIPT_DIR: (( grab $CUSTOM_SCRIPT_DIR )),
+#     in this sample, CUSTOM_SCRIPT_DIR=additional-resource/hello-world-root-depls/cf-apps-deployments/generic-app/template
 secrets: # you may define temporary keys in this section, that will be pruned upon spruce invocation, ie won't endup in spruce-generated files
   path_to_my_file: ((concat "../../../../" $CUSTOM_SCRIPT_DIR "/spruce-file-sample-from-templates.txt" ))
 


### PR DESCRIPTION
Before fix:

```sh
/tmp/build/a8fceb73 # cat additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml
---
# This is a workaround as spruce can not easily spruce bosh operators which are not valid yaml
# Spruce native bosh operator isn't supported by COA
# https://github.com/geofffranks/spruce/blob/master/doc/merging-go-patch-files.md
# As an alternative, spruce synax is used in this var file and interpolated into final manifest by coa using bosh int --var-file=files-vars.yml

#manifest_file_content: (( load
deploy_script_file_content: (( file "../../../../additional-resource/master-depls/osb-cmdb-provisioning/template/deploy-ocmdb.bash" ))
/tmp/build/a8fceb73 # ./scripts-resource/concourse/tasks/generate_manifest/generate-manifest.sh
+ spruce --version
spruce - Version 1.14.0
+ pwd
+ CURRENT_DIR=/tmp/build/a8fceb73
+ OUTPUT_DIR=/tmp/build/a8fceb73/generated-files/
+ SPRUCE_SCRIPT_DIR=scripts-resource/concourse/tasks/generate_manifest
+ SUFFIX=-tpl.yml
+ '[' '!' -e ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/meta.yml ]
+ '[' '!' -e ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/secrets.yml ]
+ '[' '!' -e ./credentials-resource/shared/secrets.yml ]
+ '[' '!' -e ./additional-resource/meta-inf.yml ]
+ echo 'selecting -tpl.yml in '"'"'additional-resource/master-depls/osb-cmdb-provisioning/template'"'"
selecting -tpl.yml in 'additional-resource/master-depls/osb-cmdb-provisioning/template'
+ ls additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml
+ basename additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml
+ filename=files-vars-tpl.yml
+ file_extension=.yml
+ echo 'processing files-vars-tpl.yml'
processing files-vars-tpl.yml
+ output_filename=files-vars.yml
+ echo 'generating files-vars.yml'
generating files-vars.yml
+ scripts-resource/concourse/tasks/generate_manifest/spruce-manifest.sh additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/meta.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/secrets.yml ./credentials-resource/shared/secrets.yml ./additional-resource/meta-inf.yml
+ spruce merge --prune secrets --prune meta-inf --prune terraform_outputs additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/meta.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/secrets.yml ./credentials-resource/shared/secrets.yml ./additional-resource/meta-inf.yml
1 error(s) detected:
 - $.deploy_script_file_content: tried to read file ../additional-resource/master-depls/osb-cmdb-provisioning/template/deploy-ocmdb.bash: could not be read - open ../additional-resource/master-depls/osb-cmdb-provisioning/template/deploy-ocmdb.bash: no such file or directory
```
------
After fix:

```sh
cat additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml
---
# This is a workaround as spruce can not easily spruce bosh operators which are not valid yaml
# Spruce native bosh operator isn't supported by COA
# https://github.com/geofffranks/spruce/blob/master/doc/merging-go-patch-files.md
# As an alternative, spruce synax is used in this var file and interpolated into final manifest by coa using bosh int --var-file=files-vars.yml

#manifest_file_content: (( load
deploy_script_file_content: (( file "../../../additional-resource/master-depls/osb-cmdb-provisioning/template/deploy-ocmdb.bash" ))

/tmp/build/a8fceb73 # ./scripts-resource/concourse/tasks/generate_manifest/generate-manifest.sh
+ spruce --version
spruce - Version 1.14.0
+ pwd
+ CURRENT_DIR=/tmp/build/a8fceb73
+ OUTPUT_DIR=/tmp/build/a8fceb73/generated-files/
+ SPRUCE_SCRIPT_DIR=scripts-resource/concourse/tasks/generate_manifest
+ SUFFIX=-tpl.yml
+ '[' '!' -e ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/meta.yml ]
+ '[' '!' -e ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/secrets.yml ]
+ '[' '!' -e ./credentials-resource/shared/secrets.yml ]
+ '[' '!' -e ./additional-resource/meta-inf.yml ]
+ echo 'selecting -tpl.yml in '"'"'additional-resource/master-depls/osb-cmdb-provisioning/template'"'"
selecting -tpl.yml in 'additional-resource/master-depls/osb-cmdb-provisioning/template'
+ ls additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml
+ basename additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml
+ filename=files-vars-tpl.yml
+ file_extension=.yml
+ echo 'processing files-vars-tpl.yml'
processing files-vars-tpl.yml
+ output_filename=files-vars.yml
+ echo 'generating files-vars.yml'
generating files-vars.yml
+ scripts-resource/concourse/tasks/generate_manifest/spruce-manifest.sh additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/meta.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/secrets.yml ./credentials-resource/shared/secrets.yml ./additional-resource/meta-inf.yml
+ spruce merge --prune secrets --prune meta-inf --prune terraform_outputs additional-resource/master-depls/osb-cmdb-provisioning/template/files-vars-tpl.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/meta.yml ./credentials-resource/master-depls/osb-cmdb-provisioning/secrets/secrets.yml ./credentials-resource/shared/secrets.yml ./additional-resource/meta-inf.yml
```