### PR TITLE
pipeline(bosh-precompile): fix pipeline team

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -167,6 +167,7 @@ jobs:
           - |
             echo "Testing environment config:"
             echo "---------------------------"
+            echo "System: $(uname -a)"
             echo "fly $(fly --version)"
             ruby --version
             bundle --version
@@ -300,7 +301,6 @@ jobs:
             CREDHUB_SECRET: "((integration-test-prereqs.credhub.secret))"
             CREDHUB_CA_CERT: ((integration-test-prereqs.credhub.ca-cert))
             CREHUB_CONCOURSE_NAMESPACE: concourse-IT
-            CONCOURSE_TEAMS: main upload
           run:
             path: /bin/bash
             args:
@@ -320,6 +320,10 @@ jobs:
                 credhub f
                 #credhub set -n
                 ruby --version
+                cd cf-ops-automation
+                CURRENT_TEAMS=$(grep -E "^[[:space:]]*team:" docs/reference_dataset/config_repository/hello-world-root-depls/ci-deployment-overview.yml|sort|uniq|cut -d':' -f2|cut -c2-)
+                CONCOURSE_TEAMS="main $CURRENT_TEAMS"
+                echo "Teams to process: ${CONCOURSE_TEAMS}"
                 for team in ${CONCOURSE_TEAMS};do
                   credhub set --type value -n "/${CREHUB_CONCOURSE_NAMESPACE}/${team}/docker-registry-url" -v "registry.hub.docker.com/"
                 done

--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -27,7 +27,7 @@
   pipeline_options = PipelineHelpers::PipelineConfigurerOptions.new.with_config(config).with_root_deployment(root_deployment_name).build
   configurer = PipelineHelpers::PipelineConfigurer.new(pipeline_options)
 
-  current_team = CiDeployment.team(all_ci_deployments, root_deployment_name, "#{root_deployment_name}-bosh-precompile-generated")
+  current_team = CiDeployment.team(all_ci_deployments, root_deployment_name, "#{root_deployment_name}-bosh-precompile-generated") || root_deployment_name
 
   name = "#{root_deployment_name}-release-precompile-deployment"
 
@@ -776,6 +776,7 @@ jobs:
       <% from_prefix = PipelineHelpers.bosh_io_hosted?(info) ? "version" : "tag" %>
       <% if offline_boshreleases_enabled %>
             echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from path:<%= info['repository']&.split('/')&.first %>/<%= name %>-((releases.<%= name %>.version)).tgz" | tee -a result-dir/flight-plan
+            echo "check-resource -r $BUILD_PIPELINE_NAME/compiled-<%= name %> --from path:<%= info['repository']&.split('/')&.first %>/<%= name %>-((releases.<%= name %>.version))-((s3-compiled-release-os))-((stemcell.version)).tgz" | tee -a result-dir/flight-plan
       <% else %>
             echo "check-resource -r $BUILD_PIPELINE_NAME/<%= name %> --from <%= from_prefix %>:<%= PipelineHelpers.tag_prefix(info) %>((releases.<%= name %>.version))" | tee -a result-dir/flight-plan
       <% end %>
@@ -795,7 +796,7 @@ jobs:
         ATC_EXTERNAL_URL: ((concourse-<%= root_deployment_name %>-target))
         FLY_USERNAME: ((concourse-<%= root_deployment_name %>-username))
         FLY_PASSWORD: "((concourse-<%= root_deployment_name %>-password))"
-        FLY_TEAM: <%= current_team || 'main' %>
+        FLY_TEAM: <%= current_team %>
   <% end %>
 
 

--- a/docs/reference_dataset/config_repository/hello-world-root-depls/ci-deployment-overview.yml
+++ b/docs/reference_dataset/config_repository/hello-world-root-depls/ci-deployment-overview.yml
@@ -5,13 +5,15 @@ ci-deployment:
     terraform_config:
       state_file_path: hello-world-root-depls/terraform-config
     pipelines:
-      hello-world-root-depls-cf-apps-generated: {}
-      hello-world-root-depls-update-generated: {}
-      hello-world-root-depls-bosh-precompile-generated: {}
-      hello-world-root-depls-bosh-generated:
-        team: main
+      hello-world-root-depls-cf-apps-generated: # This pipeline is deployed in 'main' team unless specified
+        team: hello-world-root-depls
+      hello-world-root-depls-update-generated: {} # This pipeline must be in 'main' team
+      hello-world-root-depls-bosh-precompile-generated: # This pipeline is deployed in '<root-deployment-name>' team unless specified
+        team: hello-world-root-depls
+      hello-world-root-depls-bosh-generated: # This pipeline is deployed in 'main' team unless specified
+        team: hello-world-root-depls
         vars_files:
         - hello-world-root-depls/root-deployment.yml
         - shared/concourse-credentials.yml
-      hello-world-root-depls-concourse-generated:
-        team: main
+      hello-world-root-depls-concourse-generated: # This pipeline is deployed in 'main' team unless specified
+        team: hello-world-root-depls

--- a/lib/coa/integration_tests/constants.rb
+++ b/lib/coa/integration_tests/constants.rb
@@ -15,11 +15,11 @@ module Coa
         "bootstrap-all-init-pipelines" => {
           "team" => "main",
           "jobs" => {
-            "bootstrap-pipelines"            => { "trigger" => true },
-            "reload-this-pipeline-from-git"  => { "trigger" => true },
-            "create-teams"                   => {},
-            "bootstrap-control-plane"        => {},
-            "bootstrap-update-pipelines"     => {}
+            "bootstrap-pipelines" => { "trigger" => true },
+            "reload-this-pipeline-from-git" => { "trigger" => true },
+            "create-teams" => {},
+            "bootstrap-control-plane" => {},
+            "bootstrap-update-pipelines" => {}
           }
         },
         "hello-world-root-depls-update-generated" => {
@@ -31,49 +31,49 @@ module Coa
         "control-plane" => {
           "team" => "main",
           "jobs" => {
-            "on-git-commit"            => {},
+            "on-git-commit" => {},
             "load-generated-pipelines" => {},
-            "push-changes"             => {},
-            "save-deployed-pipelines"  => {}
+            "push-changes" => {},
+            "save-deployed-pipelines" => {}
           }
         },
         "hello-world-root-depls-cf-apps-generated" => {
-          "team" => "main",
+          "team" => "hello-world-root-depls",
           "jobs" => {
             "cf-push-generic-app" => {}
           }
         },
         "hello-world-root-depls-bosh-precompile-generated" => {
-            "team" => "main",
-            "jobs" => {
-                "hello-world-root-depls-release-precompile-deployment" => {},
-                "compile-and-export-ntp" => {},
-                "compile-and-export-nginx" => {},
-                "compile-and-export-vault" => {},
-                "init-concourse-boshrelease-and-stemcell-for-hello-world-root-depls" => {},
-                "delete-hello-world-root-depls-release-precompile-deployment" => {}
-            }
+          "team" => "hello-world-root-depls",
+          "jobs" => {
+              "hello-world-root-depls-release-precompile-deployment" => {},
+              "compile-and-export-ntp" => {},
+              "compile-and-export-nginx" => {},
+              "compile-and-export-vault" => {},
+              "init-concourse-boshrelease-and-stemcell-for-hello-world-root-depls" => {},
+              "delete-hello-world-root-depls-release-precompile-deployment" => {}
+          }
         },
         "hello-world-root-depls-bosh-generated" => {
-          "team" => "main",
+          "team" => "hello-world-root-depls",
           "jobs" => {
-            "delete-deployments-review"                                          => {},
-            "approve-and-delete-disabled-deployments"                            => { "trigger" => true },
+            "delete-deployments-review" => {},
+            "approve-and-delete-disabled-deployments" => { "trigger" => true },
             "init-concourse-boshrelease-and-stemcell-for-hello-world-root-depls" => {},
-            "cloud-config-and-runtime-config-for-hello-world-root-depls"         => { "pause" => true },
-            "execute-deploy-script"                                              => {},
-            "deploy-bosh-deployment-sample"                                      => {},
-            "check-terraform-consistency"                                        => {},
-            "approve-and-enforce-terraform-consistency"                          => { "trigger" => true },
-            "recreate-all"                                                       => { "trigger" => true },
-            "recreate-bosh-deployment-sample"                                    => {},
-            "cancel-all-bosh-tasks"                                              => { "trigger" => true },
-            "push-stemcell"                                                      => {},
-            "push-boshreleases"                                                  => {}
+            "cloud-config-and-runtime-config-for-hello-world-root-depls" => { "pause" => true },
+            "execute-deploy-script" => {},
+            "deploy-bosh-deployment-sample" => {},
+            "check-terraform-consistency" => {},
+            "approve-and-enforce-terraform-consistency" => { "trigger" => true },
+            "recreate-all" => { "trigger" => true },
+            "recreate-bosh-deployment-sample" => {},
+            "cancel-all-bosh-tasks" => { "trigger" => true },
+            "push-stemcell" => {},
+            "push-boshreleases" => {}
           }
         },
         "hello-world-root-depls-concourse-generated" => {
-          "team" => "main",
+          "team" => "hello-world-root-depls",
           "jobs" => {
             "deploy-concourse-pipeline-sample-pipeline" => {}
           }

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
@@ -586,7 +586,7 @@ jobs:
         ATC_EXTERNAL_URL: ((concourse-simple-depls-target))
         FLY_USERNAME: ((concourse-simple-depls-username))
         FLY_PASSWORD: "((concourse-simple-depls-password))"
-        FLY_TEAM: main
+        FLY_TEAM: simple-depls
 groups:
   - name: Simple-depls
     jobs:


### PR DESCRIPTION
The default team in this pipeline is '<root-deployment-name>' unless it is 'main' in other pipelines. This is required as this pipeline in not loaded as others pipelines, it loaded by upgrade pipeline, not describe in `ci-deployment-overview.yml`.
We also use teams in out IT.
