### PR TITLE
WIP: task(bosh-delete-apply): ignore errors on bosh delete deployment

### DIFF
--- a/lib/tasks/bosh/delete_deployment.rb
+++ b/lib/tasks/bosh/delete_deployment.rb
@@ -3,7 +3,7 @@ module Tasks
     # holds bosh delete deployment command
     class DeleteDeployment < Executor
       def execute(name)
-        bosh_command = "bosh delete-deployment --json --non-interactive -d #{name}"
+        bosh_command = "bosh delete-deployment --json --non-interactive -d #{name} --force"
         self.class.run_command(bosh_command)
       end
     end

--- a/spec/lib/tasks/bosh/delete_deployment_spec.rb
+++ b/spec/lib/tasks/bosh/delete_deployment_spec.rb
@@ -43,14 +43,14 @@ describe Tasks::Bosh::DeleteDeployment do
         let(:expected_result) { delete_deployment_response }
 
         before do
-          allow(Open3).to receive(:capture3).with(cmd_env, "bosh delete-deployment --json --non-interactive -d #{my_deployment_name}").
+          allow(Open3).to receive(:capture3).with(cmd_env, "bosh delete-deployment --json --non-interactive -d #{my_deployment_name} --force").
             and_return([delete_deployment_json_response, nil, process_status_zero])
         end
 
         it "executes a bosh command" do
           expect(command_output).to match(expected_result)
 
-          expect(Open3).to have_received(:capture3).with(cmd_env, "bosh delete-deployment --json --non-interactive -d #{my_deployment_name}")
+          expect(Open3).to have_received(:capture3).with(cmd_env, "bosh delete-deployment --json --non-interactive -d #{my_deployment_name} --force")
         end
       end
 
@@ -59,7 +59,7 @@ describe Tasks::Bosh::DeleteDeployment do
         let(:stdout) { "o" }
 
         before do
-          allow(Open3).to receive(:capture3).with(cmd_env, "bosh delete-deployment --json --non-interactive -d #{my_deployment_name}").once.
+          allow(Open3).to receive(:capture3).with(cmd_env, "bosh delete-deployment --json --non-interactive -d #{my_deployment_name} --force").once.
               and_return([stdout, stderr, process_status_one])
         end
 


### PR DESCRIPTION
Changes proposed in this pull-request:
- use --force on bosh delete

We choose to not enable `--force`, we keep this PR if we change our mind