### PR TITLE
test(integration-tests): switch to ibm cloud

### DIFF
--- a/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/generic-app_manifest-tpl.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/generic-app_manifest-tpl.yml
@@ -4,6 +4,7 @@ applications:
     path: .
 
     memory: (( grab secrets.an_undefined_key_in_secrets_yml || an_undefined_yml_key.fallback.value || "64M" )) # as no values are defined, spruce will use the 64M default value
+    random-route: true
 
     # By default, spruce home dir is in the configuration repo, in the deployment directory
     #  (ie: credentials-resource/hello-world-root-depls/cf-apps-deployments/generic-app/)

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/pre-cf-push.sh
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/pre-cf-push.sh
@@ -3,6 +3,3 @@
 echo 'Hello, World from "pre-cf-push.sh" !'
 echo 'Here you can execute shell commands before deploying'
 cp "${BASE_TEMPLATE_DIR}"/static-app/* "${GENERATE_DIR}"
-
-echo "Allow current user to push apps (this is required only once:) )"
-cf set-space-role $CF_USERNAME $CF_ORG $CF_SPACE SpaceDeveloper


### PR DESCRIPTION
Suse standboxes sunsets, so we need to use another CF plateform. Ibm Cloud offers a free plan, so we migrate to it.

We need to use a random route as our route is already in-use. It not possible to use 'set-space-role' command, so we remove it.