### PR TITLE
feature(bosh-pipelines): detect inconsistent boshrelease detect-inconsistent-boshrelease-definitions

### DIFF
--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -19,7 +19,7 @@
   enabled_deployments&.sort&.each do |name, boshrelease|
     boshrelease['releases']&.each do |release, info|
       previous_info = uniq_releases[release]
-      raise "Inconsitency detected with deployment #{name}: trying to replace \n#{previous_info} with \n#{info}" if previous_info && ! info.eql?(previous_info)
+      raise "Inconsitency detected with '#{release}' boshrelease, in '#{name}' deployment: trying to replace\n#{previous_info} with \n#{info}" if previous_info && ! info.eql?(previous_info)
       uniq_releases[release] = info
     end
   end

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -18,6 +18,8 @@
   uniq_releases = {}
   enabled_deployments&.sort&.each do |name, boshrelease|
     boshrelease['releases']&.each do |release, info|
+      previous_info = uniq_releases[release]
+      raise "Inconsitency detected with deployment #{name}: trying to replace \n#{previous_info} with \n#{info}" if previous_info && ! info.eql?(previous_info)
       uniq_releases[release] = info
     end
   end

--- a/concourse/pipelines/template/news-pipeline.yml.erb
+++ b/concourse/pipelines/template/news-pipeline.yml.erb
@@ -8,6 +8,9 @@
   uniq_releases= {}
   all_dependencies.sort.each do |name,boshrelease|
     boshrelease["releases"]&.each do |release, info|
+      previous_info = uniq_releases[release]
+      raise "Inconsitency detected with deployment #{name}: trying to replace \n#{previous_info} with \n#{info}" if previous_info && ! info.eql?(previous_info)
+
       uniq_releases[release] = info
     end
 

--- a/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
+++ b/concourse/pipelines/template/s3-br-upload-pipeline.yml.erb
@@ -4,6 +4,8 @@
   uniq_releases= {}
   all_dependencies.sort.each do |name, boshrelease|
     boshrelease["releases"]&.each do |release, info|
+      previous_info = uniq_releases[release]
+      raise "Inconsitency detected with deployment #{name}: trying to replace \n#{previous_info} with \n#{info}" if previous_info && ! info.eql?(previous_info)
       uniq_releases[release] = info
     end
   end

--- a/lib/pipeline_generator.rb
+++ b/lib/pipeline_generator.rb
@@ -165,7 +165,7 @@ class PipelineGenerator
             options[:ops_automation] = ap_string
           end
 
-          opts.on('-i', '--input PIPELINE1,PIPELINE2', Array, 'List of pipelines to process') do |ip_array|
+          opts.on('-i', '--input PIPELINE1,PIPELINE2', Array, 'List of pipelines to process without full path and without suffix "-pipeline.yml.erb"') do |ip_array|
             options[:input_pipelines] = ip_array
           end
 


### PR DESCRIPTION
when a boshrelease is declared in `deployment-dependencies.yml`, another
deployment cannot override the definition anymore.