### PR TITLE
feature(multi-concourse-version-compliant-pipelines): update pipelines to be able to run it on concourse 5.8.x and concourse 6.4.x

### DIFF
--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -129,6 +129,17 @@ jobs:
               content += "    username: #{fly_username}\n"
               content += "    password: \"#{fly_password}\"\n"
             end
+            content =  "- type: remove\n"
+            content += "  path: /resources/name=concourse-5-micro/source/teams\n"
+            content +=  "- type: replace\n"
+            content += "  path: /resources/name=concourse-5-micro/source/teams?\n"
+            content += "  value:\n"
+            teams_list.each do |team_name|
+              content += "  - name: #{team_name}\n"
+              content += "    username: #{fly_username}\n"
+              content += "    password: \"#{fly_password}\"\n"
+            end
+
             File.open(operator_file, 'w') { |file| file.write content }
             EOF
             cat generate_team_operator.rb

--- a/concourse/pipelines/control-plane.yml
+++ b/concourse/pipelines/control-plane.yml
@@ -1,10 +1,15 @@
 ---
 resource_types:
+  - name: concourse-5-pipeline
+    type: docker-image
+    source:
+      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      tag: 5.0.0
   - name: concourse-pipeline
     type: docker-image
     source:
       repository: ((docker-registry-url))concourse/concourse-pipeline-resource
-      tag: 2.1.1
+      tag: 6.0.0
   - name: slack-notification
     type: docker-image
     source:
@@ -83,13 +88,19 @@ resources:
 - name: concourse-micro
   icon: concourse-ci
   type: concourse-pipeline
-  source:
+  source: &concourse_config
     target: ((concourse-micro-depls-target))
     insecure: "true"
     teams:
     - name: main
       username: ((concourse-micro-depls-username))
       password: "((concourse-micro-depls-password))"
+
+- name: concourse-5-micro
+  icon: concourse-ci
+  type: concourse-5-pipeline
+  source: *concourse_config
+
 jobs:
 - name: save-deployed-pipelines
   build_log_retention:
@@ -162,6 +173,59 @@ jobs:
       repository: updated-pipelines
       rebase: true
 
+- name: save-deployed-pipelines-legacy
+  build_log_retention:
+    builds: 30
+  serial: true
+  on_failure: &failure_alert
+    put: failure-alert
+    params:
+      channel: ((slack-channel))
+      text: Failed [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+  plan:
+    - in_parallel:
+        - put: concourse-meta
+        - get: cf-ops-automation
+          params: { submodules: none}
+        - get: secrets-writer
+          params: { submodules: none}
+        - get: concourse-5-micro
+          trigger: true
+    - task: sort-pipelines
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((docker-registry-url))library/ruby
+            tag: 2.6.3
+        inputs:
+          - name: concourse-5-micro
+        outputs:
+          - name: sorted-pipelines
+        run:
+          path: /bin/bash
+          args:
+            - -ec
+            - |
+              cp -p concourse-5-micro/*.yml sorted-pipelines/
+              cd sorted-pipelines
+              ruby -ryaml -e 'Dir["*.yml"].each { |yaml_file| puts "processing #{yaml_file}"; yaml = YAML.load_file(yaml_file); yaml["resources"] = yaml["resources"]&.sort_by { |x| x["name"]}; yaml["resource_types"] = yaml["resource_types"]&.sort_by { |x| x["name"]}; puts "rewriting #{yaml_file}"; File.open(yaml_file, "w") { |file| file.write(yaml.to_yaml) } }'
+
+    - task: update-git-deployed-pipelines
+      input_mapping: {reference-resource: secrets-writer, generated-resource: sorted-pipelines}
+      output_mapping: {updated-git-resource: updated-pipelines}
+      file: cf-ops-automation/concourse/tasks/git_update_a_dir_from_generated.yml
+      params:
+        COMMIT_MESSAGE: "Deployed pipelines update - [skip ci]"
+        OLD_DIR: "coa/pipelines/deployed"
+    - put: secrets-writer
+      params:
+        repository: updated-pipelines
+        rebase: true
+
 - name: on-git-commit
   build_log_retention:
     builds: 30
@@ -232,10 +296,66 @@ jobs:
           du -a config-resource/coa/pipelines/generated|wc -l
   - task: generate-concourse-pipeline-config
     file: cf-ops-automation/concourse/tasks/generate_concourse_pipeline_config/task.yml
-  - put: concourse-micro
-    attempts: 3
-    params:
-      pipelines_file: concourse-pipeline-config/pipelines-definitions.yml
+  - try:
+      put: concourse-micro
+      attempts: 3
+      params:
+        pipelines_file: concourse-pipeline-config/pipelines-definitions.yml
+      on_success:
+        task: set-success-tag
+        output_mapping: { success-tag: concourse-micro-success}
+        config: &success_tag
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ((docker-registry-url))governmentpaas/git-ssh
+              tag: 2857fdbaea59594c06cf9c6e32027091b67d4767
+          outputs:
+            - name: success-tag
+          run:
+            path: sh
+            args:
+              - -ec
+              - touch success-tag/task.ok
+      on_failure:
+        put: concourse-5-micro
+        attempts: 3
+        params:
+          pipelines_file: concourse-pipeline-config/pipelines-definitions.yml
+        on_success:
+          task: set-success-tag
+          output_mapping: { success-tag: concourse-5-micro-success}
+          config: *success_tag
+
+  - task: check-success-tag
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: ((docker-registry-url))governmentpaas/git-ssh
+          tag: 2857fdbaea59594c06cf9c6e32027091b67d4767
+      inputs:
+        - name: concourse-micro-success
+          optional: true
+        - name: concourse-5-micro-success
+          optional: true
+      run:
+        path: sh
+        args:
+          - -ec
+          - |
+            if [ -e concourse-micro-success/task.ok ];then
+              echo "Task concourse-micro successfull"
+              exit 0
+            fi
+            if [ -e concourse-5-micro-success/task.ok ];then
+              echo "Task concourse-5-micro successfull"
+              exit 0
+            fi
+            echo "Failed to update pipelines, please check logs"
+            exit 1
 
 - name: push-changes
   build_log_retention:

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -731,7 +731,7 @@ jobs:
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
     - get: ((stemcell-main-name))
       trigger: true
-      tarball: false
+      <%= "tarball: false" unless offline_stemcells_enabled %>
       attempts: 2
     - get: cf-ops-automation
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
@@ -739,7 +739,7 @@ jobs:
   <% deployment_details.releases.each do |release, _info| %>
     - get: <%= release %>
       trigger: true
-      tarball: false
+      <%= "tarball: false" unless offline_boshreleases_enabled %>
       attempts: 2
   <% end %>
   <% if deployment_details.local_deployment_secrets_scan? %>

--- a/concourse/pipelines/template/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/template/concourse-pipeline.yml.erb
@@ -9,11 +9,17 @@
 %>
 ---
 resource_types:
+  - name: concourse-5-pipeline
+    type: docker-image
+    source:
+      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      tag: 5.0.0
+
   - name: concourse-pipeline
     type: docker-image
     source:
       repository: ((docker-registry-url))concourse/concourse-pipeline-resource
-      tag: 2.1.1
+      tag: 6.0.0
 
   - name: slack-notification
     type: docker-image
@@ -46,6 +52,18 @@ resources:
     - name: main
       username: ((concourse-<%= depls %>-username))
       password: ((concourse-<%= depls %>-password))
+
+- name: concourse-5-legacy-for-<%= depls %>
+  icon: concourse-ci
+  type: concourse-5-pipeline
+  source:
+    target: ((concourse-<%= depls %>-target))
+    insecure: ((concourse-<%= depls %>-insecure))
+    teams:
+      - name: main
+        username: ((concourse-<%= depls %>-username))
+        password: ((concourse-<%= depls %>-password))
+
 
 - name: cf-ops-automation
   icon: rocket
@@ -182,10 +200,69 @@ jobs:
       CONFIG_PATH: config-resource/coa/config
       OUTPUT_CONFIG_PATH: secrets-<%=name %>/coa/config
       OUTPUT_PIPELINE_PATH: final-<%= name %>-pipeline
-  - put: concourse-for-<%= depls %>
-    attempts: 3
-    params:
-      pipelines_file: concourse-pipeline-config/pipelines-definitions.yml
+  - try:
+      put: concourse-for-<%= depls %>
+      attempts: 3
+      params:
+        pipelines_file: concourse-pipeline-config/pipelines-definitions.yml
+      on_success:
+        task: set-success-tag
+        output_mapping: { success-tag: concourse-micro-success}
+        config: &success_tag
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ((docker-registry-url))governmentpaas/git-ssh
+              tag: 2857fdbaea59594c06cf9c6e32027091b67d4767
+          outputs:
+            - name: success-tag
+          run:
+            path: sh
+            args:
+              - -ec
+              - touch success-tag/task.ok
+      on_failure:
+        put: concourse-5-legacy-for-<%= depls %>
+        attempts: 3
+        params:
+          pipelines_file: concourse-pipeline-config/pipelines-definitions.yml
+        on_success:
+          task: set-success-tag
+          output_mapping: { success-tag: concourse-5-micro-success}
+          config: *success_tag
+
+  - task: check-success-tag
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: ((docker-registry-url))governmentpaas/git-ssh
+          tag: 2857fdbaea59594c06cf9c6e32027091b67d4767
+      inputs:
+        - name: concourse-micro-success
+          optional: true
+        - name: concourse-5-micro-success
+          optional: true
+      run:
+        path: sh
+        args:
+          - -ec
+          - |
+            if [ -e concourse-micro-success/task.ok ];then
+              echo "Task concourse-micro successfull"
+              exit 0
+            fi
+            if [ -e concourse-5-micro-success/task.ok ];then
+              echo "Task concourse-5-micro successfull"
+              exit 0
+            fi
+            echo "Failed to update pipelines, please check logs"
+            exit 1
+
+
+
   - task: execute-<%= name %>-post-deploy
     input_mapping: {scripts-resource: cf-ops-automation, template-resource: paas-templates-<%= name %>, credentials-resource: secrets-<%= name %>, additional-resource: final-<%= name %>-pipeline}
     output_mapping: {generated-files: post-deploy-result}

--- a/lib/coa/integration_tests/constants.rb
+++ b/lib/coa/integration_tests/constants.rb
@@ -34,7 +34,7 @@ module Coa
             "on-git-commit"            => {},
             "load-generated-pipelines" => {},
             "push-changes"             => {},
-            "save-deployed-pipelines"  => {}
+            "save-deployed-pipelines-legacy"  => {}
           }
         },
         "hello-world-root-depls-cf-apps-generated" => {

--- a/spec/scripts/generate-depls/fixtures/references/empty-concourse.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-concourse.yml
@@ -1,11 +1,16 @@
 
 ---
 resource_types:
+  - name: concourse-5-pipeline
+    type: docker-image
+    source:
+      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      tag: 5.0.0
   - name: concourse-pipeline
     type: docker-image
     source:
       repository: ((docker-registry-url))concourse/concourse-pipeline-resource
-      tag: 2.1.1
+      tag: 6.0.0
   - name: slack-notification
     type: docker-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -482,7 +482,6 @@ jobs:
       params: { submodules: none, depth: 0 }
     - get: ((stemcell-main-name))
       trigger: true
-      tarball: false
       attempts: 2
     - get: cf-ops-automation
       params: { submodules: none, depth: 0 }
@@ -691,7 +690,6 @@ jobs:
       params: { submodules: none, depth: 0 }
     - get: ((stemcell-main-name))
       trigger: true
-      tarball: false
       attempts: 2
     - get: cf-ops-automation
       params: { submodules: none, depth: 0 }


### PR DESCRIPTION
feature(multi-concourse-version-compliant-pipelines): update pipelines to be able to run it on concourse 5.8.x and concourse 6.4.x

It seems concourse 6.4 do some checks on resource get params and it fails if unexpected params are detected.
We need to support two concourse-pipeline resources as authentication between concourse 5.8.1 and 6.4.x are not compatible.  
So we add dual mode to reach concourse, as concourse 6 is the target version, we first try to deploy on v6 and only on failure we try on v5. As when there is a failure, build stop we need to use a `try` step to allow failure, and we need a way to detect success as `try` step always succeed. We use `on_success`, as it seems only triggered when `try` step succeed.