### PR TITLE
pipeline(bosh-precompile): only use templates to generate pipeline

### DIFF
--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -6,12 +6,14 @@
     deployment_info['status'] == 'disabled'
   end
 
-  enabled_deployments = all_dependencies.select do |_, deployment_info|
-    deployment_info['status'] == 'enabled' && deployment_info['bosh-deployment']
+  precompile_excluded_deployments = config&.dig(root_deployment_name,'precompile','excluded-deployments') || []
+
+  filtered_deployments = all_dependencies.select do |deployment_name, deployment_info|
+    !precompile_excluded_deployments.include?(deployment_name) && deployment_info['bosh-deployment']
   end
 
   uniq_releases = {}
-  enabled_deployments&.sort&.each do |name, boshrelease|
+  filtered_deployments&.sort&.each do |name, boshrelease|
     boshrelease['releases']&.each do |release, info|
       previous_info = uniq_releases[release]
       raise "Inconsitency detected with '#{release}' boshrelease, in '#{name}' deployment: trying to replace\n#{previous_info} with \n#{info}" if previous_info && ! info.eql?(previous_info)
@@ -581,7 +583,7 @@ jobs:
     <% end %>
     <% end %>
 
-  <% if enabled_deployments.any? %>
+  <% if filtered_deployments.any? %>
   - name: init-concourse-boshrelease-and-stemcell-for-<%= root_deployment_name %>
     <% jobs["Utils"] << "init-concourse-boshrelease-and-stemcell-for-#{root_deployment_name}" %>
     on_failure:

--- a/concourse/tasks/resolve_manifest_versions/resolve_manifest_versions.rb
+++ b/concourse/tasks/resolve_manifest_versions/resolve_manifest_versions.rb
@@ -59,7 +59,7 @@ class ResolveManifestVersions
     version = stemcell.dig('version')
     optional_os = stemcell.dig('os')
     optional_name = stemcell.dig('name')
-    [stemcell_alias, version, optional_os, optional_name ]
+    [stemcell_alias, version, optional_os, optional_name]
   end
 
   def process_releases_versions(resolved_manifest, versions)

--- a/docs/reference_dataset/config_repository/private-config.yml
+++ b/docs/reference_dataset/config_repository/private-config.yml
@@ -28,3 +28,5 @@
 #    serial_group_naming_strategy: SerialGroupMd5NamingStrategy #Default: SerialGroupRoundRobinNamingStrategy
 #  git:
 #    shallow-clone-depth: 1 # Default: 0, ie disabled
+#    precompile:
+#       excluded_deployments: [] # Default: [] # List deployments to exclude from precompilation. As precompilation does not use secrets repository to determine enabled deployments, it might be convenient to exclude a deployment not enanled in secrets.

--- a/docs/reference_dataset/template_repository/shared-config.yml
+++ b/docs/reference_dataset/template_repository/shared-config.yml
@@ -34,3 +34,5 @@ default:
 #  concourse:
 #    parallel_execution_limit: 10 # Default: -1, ie unlimited
 #    serial_group_naming_strategy: SerialGroupMd5NamingStrategy #Default: SerialGroupRoundRobinNamingStrategy
+#    precompile:
+#       excluded_deployments: [] # Default: [] # List deployments to exclude from precompilation. As precompilation does not use secrets repository to determine enabled deployments, it might be convenient to exclude a deployment not enanled in secrets.

--- a/lib/deployment.rb
+++ b/lib/deployment.rb
@@ -4,6 +4,7 @@ require_relative 'active_support_copy_deep_merge'
 class Deployment
   attr_reader :name, :details
 
+  DEPLOYERS = %w[bosh-deployment kubernetes concourse terraform].freeze
   def initialize(deployment_name, details = {})
     @name = deployment_name
     @details = {}
@@ -25,6 +26,7 @@ class Deployment
 
   def disable
     details['status'] = 'disabled'
+    DEPLOYERS.each { |deployer| details[deployer]&.delete('active') }
     self
   end
 

--- a/lib/deployment_deployers_config.rb
+++ b/lib/deployment_deployers_config.rb
@@ -38,7 +38,7 @@ class DeploymentDeployersConfig
   end
 
   def load_bosh_config(deployment_details)
-    puts "Bosh release detected: #{@deployment_name}"
+    puts "Looking for bosh deployment files for #{@deployment_name}"
     dependency_filename = File.join(@public_base_location, DEPLOYMENT_DEPENDENCIES_FILENAME)
     return unless File.exist?(dependency_filename)
 

--- a/lib/root_deployment.rb
+++ b/lib/root_deployment.rb
@@ -20,21 +20,11 @@ class RootDeployment
 
   def overview_from_hash(deployment_factory)
     dependencies = {}
-
-    select_deployment_scan_files&.each do |filename|
-      dirname = filename.split(File::SEPARATOR).last
+    select_deployment_scan_files&.each do |enable_deployment_path|
+      dirname = enable_deployment_path.split(File::SEPARATOR).last
       puts "Processing #{dirname}"
-
-      enable_deployment_file = File.join(filename, ENABLE_DEPLOYMENT_FILENAME)
-      deployment = if File.exist?(enable_deployment_file)
-                     base_location = File.join(@dependency_root_path, @root_deployment_name, dirname)
-                     deployers_config = DeploymentDeployersConfig.new(dirname, base_location, filename, deployment_factory)
-                     deployers_config.load_configs
-                   else
-                     puts "Deployment #{dirname} is inactive"
-                     Deployment.new(dirname).disable
-                   end
-
+      deployers_config = create_deployment_deployer_config(dirname, deployment_factory, enable_deployment_path)
+      deployment = load_deployment_config_files(dirname, deployers_config, enable_deployment_path)
       dependencies[deployment.name] = deployment.details
     end
 
@@ -50,6 +40,28 @@ class RootDeployment
   end
 
   private
+
+  def create_deployment_deployer_config(deployment_name, deployment_factory, filename)
+    base_location = File.join(@dependency_root_path, @root_deployment_name, deployment_name)
+    DeploymentDeployersConfig.new(deployment_name, base_location, filename, deployment_factory)
+  end
+
+  def load_deployment_config_files(deployment_name, deployers_config, enable_deployment_path)
+    enable_deployment_file = File.join(enable_deployment_path, ENABLE_DEPLOYMENT_FILENAME)
+
+    if File.exist?(enable_deployment_file)
+      deployers_config.load_configs
+    else
+      puts "Deployment #{deployment_name} is inactive, ignoring inconsistencies."
+      begin
+        deployers_config.load_configs.disable
+      rescue RuntimeError => e
+        raise e unless e.message.start_with?("Inconsistency detected: deployment <#{deployment_name}> is marked as active")
+
+        Deployment.new(deployment_name).disable
+      end
+    end
+  end
 
   def select_deployment_scan_files
     enable_deployment_scan = File.join(@enable_deployment_root_path, @root_deployment_name, '/*')

--- a/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
@@ -1,0 +1,619 @@
+require 'rspec'
+require 'fileutils'
+require 'tmpdir'
+require 'template_processor'
+require 'ci_deployment'
+require 'deployment_deployers_config'
+require 'pipeline_generator'
+require_relative 'test_fixtures'
+
+describe 'BoshPrecompilePipelineTemplateProcessing' do
+  let(:root_deployment_name) { 'my-root-depls' }
+  let(:bosh_cert) { BOSH_CERT_LOCATIONS = { root_deployment_name => 'shared/certificate.pem' }.freeze }
+  let(:ops_automation_path) { '.' }
+  let(:processor_context) do
+    { depls: root_deployment_name,
+      bosh_cert: bosh_cert,
+      all_dependencies: all_dependencies,
+      all_ci_deployments: all_ci_deployments,
+      git_submodules: git_submodules,
+      config: loaded_config,
+      ops_automation_path: ops_automation_path }
+  end
+  let(:secrets_dirs_overview) { {} }
+  let(:root_deployment_versions) { {} }
+  let(:all_dependencies) do
+    deps_yaml = <<~YAML
+      bosh-bats:
+        status: disabled
+        stemcells:
+          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+        bosh-deployment: {}
+        releases:
+          bosh:
+            base_location: https://github.com/
+            repository: cloudfoundry/bosh
+            version: 271.0.0
+      maria-db:
+        status: disabled
+      shield-expe:
+        stemcells:
+          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+        releases:
+          cf-routing-release:
+            base_location: https://bosh.io/d/github.com/
+            repository: cloudfoundry-incubator/cf-routing-release
+            version: 0.169.0
+        errands:
+            import:
+            smoke-tests:
+              display-name: automated-smoke-tests
+        manual-errands:
+            manual-import:
+            manual-smoke-tests:
+              display-name: my-smoke-tests
+        bosh-deployment:
+          active: true
+        status: enabled
+      bui:
+        stemcells:
+          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+        releases:
+          route-registrar-boshrelease:
+            base_location: https://bosh.io/d/github.com/
+            repository: cloudfoundry-community/route-registrar-boshrelease
+            version: '3'
+          haproxy-boshrelease:
+            base_location: https://bosh.io/d/github.com/
+            repository: cloudfoundry-community/haproxy-boshrelease
+            version: 8.0.12
+        bosh-deployment:
+          active: true
+        status: enabled
+    YAML
+    YAML.safe_load(deps_yaml)
+  end
+  let(:all_ci_deployments) { {} }
+  let(:git_submodules) { {} }
+  let(:loaded_config) do
+    my_config_yaml = <<~YAML
+      offline-mode:
+        boshreleases: true
+        stemcells: true
+        docker-images: false
+    YAML
+    YAML.safe_load(my_config_yaml)
+  end
+  let(:expected_resource_types) do
+    resource_types_yaml = <<~YAML
+      - name: slack-notification
+        type: docker-image
+        source:
+          repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+          tag: v1.4.2
+      - name: bosh-deployment-v2
+        type: docker-image
+        source:
+          repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+          tag: v2.12.0
+    YAML
+    YAML.safe_load(resource_types_yaml)
+  end
+  let(:groups) do
+    [
+      { 'name' => 'my-root-depls',
+        'jobs' =>
+         %w[compile-and-export-bosh
+            compile-and-export-cf-routing-release
+            compile-and-export-haproxy-boshrelease
+            compile-and-export-route-registrar-boshrelease
+            init-concourse-boshrelease-and-stemcell-for-my-root-depls
+            push-boshreleases
+            push-stemcell
+            upload-compiled-bosh
+            upload-compiled-cf-routing-release
+            upload-compiled-haproxy-boshrelease
+            upload-compiled-route-registrar-boshrelease] },
+      { 'name' => 'utils', 'jobs' => %w[init-concourse-boshrelease-and-stemcell-for-my-root-depls push-boshreleases push-stemcell] },
+      { "name" => "compiled-releases", "jobs" => %w[upload-compiled-bosh upload-compiled-cf-routing-release upload-compiled-haproxy-boshrelease upload-compiled-route-registrar-boshrelease] },
+      { "name" => "releases", "jobs" => %w[compile-and-export-bosh compile-and-export-cf-routing-release compile-and-export-haproxy-boshrelease compile-and-export-route-registrar-boshrelease] },
+      { "name" => "b", "jobs" => %w[compile-and-export-bosh upload-compiled-bosh] },
+      { "name" => "c", "jobs" => %w[compile-and-export-cf-routing-release upload-compiled-cf-routing-release] },
+      { "name" => "h", "jobs" => %w[compile-and-export-haproxy-boshrelease upload-compiled-haproxy-boshrelease] },
+      { "name" => "r", "jobs" => %w[compile-and-export-route-registrar-boshrelease upload-compiled-route-registrar-boshrelease] }
+    ]
+  end
+  let(:enable_root_deployment_terraform) do
+    ci_deployments_yaml = <<~YAML
+      #{root_deployment_name}:
+        terraform_config:
+          state_file_path: my-tfstate-location
+        target_name: my-concourse-name
+        pipelines:
+          #{root_deployment_name}-bosh-precompile-generated:
+            config_file: path/located/in/secrets-repo/pipelines/#{root_deployment_name}-generated.yml
+            vars_files:
+            - another/path/located/in/secrets-repo/pipelines/credentials-iaas-specific.yml
+            - #{root_deployment_name}/root-deployment.yml
+    YAML
+    YAML.safe_load ci_deployments_yaml
+  end
+  let(:expected_shield_errand_resource) do
+    my_shield_errand_yaml = <<~YAML
+      - name: errand-shield-expe
+        icon: arrange-send-to-back
+        type: bosh-errand
+        source:
+          target: ((bosh-target))
+          client: ((bosh-username))
+          client_secret: ((bosh-password))
+          deployment: shield-expe
+          ca_cert: shared/certificate.pem
+    YAML
+    YAML.safe_load(my_shield_errand_yaml)
+  end
+  let(:config) { { dump_output: true, output_path: @output_dir } }
+
+  context 'when processing bosh-precompile-pipeline.yml.erb' do
+    subject { TemplateProcessor.new root_deployment_name, config, processor_context }
+
+    before(:context) do
+      @output_dir = Dir.mktmpdir('generated-pipelines')
+      @pipelines_output_dir = File.join(@output_dir, 'pipelines')
+      @template_pipeline_name = 'bosh-precompile-pipeline.yml.erb'
+      @pipelines_dir = Dir.mktmpdir('pipeline-templates')
+
+      FileUtils.copy("concourse/pipelines/template/#{@template_pipeline_name}", @pipelines_dir)
+    end
+
+    after(:context) do
+      FileUtils.rm_rf(@output_dir)
+      FileUtils.rm_rf(@pipelines_dir)
+    end
+
+    let(:generated_pipeline) do
+      pipeline_template = @processed_template[File.join(@pipelines_dir, @template_pipeline_name)]
+      generated_pipeline_path = File.join(@pipelines_output_dir, pipeline_template)
+      YAML.load_file(generated_pipeline_path)
+    end
+
+    before do
+      @processed_template = subject.process(@pipelines_dir + '/*')
+    end
+
+    context 'when disabled deployments are presents' do
+      let(:expected_compiled_exported_deployments) { %W[compile-and-export-bosh compile-and-export-route-registrar-boshrelease compile-and-export-haproxy-boshrelease compile-and-export-cf-routing-release] }
+      let(:expected_uploaded_deployments) { %W[upload-compiled-bosh upload-compiled-route-registrar-boshrelease upload-compiled-haproxy-boshrelease upload-compiled-cf-routing-release] }
+
+      it 'generates compile and export job for dependencies describe in disabled deployments' do
+        filtered_generated_jobs = generated_pipeline['jobs'].select { |job| job['name']&.start_with?('compile-and-export') }.flat_map { |job| job['name'] }
+        expect(filtered_generated_jobs).to match(expected_compiled_exported_deployments)
+      end
+
+      it 'generates upload job for dependencies describe in disabled deployments' do
+        filtered_generated_jobs = generated_pipeline['jobs'].select { |job| job['name']&.start_with?('upload-compiled') }.flat_map { |job| job['name'] }
+        expect(filtered_generated_jobs).to match(expected_uploaded_deployments)
+      end
+    end
+
+    context 'when deployments are excluded' do
+      let(:expected_compiled_exported_deployments) { %W[compile-and-export-bosh compile-and-export-route-registrar-boshrelease compile-and-export-haproxy-boshrelease compile-and-export-cf-routing-release] }
+      let(:expected_uploaded_deployments) { %W[upload-compiled-bosh upload-compiled-route-registrar-boshrelease upload-compiled-haproxy-boshrelease upload-compiled-cf-routing-release] }
+      let(:loaded_config) do
+        my_config_yaml = <<~YAML
+          offline-mode:
+            boshreleases: true
+            stemcells: true
+            docker-images: false
+
+          #{root_deployment_name}:
+            precompile:
+              excluded_deployments:
+                - bui
+        YAML
+        YAML.safe_load(my_config_yaml)
+      end
+
+      it 'generates compile jobs only for non excluded deployments' do
+        filtered_generated_jobs = generated_pipeline['jobs'].select { |job| job['name']&.start_with?('compile-and-export') }.flat_map { |job| job['name'] }
+        expect(filtered_generated_jobs).to match(expected_compiled_exported_deployments)
+      end
+
+      it 'generates upload job for dependencies describe in disabled deployments' do
+        filtered_generated_jobs = generated_pipeline['jobs'].select { |job| job['name']&.start_with?('upload-compiled') }.flat_map { |job| job['name'] }
+        expect(filtered_generated_jobs).to match(expected_uploaded_deployments)
+      end
+    end
+
+    context 'without ci deployment overview' do
+      it 'processes only one template' do
+        expect(@processed_template.length).to eq(1)
+      end
+
+      it 'processes is not empty' do
+        expect(@processed_template).not_to be_empty
+      end
+
+      it 'generates a valid yaml file' do
+        expect(generated_pipeline).not_to be_falsey
+      end
+
+      it 'generates all resource_types' do
+        expect(generated_pipeline['resource_types']).to match(expected_resource_types)
+      end
+
+      it 'generates all groups' do
+        expect(generated_pipeline['groups'].flat_map { |group| group['name'] }.sort).to match(groups.flat_map { |group| group['name'] }.sort)
+      end
+
+      it 'generates a group using root deployment name ' do
+        generated_group = generated_pipeline['groups'].select { |concourse_group| concourse_group['name'] == root_deployment_name.downcase }
+        expect(generated_group).not_to be_empty
+      end
+    end
+
+    context 'when offline boshrelease mode is enabled with precompilation' do
+      let(:loaded_config) do
+        my_config_yaml = <<~YAML
+          offline-mode:
+            boshreleases: true
+            stemcells: true
+            docker-images: false
+        YAML
+        YAML.safe_load(my_config_yaml)
+      end
+      let(:expected_boshreleases) do
+        { 'bosh' => 'cloudfoundry',
+          'cf-routing-release' => 'cloudfoundry-incubator',
+          'route-registrar-boshrelease' => 'cloudfoundry-community',
+          'haproxy-boshrelease' => 'cloudfoundry-community' }
+      end
+      let(:expected_s3_precompiled_boshreleases) do
+        expected_boshreleases.map do |br_name, br_repo|
+          fragment = <<~YAML
+            - name: compiled-#{br_name}
+              icon: home-floor-b
+              type: s3
+              source:
+                bucket: ((s3-compiled-release-bucket))
+                region_name: ((s3-compiled-release-region-name))
+                regexp: #{br_repo}/#{br_name}-(.*)-(.*)-(.*)-((stemcell.version)).tgz
+                access_key_id: ((s3-compiled-release-access-key-id))
+                secret_access_key: ((s3-compiled-release-secret-key))
+                endpoint: ((s3-compiled-release-endpoint))
+                skip_ssl_verification: ((s3-compiled-release-skip-ssl-verification))
+              version:
+                path: "#{br_repo}/#{br_name}-((releases.#{br_name}.version))-((s3-compiled-release-os))-((stemcell.version)).tgz"
+          YAML
+          YAML.safe_load fragment
+        end.flatten
+      end
+      let(:expected_s3_boshreleases) do
+        expected_boshreleases.map do |br_name, br_repo|
+          fragment = <<~YAML
+            - name: #{br_name}
+              icon: home-floor-a
+              type: s3
+              source:
+                bucket: ((s3-br-bucket))
+                region_name: ((s3-br-region-name))
+                regexp: #{br_repo}/#{br_name}-(.*).tgz
+                access_key_id: ((s3-br-access-key-id))
+                secret_access_key: ((s3-br-secret-key))
+                endpoint: ((s3-br-endpoint))
+                skip_ssl_verification: ((s3-br-skip-ssl-verification))
+              version:
+                path: "#{br_repo}/#{br_name}-((releases.#{br_name}.version)).tgz"
+          YAML
+          YAML.safe_load fragment
+        end.flatten
+      end
+      let(:expected_boshrelease_put_version) do
+        expected_boshreleases.flat_map { |name, _repo| { name => "#{name}/*.tgz" } }
+      end
+      let(:expected_s3_deployment_put) do
+        expected_yaml = <<~YAML
+          - bui-deployment:
+            - #{expected_boshrelease_put_version.flat_map { |br| br['haproxy-boshrelease'] }.compact.first}
+            - #{expected_boshrelease_put_version.flat_map { |br| br['route-registrar-boshrelease'] }.compact.first}
+          - shield-expe-deployment:
+            - #{expected_boshrelease_put_version.flat_map { |br| br['cf-routing-release'] }.compact.first}
+        YAML
+        YAML.safe_load expected_yaml
+      end
+      let(:expected_push_stemcell_tasks) { %w[upload-stemcells] }
+      let(:expected_push_boshreleases_tasks) { %w[reformat-root-deployment-yml missing-s3-boshreleases repackage-releases repackage-releases-fallback upload-repackaged-releases upload-to-director check-repackaging-errors] }
+
+      it 'generates s3 precompiled resources (ie use precompile bucket)' do
+        s3_precompiled_boshreleases = generated_pipeline['resources'].select { |resource| resource['type'] == 's3' && resource['name'].start_with?('compiled-') }
+        expect(s3_precompiled_boshreleases).to include(*expected_s3_precompiled_boshreleases)
+      end
+
+      it 'generates s3 bosh release resource (ie use br bucket) ' do
+        s3_boshreleases = generated_pipeline['resources'].select { |resource| resource['type'] == 's3' && !resource['name'].start_with?('compiled-') && resource['name'] != "((stemcell-main-name))" }
+        expect(s3_boshreleases).to include(*expected_s3_boshreleases)
+      end
+
+      it 'does not generate s3 version using path on get' do
+        boshrelease_get_version = generated_pipeline['jobs'].flat_map { |job| job['plan'] }
+          .flat_map { |plan| plan['in_parallel'] }
+          .compact
+          .select { |resource| expected_boshreleases.key?(resource['get']) }
+          .flat_map { |resource| { resource['get'] => resource['version'] } }
+        expect(boshrelease_get_version).to all(satisfy { |_k, v| v.nil? })
+      end
+
+      it 'generates push-stemcells tasks' do
+        push_stemcell_job_tasks = generated_pipeline['jobs']
+                                      .select { |job| job['name'] == "push-stemcell" }
+                                      .flat_map { |job| job['plan'] }
+                                      .flat_map { |step| step['task'] }.compact
+        expect(push_stemcell_job_tasks).to match(expected_push_stemcell_tasks)
+      end
+
+      it 'generates push-boshreleases tasks' do
+        push_boshreleases_job_tasks = generated_pipeline['jobs']
+                                      .select { |job| job['name'] == "push-boshreleases" }
+                                      .flat_map { |job| job['plan'] }
+                                      .flat_map { |step| step['task'] }.compact
+        expect(push_boshreleases_job_tasks).to match(expected_push_boshreleases_tasks)
+      end
+
+
+      it 'generates init-concourse-boshrelease-and-stemcell-for-ops-depls' do
+        expected_init_version = expected_boshreleases.values.flat_map { |get_version| "path:#{get_version}" }
+        init_args = generated_pipeline['jobs']
+          .select { |job| job['name'] == "init-concourse-boshrelease-and-stemcell-for-#{root_deployment_name}" }
+          .flat_map { |job| job['plan'] }
+          .select { |step| step['task'] && step['task'] == "generate-#{root_deployment_name}-flight-plan" }
+          .flat_map { |task| task['config']['run']['args'] }
+        expect(init_args[1]).to include(*expected_init_version)
+      end
+    end
+
+
+    context 'when online boshreleases and offline stemcells are used' do
+      let(:loaded_config) do
+        my_config_yaml = <<~YAML
+          offline-mode:
+            stemcells: true
+          precompile-mode: false
+        YAML
+        YAML.safe_load(my_config_yaml)
+      end
+      let(:expected_s3_stemcell) do
+        expected_yaml = <<~YAML
+          - name: ((stemcell-main-name))
+            icon: home-floor-l
+            type: s3
+            source:
+              access_key_id: ((s3-stemcell-access-key-id))
+              bucket: ((s3-stemcell-bucket))
+              endpoint: ((s3-stemcell-endpoint))
+              regexp: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-(.*)-((stemcell-main-name)).tgz
+              region_name: ((s3-stemcell-region-name))
+              secret_access_key: ((s3-stemcell-secret-key))
+              skip_ssl_verification: ((s3-stemcell-skip-ssl-verification))
+            version:
+              path: ((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell.version))-((stemcell-main-name)).tgz
+        YAML
+        YAML.safe_load expected_yaml
+      end
+
+      let(:expected_push_stemcell_tasks) { %w[upload-stemcells] }
+      let(:expected_push_boshreleases_tasks) { %w[repackage-releases repackage-releases-fallback upload-to-director check-repackaging-errors] }
+      let(:expected_stemcell_init) { 'echo "check-resource -r $BUILD_PIPELINE_NAME/((stemcell-main-name)) --from path:((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell.version))-((stemcell-main-name)).tgz' }
+
+      it 'generates s3 stemcell with pinned version' do
+        bosh_io_stemcell = generated_pipeline['resources'].select { |resource| resource['name'] == '((stemcell-main-name))' }
+        expect(bosh_io_stemcell).to eq(expected_s3_stemcell)
+      end
+
+      it 'generates s3 version using path on get' do
+        stemcell_get_step = generated_pipeline['jobs']
+                                .select { |job| job['name'] == "push-stemcell" }
+                                .flat_map { |job| job['plan'] }
+                                .flat_map { |plan| plan['in_parallel'] }
+                                .compact
+                                .select { |resource| resource['get'] == '((stemcell-main-name))' }
+        expect(stemcell_get_step).to be_empty
+      end
+
+      it 'generates push-stemcell with stemcell upload to director' do
+        push_stemcell_job_tasks = generated_pipeline['jobs']
+                          .select { |job| job['name'] == "push-stemcell" }
+                          .flat_map { |job| job['plan'] }
+                          .flat_map { |step| step['task'] }.compact
+        expect(push_stemcell_job_tasks).to match(expected_push_stemcell_tasks)
+      end
+
+      it 'generates push-boshreleases tasks' do
+        push_boshreleases_job_tasks = generated_pipeline['jobs']
+                                          .select { |job| job['name'] == "push-boshreleases" }
+                                          .flat_map { |job| job['plan'] }
+                                          .flat_map { |step| step['task'] }.compact
+        expect(push_boshreleases_job_tasks).to match(expected_push_boshreleases_tasks)
+      end
+
+      it 'generates init-concourse-boshrelease-and-stemcell-for-#{root_deployment_name}' do
+        init_args = generated_pipeline['jobs']
+                        .select { |job| job['name'] == "init-concourse-boshrelease-and-stemcell-for-#{root_deployment_name}" }
+                        .flat_map { |job| job['plan'] }
+                        .select { |step| step['task'] && step['task'] == "generate-#{root_deployment_name}-flight-plan" }
+                        .flat_map { |task| task['config']['run']['args'] }
+        expect(init_args[1]).to include(*expected_stemcell_init)
+      end
+    end
+
+    context 'when stemcell offline mode is disabled' do
+      let(:loaded_config) do
+        my_config_yaml = <<~YAML
+          offline-mode:
+            boshreleases: false
+            stemcells: false
+            docker-images: false
+        YAML
+        YAML.safe_load(my_config_yaml)
+      end
+      let(:expected_bosh_io_stemcell) do
+        expected_yaml = <<~YAML
+          - name: ((stemcell-main-name))
+            icon: home-floor-g
+            type: bosh-io-stemcell
+            source:
+              name: ((stemcell-name-prefix))((stemcell-main-name))
+            version:
+              version: ((stemcell.version))
+        YAML
+        YAML.safe_load expected_yaml
+      end
+      let(:expected_stemcell_upload_task) do
+        [{ "task"=>"download-stemcell",
+           "attempts"=>2,
+           "file"=>"cf-ops-automation/concourse/tasks/download_stemcell/task.yml",
+           "output_mapping"=>{"stemcell"=>"((stemcell-main-name))"},
+           "params"=>
+                 {"STEMCELL_BASE_LOCATION"=>"https://bosh.io/d/stemcells",
+                       "STEMCELL_MAIN_NAME"=>"((stemcell-main-name))",
+                       "STEMCELL_PREFIX"=>"((stemcell-name-prefix))",
+                       "STEMCELL_VERSION"=>"((stemcell.version))"}
+          },
+         {"task"=>"upload-to-director",
+         "file"=>"cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml",
+         "input_mapping"=> {"config-resource"=>"secrets-full-writer", "stemcell"=>"((stemcell-main-name))"},
+         "attempts" => 2,
+         "params"=>
+            {"BOSH_CA_CERT"=> "config-resource/shared/certs/internal_paas-ca/server-ca.crt",
+             "BOSH_CLIENT"=>"((bosh-username))",
+             "BOSH_CLIENT_SECRET"=>"((bosh-password))",
+             "BOSH_ENVIRONMENT"=>"((bosh-target))"}
+       }]
+      end
+      let(:expected_stemcell_init) { 'echo "check-resource -r $BUILD_PIPELINE_NAME/((stemcell-main-name)) --from version:((stemcell.version))" | tee -a result-dir/flight-plan' }
+
+      it 'generates bosh-io stemcell with pinned version' do
+        bosh_io_stemcell = generated_pipeline['resources'].select { |resource| resource['type'] == 'bosh-io-stemcell' }
+        expect(bosh_io_stemcell).to eq(expected_bosh_io_stemcell)
+      end
+
+      it 'generates bosh_io version using path on get' do
+        stemcell_get_step = generated_pipeline['jobs']
+          .select { |job| job['name'] == "push-stemcell" }
+          .flat_map { |job| job['plan'] }
+          .flat_map { |plan| plan['in_parallel'] }
+          .compact
+          .select { |resource| resource['get'] == '((stemcell-main-name))' }
+        expect(stemcell_get_step).to be_empty
+      end
+
+      it 'generates push-stemcell with stemcell upload to director' do
+        upload_task = generated_pipeline['jobs']
+          .select { |job| job['name'] == "push-stemcell" }
+          .flat_map { |job| job['plan'] }
+          .select { |step| step['task'] }
+        expect(upload_task).to match(expected_stemcell_upload_task)
+      end
+
+      it 'generates init-concourse-boshrelease-and-stemcell-for-ops-depls' do
+        init_args = generated_pipeline['jobs']
+          .select { |job| job['name'] == "init-concourse-boshrelease-and-stemcell-for-#{root_deployment_name}" }
+          .flat_map { |job| job['plan'] }
+          .select { |step| step['task'] && step['task'] == "generate-#{root_deployment_name}-flight-plan" }
+          .flat_map { |task| task['config']['run']['args'] }
+        expect(init_args[1]).to include(*expected_stemcell_init)
+      end
+    end
+
+    context 'with ci deployment overview without terraform' do
+      let(:all_ci_deployments) do
+        ci_deployments_yaml = <<~YAML
+          #{root_deployment_name}:
+            target_name: my-concourse-name
+            pipelines:
+              #{root_deployment_name}-bosh-precompile-generated:
+                team: #{custom_team}
+              #{root_deployment_name}-cf-apps-generated:
+        YAML
+        YAML.safe_load ci_deployments_yaml
+      end
+      let(:custom_team) { 'my-custom-team' }
+      let(:fly_into_concourse_context) do
+        { depls: root_deployment_name,
+          team: custom_team }
+      end
+      let(:expected_fly_into_concourse) do
+        Coa::TestFixtures.expand_task_params_template('fly-into-concourse', fly_into_concourse_context)
+      end
+
+      it 'generates all resource_types' do
+        expect(generated_pipeline['resource_types']).to match_array(expected_resource_types)
+      end
+
+      it 'generates all groups' do
+        groups.select { |item| %w[Utils My-root-depls].include?(item['name']) }.each do |item|
+          item['jobs'].sort!
+        end
+        expect(generated_pipeline['groups']).to match_array(groups)
+      end
+
+      it 'generates retrigger all and init boshrelease version' do
+        fly_into_concourse_params = generated_pipeline['jobs']
+          .flat_map { |job| job['plan'] }
+          .select { |step| step['task']&.start_with?("fly-into-concourse") }
+          .flat_map { |step| step['params'] }
+
+        fly_into_concourse_params.each { |task_params| expect(task_params).to match(expected_fly_into_concourse) }
+      end
+    end
+  end
+
+  context 'when a boshrelease overrides with another value' do
+    subject { TemplateProcessor.new root_deployment_name, config, processor_context }
+
+    let(:all_dependencies) do
+      deps_yaml = <<~YAML
+        shield-expe:
+          stemcells:
+            bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          releases:
+            cf-routing-release:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-incubator/cf-routing-release
+              version: 0.169.0
+          bosh-deployment:
+            active: true
+          status: enabled
+        bui:
+          stemcells:
+            bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          releases:
+            cf-routing-release:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-community/route-registrar-boshrelease
+              version: '3'
+            haproxy-boshrelease:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-community/haproxy-boshrelease
+              version: 8.0.12
+          bosh-deployment:
+            active: true
+          status: enabled
+      YAML
+      YAML.safe_load(deps_yaml)
+    end
+    let(:template_processing_error) { subject.process(@pipelines_dir + '/*') }
+
+    before(:context) do
+      @output_dir = Dir.mktmpdir('generated-pipelines')
+      @pipelines_output_dir = File.join(@output_dir, 'pipelines')
+      @template_pipeline_name = 'bosh-precompile-pipeline.yml.erb'
+      @pipelines_dir = Dir.mktmpdir('pipeline-templates')
+
+      FileUtils.copy("concourse/pipelines/template/#{@template_pipeline_name}", @pipelines_dir)
+    end
+
+    it 'raises an error' do
+      expect { template_processing_error }.to raise_error(RuntimeError, /Inconsitency detected with 'cf-routing-release' boshrelease, in 'shield-expe' deployment: trying to replace.*/)
+    end
+  end
+end


### PR DESCRIPTION
Changes proposed in this pull-request:
- we do not filter on deployment state to determine when to include dependencies


We do not use secret repository to determine which deployment we need to proccess, we scan every deployments for dependencies.

it still possible to exclude some deployments using `shared-confg.yml` and `private-config.yml`, by setting properties below:
```
   <root-deployment-name>:
      precompile:
         excluded_deployments: [] # Default: [] # List deployments to exclude
   from precompilation. As precompilation does not use secrets repository to
   determine enabled deployments, it might be convenient to exclude a
   deployment not enanled in secrets.
```