### PR TITLE
feature(bosh-pipeline): support errand name customization

### DIFF
--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -760,8 +760,9 @@ jobs:
 
   <% if deployment_details.errands? %>
     <% deployment_details.errands.each do |errand_name, errand_info| %>
-- name: run-errand-<%= name %>-<%= errand_name %>
-  <% jobs["deploy-#{name[0]}*"] << "run-errand-#{name}-#{errand_name}" %>
+    <% errand_display_name = errand_info&.dig('display-name') || errand_name %>
+- name: run-errand-<%= name %>-<%= errand_display_name %>
+  <% jobs["deploy-#{name[0]}*"] << "run-errand-#{name}-#{errand_display_name}" %>
   serial_groups: [auto-errand-<%= name %>]
   on_failure:
     put: failure-alert
@@ -784,8 +785,10 @@ jobs:
 
   <% if deployment_details.manual_errands? %>
     <% deployment_details.manual_errands.each do |errand_name, errand_info| %>
-- name: run-manual-errand-<%= name %>-<%= errand_name %>
-  <% jobs["deploy-#{name[0]}*"] << "run-manual-errand-#{name}-#{errand_name}" %>
+    <% errand_display_name = errand_info&.dig('display-name') || errand_name %>
+- name: run-manual-errand-<%= name %>-<%= errand_display_name %>
+  <% jobs["deploy-#{name[0]}*"] << "run-manual-errand-#{name}-#{errand_display_name}" %>
+
   serial: true
   on_failure:
     put: failure-alert

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/deployment-dependencies.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/deployment-dependencies.yml
@@ -25,7 +25,9 @@ deployment:
         repository: cloudfoundry-community/vault-boshrelease
     errands: # errands to execute automatically after each deploy. Errand are executed one by one in random order.
       # errand-1:
+        # display-name: my-custom-name   # => run-errand-bosh-deployment-sample-my-custom-name (ie: run-errand-<deployment-name>-<display-name>)
       # errand-2:
     manual-errands: # errands manually executed by an operator
       # manual-errand-1:
       # manual-errand-2:
+        # display-name: my-custom-name   # => run-manual-errand-bosh-deployment-sample-my-custom-name

--- a/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
@@ -39,9 +39,11 @@ describe 'BoshPipelineTemplateProcessing' do
         errands:
             import:
             smoke-tests:
+              display-name: automated-smoke-tests
         manual-errands:
             manual-import:
             manual-smoke-tests:
+              display-name: my-smoke-tests
         bosh-deployment:
           active: true
         status: enabled
@@ -116,12 +118,12 @@ describe 'BoshPipelineTemplateProcessing' do
           'recreate-bui',
           'recreate-shield-expe',
           'retrigger-all-jobs',
-          'run-errand-shield-expe-import', 
-          'run-errand-shield-expe-smoke-tests', 
-          'run-manual-errand-shield-expe-manual-import', 
-          'run-manual-errand-shield-expe-manual-smoke-tests'] },
+          'run-errand-shield-expe-automated-smoke-tests',
+          'run-errand-shield-expe-import',
+          'run-manual-errand-shield-expe-manual-import',
+          'run-manual-errand-shield-expe-my-smoke-tests'] },
       { 'name' => 'Deploy-b*', 'jobs' => ['deploy-bui'] },
-      { 'name' => 'Deploy-s*', 'jobs' => ['deploy-shield-expe', 'run-errand-shield-expe-import', 'run-errand-shield-expe-smoke-tests', 'run-manual-errand-shield-expe-manual-import', 'run-manual-errand-shield-expe-manual-smoke-tests' ] },
+      { 'name' => 'Deploy-s*', 'jobs' => ['deploy-shield-expe', 'run-errand-shield-expe-automated-smoke-tests', 'run-errand-shield-expe-import', 'run-manual-errand-shield-expe-manual-import', 'run-manual-errand-shield-expe-my-smoke-tests' ] },
       { 'name' => 'Recreate',
         'jobs' => ['recreate-all', 'recreate-bui', 'recreate-shield-expe'] },
       { 'name' => 'Utils',
@@ -213,9 +215,14 @@ describe 'BoshPipelineTemplateProcessing' do
         expect(generated_errand_resource).to match(expected_shield_errand_resource)
       end
 
-      it 'generates an errand job for shield boshrelease' do
+      it 'generates an errand job for shield boshrelease with default name' do
         generated_errand_job = generated_pipeline['jobs'].select { |job| job['name'] == 'run-errand-shield-expe-import' }.flat_map { |job| job['plan'] }
         expect(generated_errand_job).to match(expected_shield_errand)
+      end
+
+      it 'generates an errand job for shield boshrelease with custom name' do
+        generated_errand_job = generated_pipeline['jobs'].select { |job| job['name'] == 'run-errand-shield-expe-automated-smoke-tests' }.flat_map { |job| job['plan'] }
+        expect(generated_errand_job).not_to be_nil
       end
 
       it 'generates a concourse job per errand for shield boshrelease' do
@@ -243,6 +250,7 @@ describe 'BoshPipelineTemplateProcessing' do
             manual-errands:
               manual-import:
               manual-smoke-tests:
+                display-name: my-smoke-tests
             bosh-deployment:
               active: true
             status: enabled
@@ -268,9 +276,14 @@ describe 'BoshPipelineTemplateProcessing' do
         expect(generated_errand_resource).to match(expected_shield_errand_resource)
       end
 
-      it 'generates an errand job for shield boshrelease' do
-        generated_errand_job = generated_pipeline['jobs'].select { |job| job['name'] == 'run-manual-errand-shield-expe-manual-smoke-tests' }.flat_map { |job| job['plan'] }
+      it 'generates an errand job for shield boshrelease with custom name' do
+        generated_errand_job = generated_pipeline['jobs'].select { |job| job['name'] == 'run-manual-errand-shield-expe-my-smoke-tests' }.flat_map { |job| job['plan'] }
         expect(generated_errand_job).to match(expected_shield_manual_errand)
+      end
+
+      it 'generates an errand job for shield boshrelease with default name' do
+        generated_errand_job = generated_pipeline['jobs'].select { |job| job['name'] == 'run-manual-errand-shield-expe-manual-import' }.flat_map { |job| job['plan'] }
+        expect(generated_errand_job).to_not be_nil
       end
 
       it 'generates a concourse job per manual errand for shield boshrelease' do


### PR DESCRIPTION
By default, errands are named 'run-errand-<deployment-name>-<errand-name>', unless a `display-name` is set in errand definition in deployment-dependencies.yml. When `display-name` is set, name is 'run-errand-<deployment-name>-<display-name>'

close #296