### PR TITLE
Improve wording of error message

### DIFF
--- a/concourse/tasks/check_configuration/run.sh
+++ b/concourse/tasks/check_configuration/run.sh
@@ -29,13 +29,13 @@ if [[ "$LOCAL_SECRETS_SCAN" = "true" ]];then
   echo "Local secrets scan enabled for ${DEPLOYMENT}"
   if [[ ! -e "$CONFIG_DEPLOYMENT_PATH/secrets.yml" && ! -e "$CONFIG_DEPLOYMENT_PATH/meta.yml" ]];then
     echo "ERROR: inconsistency detected in ${DEPLOYMENT}"
-    echo "ERROR: local-secret-scan enabled in deployment-dependencies.yml for ${DEPLOYMENT}, but no config files (meta.yml, secrets.yml) detected at $CONFIG_DEPLOYMENT_PATH" >> ${LOG_FILE}
+    echo "ERROR: local_deployment_scan enabled in deployment-dependencies.yml for ${DEPLOYMENT}, but no config files (meta.yml, secrets.yml) detected at $CONFIG_DEPLOYMENT_PATH" >> ${LOG_FILE}
   fi
 else
   echo "Local secrets scan disabled for ${DEPLOYMENT}"
   if [[ -e "$CONFIG_DEPLOYMENT_PATH/secrets.yml" || -e "$CONFIG_DEPLOYMENT_PATH/meta.yml" ]];then
     echo "ERROR: inconsistency detected in ${DEPLOYMENT}"
-    echo "ERROR: local-secret-scan disabled  in deployment-dependencies.yml for ${DEPLOYMENT}, but config files (meta.yml, secrets.yml) detected at $CONFIG_DEPLOYMENT_PATH" >> ${LOG_FILE}
+    echo "ERROR: local_deployment_scan disabled  in deployment-dependencies.yml for ${DEPLOYMENT}, but config files (meta.yml, secrets.yml) detected at $CONFIG_DEPLOYMENT_PATH" >> ${LOG_FILE}
   fi
 fi
 

--- a/spec/tasks/check_config/task_spec.rb
+++ b/spec/tasks/check_config/task_spec.rb
@@ -54,7 +54,7 @@ describe 'check_configuration task' do
     let(:expected_errors) do
       ['ERROR: dummy-path does not exist (templates-resource/hello-world-root-depls/bosh-deployment-sample), please check related deployment-dependencies.yml',
        "\n",
-       'ERROR: local-secret-scan enabled in deployment-dependencies.yml for bosh-deployment-sample, but no config files (meta.yml, secrets.yml) detected at config-resource/hello-world-root-depls/bosh-deployment-sample/secrets',
+       'ERROR: local_deployment_scan enabled in deployment-dependencies.yml for bosh-deployment-sample, but no config files (meta.yml, secrets.yml) detected at config-resource/hello-world-root-depls/bosh-deployment-sample/secrets',
        "\n"].join('')
     end
 


### PR DESCRIPTION
Was:

ERROR: local-secret-scan disabled  in deployment-dependencies.yml for osb-cmdb-provisioning, but config files (meta.yml, secrets.yml) detected at config-resource/master-depls/osb-cmdb-provisioning/secrets

while expected property is `local_deployment_scan` and not `local-secret-scan`


with deployment-dependencies.yml, this fails: 
```yaml
deployment:
  osb-cmdb-provisioning:
    resources:
    releases:
      cf-cli:
        base_location: https://bosh.io/d/github.com/
        repository: bosh-packages/cf-cli-release
    errands:
      errand-scripting:
```

whith deployment-dependencies.yml deployment is ok

```
deployment:
  osb-cmdb-provisioning:
    resources:
      secrets:
        local_deployment_scan: true
    releases:
      cf-cli:
        base_location: https://bosh.io/d/github.com/
        repository: bosh-packages/cf-cli-release
    errands:
      errand-scripting:
```