### PR TITLE
fix(bootstrap-all-init-pipeline): replace curl by wget

### DIFF
--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -284,7 +284,7 @@ jobs:
           mkdir -p /usr/local/bin
           FLY=/usr/local/bin/fly
           echo "Fetching fly...";
-          curl -SsL "$ATC_EXTERNAL_URL/api/v1/cli?arch=amd64&platform=linux" -k > $FLY;
+          wget --no-check-certificate -O "$FLY" "$ATC_EXTERNAL_URL/api/v1/cli?arch=amd64&platform=linux"
           chmod +x $FLY;
 
           echo "Login to Concourse using extracted credentials (ATC_EXTERNAL_URL, FLY_USERNAME, FLY_PASSWORD)"

--- a/lib/coa/integration_tests/constants.rb
+++ b/lib/coa/integration_tests/constants.rb
@@ -15,10 +15,11 @@ module Coa
         "bootstrap-all-init-pipelines" => {
           "team" => "main",
           "jobs" => {
-            "bootstrap-pipelines"        => { "trigger" => true },
-            "create-teams"               => {},
-            "bootstrap-control-plane"    => {},
-            "bootstrap-update-pipelines" => {}
+            "bootstrap-pipelines"            => { "trigger" => true },
+            "reload-this-pipeline-from-git"  => { "trigger" => true },
+            "create-teams"                   => {},
+            "bootstrap-control-plane"        => {},
+            "bootstrap-update-pipelines"     => {}
           }
         },
         "hello-world-root-depls-update-generated" => {

--- a/scripts/concourse-bootstrap.sh
+++ b/scripts/concourse-bootstrap.sh
@@ -49,20 +49,18 @@ else
 fi
 echo "COA config directory detected: <${CONFIG_DIR}>"
 
-FILTERED_CONFIG_FILES=$(cd ${CONFIG_DIR} && ls -1 credentials-*.yml|grep -v pipeline)
+FILTERED_CONFIG_FILES=$(cd "${CONFIG_DIR}" && ls -1 credentials-*.yml|grep -v pipeline)
 VARS_FILES=""
 for config_file in ${FILTERED_CONFIG_FILES}; do
     VARS_FILES="${VARS_FILES}-l \"${CONFIG_DIR}/${config_file}\" "
 done
-echo ${VARS_FILES}
-set +e
-set -x
-${FLY_CMD} -t ${FLY_TARGET} set-pipeline ${FLY_SET_PIPELINE_OPTION} -p ${PIPELINE} -c ${SCRIPT_DIR}/concourse/pipelines/${PIPELINE}.yml  \
-            ${VARS_FILES}
-set +x
-set -e
-${FLY_CMD} -t ${FLY_TARGET} unpause-pipeline -p ${PIPELINE}
-if [ "$SKIP_TRIGGER" != "true" ]
-then
-    ${FLY_CMD} -t ${FLY_TARGET} trigger-job -j "${PIPELINE}/bootstrap-pipelines"
+echo "Selected var files: ${VARS_FILES}"
+
+set +e; set -x
+"${FLY_CMD}" -t "${FLY_TARGET}" set-pipeline ${FLY_SET_PIPELINE_OPTION} -p "${PIPELINE}" -c "${SCRIPT_DIR}/concourse/pipelines/${PIPELINE}.yml" ${VARS_FILES}
+set +x; set -e
+
+${FLY_CMD} -t ${FLY_TARGET} unpause-pipeline -p "${PIPELINE}"
+if [ "$SKIP_TRIGGER" != "true" ]; then
+    "${FLY_CMD}" -t "${FLY_TARGET}" trigger-job -j "${PIPELINE}/bootstrap-pipelines"
 fi


### PR DESCRIPTION
Curl is not included in `governmentpaas/bosh-cli-v2` image, so we switch to wget, as it is embedded in image.
We broke this task when we swtiched to this image (from `governmentpaas/curl-ssl`).
We also include `reload-this-pipeline-from-git` in `integration-tests`