### PR TITLE
feature(bosh-delete-deployment): fail-slow, to delete as much deployments as possible

### DIFF
--- a/concourse/tasks/bosh_delete_apply/delete_apply.rb
+++ b/concourse/tasks/bosh_delete_apply/delete_apply.rb
@@ -9,6 +9,29 @@ class DeleteApply
   end
 
   def process
+    deployed_bosh_deployments = filter_deployment_to_delete
+
+    deployment_deletion_failure = delete_deployments(deployed_bosh_deployments)
+    if deployment_deletion_failure.empty?
+      @config_repo_deployments.cleanup_disabled_deployments
+    else
+      deployment_deletion_failure.each { |deployment_name, error| puts "Error deleting #{deployment_name}: #{error}" }
+      raise Tasks::Bosh::BoshCliError, "Failed to delete deployments: #{deployment_deletion_failure.keys}"
+    end
+  end
+
+  private
+
+  def delete_deployments(deployed_bosh_deployments)
+    puts "Deployments to delete: #{deployed_bosh_deployments}"
+    deployment_deletion_failure = {}
+    deployed_bosh_deployments.each do |deployment_name|
+      delete_deployment(deployment_deletion_failure, deployment_name)
+    end
+    deployment_deletion_failure
+  end
+
+  def filter_deployment_to_delete
     expected_deployments = @config_repo_deployments.enabled_deployments
     puts "Expected deployments: #{expected_deployments}"
     protected_deployments = @config_repo_deployments.protected_deployments
@@ -18,12 +41,13 @@ class DeleteApply
     puts "Active bosh deployments: #{deployed_bosh_deployments}"
     puts "Filtering deployments (ie: excluding expected and protected deployments)"
     deployed_bosh_deployments.delete_if { |deployment_name| expected_deployments&.include?(deployment_name) || protected_deployments&.include?(deployment_name) }
+    deployed_bosh_deployments
+  end
 
-    puts "Deployments to delete: #{deployed_bosh_deployments}"
-    deployed_bosh_deployments.each do |deployment_name|
-      @delete_command_holder.execute(deployment_name)
-      @config_repo_deployments.cleanup_deployment(deployment_name)
-    end
-    @config_repo_deployments.cleanup_disabled_deployments
+  def delete_deployment(deployment_deletion_failure, deployment_name)
+    @delete_command_holder.execute(deployment_name)
+    @config_repo_deployments.cleanup_deployment(deployment_name)
+  rescue Tasks::Bosh::BoshCliError => e
+    deployment_deletion_failure[deployment_name] = e
   end
 end

--- a/spec/tasks/bosh_delete_apply/delete_apply_spec.rb
+++ b/spec/tasks/bosh_delete_apply/delete_apply_spec.rb
@@ -85,15 +85,50 @@ describe DeleteApply do
       context "when a CLI commands fails" do
         let(:stderr) { "e" }
         let(:stdout) { "o" }
+        let(:error_message) {
+          <<~TEXT
+            Stderr: (Tasks::Bosh::BoshCliError)
+            Stdout:
+            {
+                "Tables": null,
+                "Blocks": [
+                    "Deleting instances: worker/2f126d82-e8fc-4dc5-92d9-6a4f0f2bd883 (2)",
+                    "\nTask 9264639 | 08:07:07 | ",
+                    "Deleting instances: master/b01722bd-c732-45a4-a4ac-c29e6c124e9a (1)",
+                    "\nTask 9264639 | 08:07:07 | ",
+                    "Deleting instances: worker/94f3fbe5-7c27-4725-b681-a382b0aa784f (4)",
+                    "\nTask 9264639 | 08:07:08 | ",
+                    "Deleting instances: management/e3519ca5-0a79-4ac7-92b0-b52791e57a52 (0) (00:00:01)",
+                    "\n                     L Error: Action Failed get_task: Task c3c9f620-f0fd-490d-580c-0bb639e8b767 result: 1 of 2 pre-stop scripts failed. Failed Jobs: action. Successful Jobs: management.",
+                    "\nTask 9264639 | 08:08:35 | ",
+                    "Deleting instances: worker/2f126d82-e8fc-4dc5-92d9-6a4f0f2bd883 (2) (00:01:28)",
+                    "\nTask 9264639 | 08:08:40 | ",
+                    "Deleting instances: worker/4c9c9065-d723-410e-8fa7-b28c09277a61 (0) (00:01:56)",
+                    "\nTask 9264639 | 08:09:03 | ",
+                    "Error: Action Failed get_task: Task c3c9f620-f0fd-490d-580c-0bb639e8b767 result: 1 of 2 pre-stop scripts failed. Failed Jobs: action. Successful Jobs: management."
+                ],
+                "Lines": [
+                    "Using environment '192.168.99.155' as client 'admin'",
+                    "Using deployment 'k_7bd80932-4d39-4fb9-969a-2445ade2495d'",
+                    "Task 9264639",
+                    "\n",
+                    "\n\nTask 9264639 Started  Tue Feb 25 08:07:07 UTC 2020\nTask 9264639 Finished Tue Feb 25 08:09:03 UTC 2020\nTask 9264639 Duration 00:01:56",
+                    "\nTask 9264639 error\n",
+                    "Deleting deployment 'k_7bd80932-4d39-4fb9-969a-2445ade2495d':\n  Expected task '9264639' to succeed but state is 'error'",
+                    "Exit code 1"
+                ]
+            }
+          TEXT
+        }
 
         before do
           allow(bosh_list_deployments).to receive(:execute).and_return(%w[a b c d1 d2 d3])
-          allow(bosh_delete_deployment).to receive(:execute).and_raise(Tasks::Bosh::BoshCliError)
+          allow(bosh_delete_deployment).to receive(:execute).and_raise(Tasks::Bosh::BoshCliError, error_message)
         end
 
         it "error" do
           expect { delete_apply.process }.
-              to raise_error(Tasks::Bosh::BoshCliError)
+            to raise_error(Tasks::Bosh::BoshCliError, "Failed to delete deployments: [\"d1\", \"d2\", \"d3\"]")
         end
       end
     end


### PR DESCRIPTION
to avoid leaks, we choose to ignore errors on bosh delete, so we can delete as much deployments as possible and we get all errors at the end.