### PR TITLE
feature(tune-cf-push-options): allow cf push customization

### DIFF
--- a/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/cf-env.sh
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/cf-env.sh
@@ -1,0 +1,4 @@
+#
+# CF_PUSH_OPTIONS= # Use this syntax to avoid using cf push default parameters
+
+CF_PUSH_OPTIONS="${CF_PUSH_OPTIONS} --app-start-timeout 30" # Use this syntax to complete cf push default parameters

--- a/scripts/cf/push.sh
+++ b/scripts/cf/push.sh
@@ -30,9 +30,10 @@ validate
 CURRENT_DIR=$(pwd)
 OUTPUT_DIR=${OUTPUT_DIR:-${CURRENT_DIR}/generated-files}
 COMMON_SCRIPT_DIR=${COMMON_SCRIPT_DIR:-scripts-resource/scripts/cf}
-ADDITIONAL_RESSOURCE=${ADDITIONAL_RESSOURCE:-additional-resource}
+ADDITIONAL_RESOURCE=${ADDITIONAL_RESOURCE:-additional-resource}
 
 CF_MANIFEST=${CF_MANIFEST:-manifest.yml}
+CF_ENV_FILE="${CUSTOM_SCRIPT_DIR}"/cf-env.sh
 
 cf --version
 
@@ -42,8 +43,8 @@ API_OPTIONS="--skip-ssl-validation"
 cf api "$CF_API_URL" $API_OPTIONS
 cf auth "$CF_USERNAME" "$CF_PASSWORD"
 
-echo "copying file from $ADDITIONAL_RESSOURCE to $OUTPUT_DIR"
-cp -r $ADDITIONAL_RESSOURCE/. $OUTPUT_DIR/
+echo "copying file from $ADDITIONAL_RESOURCE to $OUTPUT_DIR"
+cp -r $ADDITIONAL_RESOURCE/. $OUTPUT_DIR/
 
 if [ -n "$CUSTOM_SCRIPT_DIR" ] && [ -f "$CUSTOM_SCRIPT_DIR/pre-cf-push.sh" ]; then
   echo   "pre CF push script detected - Available Environment variables: GENERATE_DIR: <$OUTPUT_DIR> | BASE_TEMPLATE_DIR: <$CUSTOM_SCRIPT_DIR>"
@@ -55,8 +56,18 @@ fi
 
 cf target -o "$CF_ORG" -s "$CF_SPACE"
 
+CF_PUSH_OPTIONS="--strategy rolling"
+echo "To override default option, create 'cf-env' file alongside 'pre-cf-push.sh'. And set a shell variable, named 'CF_PUSH_OPTIONS', to expected value - Default: $CF_PUSH_OPTIONS"
+
+if [ -f "$CF_ENV_FILE" ];then
+  echo "Overriding CF push options"
+  source $CF_ENV_FILE
+fi
+
+echo "CF push options: $CF_PUSH_OPTIONS"
+
 set +e
-cf push -f ${CF_MANIFEST} --strategy rolling 2>&1 | tee /tmp/cf-push.log
+cf push -f ${CF_MANIFEST} ${CF_PUSH_OPTIONS} 2>&1 | tee /tmp/cf-push.log
 ret_code=$?
 if [ $ret_code -ne 0 ]; then
   DISPLAY_LOG_CMD=$(  grep "TIP: use 'cf logs" /tmp/cf-push.log | cut -d\' -f2)


### PR DESCRIPTION
With cf cli v7 support, we switch to "rolling strategy" to avoid application downtime. But "--strategy" in not compliant with "-f" option when manifest includes multiple app definitions. So we add a mechanism to override cf push default parameters.

Fixes #240.