### PR TITLE
Concourse 7.2 bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM ruby:2.7.1
 
-# 3791e5703717a074429311d2d218c234a270f5b358210b6bb722b684dc1b5153  fly-5.8.1-linux-amd64.tgz
-# 28d59035d87157f3e87496c2350deefebbe050baed3fcc7f968605fa144bb11e  fly-6.4.0-linux-amd64.tgz
-# 16d27cf2c416f6fbcd993e6e9ac01fc67200b8d173048ca44ddced10faa8a8b7  fly-6.5.1-linux-amd64.tgz
-# 6d07d253008ec58417323d62d944032ff2fabe362b850da89582dd9aa2f61cf9  fly-6.7.1-linux-amd64.tgz
 # 974ec56d3b43e7ef77fa8fc43b0652a308b39e8d860191f861812e7111af20bc  fly-6.7.2-linux-amd64.tgz
-ARG CONCOURSE_VERSION=6.7.2
-ARG CONCOURSE_SHA256=974ec56d3b43e7ef77fa8fc43b0652a308b39e8d860191f861812e7111af20bc
+# 4e0502afbd60d2501c67deef1c640100d2c37ee1c26755138cc24f5d4d527a3a  fly-7.1.0-linux-amd64.tgz
+# f511e497cf12b1e9a0dda124cc7c6619fc2afa24a5b6776bb6746eedba8dfaa9  fly-7.2.0-linux-amd64.tgz
+# https://github.com/concourse/concourse/releases/
+ARG CONCOURSE_VERSION=7.2.0
+ARG CONCOURSE_SHA256=f511e497cf12b1e9a0dda124cc7c6619fc2afa24a5b6776bb6746eedba8dfaa9
 
-ARG BOSH_CLI_VERSION=6.2.1
-ARG BOSH_CLI_SHA256=ca7580008abfd4942dcb1dd6218bde04d35f727717a7d08a2bc9f7d346bce0f6
+#
+ARG BOSH_CLI_VERSION=6.4.1
+ARG BOSH_CLI_SHA256=756d8e403f1d349ef3766d28980379c24da6212fa45dcf296c0519d4ec54d66a
 
 RUN apt-get update && \
  apt-get -y install tree vim netcat dnsutils jq

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/pipeline-sample/concourse-pipeline-config/pipeline-sample-tpl.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/pipeline-sample/concourse-pipeline-config/pipeline-sample-tpl.yml
@@ -33,7 +33,7 @@ resources:
 jobs:
 - name: (( concat "upload-" secrets.release-name "-" secrets.release-version "-boshrelease-to-s3" ))
   plan:
-    - aggregate:
+    - in_parallel:
       - get: (( grab secrets.release-name ))
         attempts: 2
     - task: create-boshrelease-tarball
@@ -62,7 +62,7 @@ jobs:
 
 - name: (( concat "upload-latest-" secrets.release-name "-boshrelease-to-s3" ))
   plan:
-    - aggregate:
+    - in_parallel:
       - get: (( grab secrets.release-name ))
         attempts: 2
         trigger: true

--- a/lib/coa/utils/concourse/build.rb
+++ b/lib/coa/utils/concourse/build.rb
@@ -3,6 +3,7 @@ require_relative '../coa_logger'
 module Coa
   module Utils
     module Concourse
+      require 'json'
       # Concourse's Builds concept: https://concourse-ci.org/builds.html
       class Build
         include Coa::Utils::CoaLogger
@@ -53,10 +54,10 @@ module Coa
         end
 
         def update_status_from_raw_builds(raw_builds)
-          build = raw_builds.split("\n").max_by { |bd| bd.split[2] } # [2] contains an incremental id for the build
-          split_build = build.split
-          self.status = split_build[3]
-        rescue NoMethodError => _ # this would indicate that the build is not listed
+          builds = JSON.parse(raw_builds)
+          latest_build = builds.max_by { |build| build['id'] }
+          self.status = latest_build['status']
+        rescue NoMethodError => _e # this would indicate that the build is not listed
           logger.debug "The build has probably not started yet."
         end
 

--- a/lib/coa/utils/concourse/fly.rb
+++ b/lib/coa/utils/concourse/fly.rb
@@ -35,7 +35,7 @@ module Coa
         end
 
         def get_raw_job_builds(full_job_name)
-          run "builds --job #{full_job_name}"
+          run "builds --job #{full_job_name} --json"
         end
 
         def set_pipeline(pipeline, options)

--- a/spec/lib/coa/utils/concourse/build_spec.rb
+++ b/spec/lib/coa/utils/concourse/build_spec.rb
@@ -4,7 +4,7 @@ require 'coa/utils/concourse'
 describe Coa::Utils::Concourse::Build do
   let(:fly)      { instance_double("Coa::Utils::Concourse::Fly") }
   let(:pipeline) { instance_double("Coa::Utils::Concourse::Pipeline", pause: true) }
-  let(:job)      { instance_double("Coa::Utils::Concourse::Job", fullname: "p1/j1", pipeline: pipeline ) }
+  let(:job)      { instance_double("Coa::Utils::Concourse::Job", fullname: "p1/j1", pipeline: pipeline) }
 
   before do
     stub_const("#{described_class}::MAX_RETRIES", 2)
@@ -17,7 +17,39 @@ describe Coa::Utils::Concourse::Build do
     let(:build) { described_class.new(job: job) }
 
     context "when the jobs has succeeded" do
-      let(:build_response) { "34455  p1/j1  1  succeeded  2018-12-14@09:27:20+0000  n/a  17m33s+" }
+      let(:build_response) do
+        <<~JSON
+          [
+            {
+              "id": 7397,
+              "team_name": "main",
+              "name": "3",
+              "status": "succeeded",
+              "api_url": "/api/v1/builds/7397",
+              "job_name": "j1",
+              "pipeline_id": 18,
+              "pipeline_name": "p1",
+              "created_by": "a_user",
+              "start_time": 1620503583,
+              "end_time": 1620503644
+            },
+            {
+              "id": 7393,
+              "team_name": "main",
+              "name": "2",
+              "status": "succeeded",
+              "api_url": "/api/v1/builds/7393",
+              "job_name": "j1",
+              "pipeline_id": 18,
+              "pipeline_name": "p1",
+              "created_by": "a_user",
+              "start_time": 1620413583,
+              "end_time": 1620413644
+            }
+          ]
+        JSON
+      end
+      # Concourse pre 7.2.0 format: { "34455  p1/j1  1  succeeded  2018-12-14@09:27:20+0000  n/a  17m33s+" }
 
       it "returns a build directly" do
         allow(job).to receive(:raw_builds).and_return(build_response)
@@ -30,7 +62,25 @@ describe Coa::Utils::Concourse::Build do
     end
 
     context "when the job has not succeeded" do
-      let(:build_response) { "34455  p1/j1  1  started  2018-12-14@09:27:20+0000  n/a  17m33s+" }
+      # let(:build_response) { "34455  p1/j1  1  started  2018-12-14@09:27:20+0000  n/a  17m33s+" }
+      let(:build_response) do
+        <<~JSON
+          [
+            {
+              "id": 7397,
+              "team_name": "main",
+              "name": "3",
+              "status": "started",
+              "api_url": "/api/v1/builds/7397",
+              "job_name": "j1",
+              "pipeline_id": 18,
+              "pipeline_name": "p1",
+              "created_by": "a_user",
+              "start_time": 1620403683
+            }
+          ]
+        JSON
+      end
 
       it "retries" do
         allow(job).to receive(:raw_builds).and_return(build_response)


### PR DESCRIPTION
Changes proposed in this pull-request:
- upgrade concourse to latest version (7.2)
- adapt IT to new cli output (switch to json output)

This PR replaces and closes #364