### PR TITLE
feature(allow-incomplete-crehub-interpolation):

### DIFF
--- a/concourse/tasks/bosh_update_config/run.sh
+++ b/concourse/tasks/bosh_update_config/run.sh
@@ -63,7 +63,7 @@ cat "${BOSH_INTERPOLATED_FILE}"
 
 echo "apply credhub interpolation to bosh interpolated file"
 CREDHUB_INTERPOLATED_FILE="credhub-interpolated-${CONFIG_TYPE}-config.yml"
-credhub interpolate -f "${BOSH_INTERPOLATED_FILE}" > "${CREDHUB_INTERPOLATED_FILE}"
+credhub interpolate -f "${BOSH_INTERPOLATED_FILE}" --skip-missing > "${CREDHUB_INTERPOLATED_FILE}"
 
 echo "updating ${CONFIG_TYPE} with ${CREDHUB_INTERPOLATED_FILE}"
 bosh -n update-config --type "${CONFIG_TYPE}" --name default "${CREDHUB_INTERPOLATED_FILE}"


### PR DESCRIPTION
Credhub won't error on missing variable, it is going to fail during `bosh deployment` step

close #331

