### PR TITLE
switch to 'registry-image'

### DIFF
--- a/ci/bootstrap_coa_env/bosh-deployment-manifest-prereqs.yml
+++ b/ci/bootstrap_coa_env/bosh-deployment-manifest-prereqs.yml
@@ -12,7 +12,7 @@ bosh:
           url: git+https://github.com/cppforlife/zookeeper-release
       stemcells:
         - alias: default
-          os: ubuntu-xenial
+          os: ubuntu-bionic
           version: latest
 
       update:

--- a/ci/bootstrap_coa_env/git-server-manifest-prereqs.yml
+++ b/ci/bootstrap_coa_env/git-server-manifest-prereqs.yml
@@ -23,7 +23,7 @@ git_server_manifest:
     - name: concourse-bucc
   stemcells:
   - alias: default
-    os: ubuntu-xenial
+    os: ubuntu-bionic
     version: latest
   update:
     canaries: 1

--- a/ci/bootstrap_coa_env/pipeline-vars-iaas-prereqs.yml
+++ b/ci/bootstrap_coa_env/pipeline-vars-iaas-prereqs.yml
@@ -1,6 +1,6 @@
 pipeline_vars:
   iaas-type: openstack
   stemcell-name-prefix: ""
-  stemcell-main-name: bosh-openstack-kvm-ubuntu-xenial-go_agent
+  stemcell-main-name: bosh-openstack-kvm-ubuntu-bionic-go_agent
   stemcell-version: "621.76"
   bosh-openstack-cpi-release-version: "39"

--- a/ci/bootstrap_coa_env/pipeline-vars-s3-prereqs.yml
+++ b/ci/bootstrap_coa_env/pipeline-vars-s3-prereqs.yml
@@ -13,4 +13,4 @@ pipeline_vars:
   s3-compiled-release-secret-key: ""
   s3-compiled-release-endpoint: ""
   s3-compiled-release-skip-ssl-verification: false
-  s3-compiled-release-os: ubuntu-xenial
+  s3-compiled-release-os: ubuntu-bionic

--- a/ci/bootstrap_coa_env/virtualbox/git-server-manifest-prereqs.yml
+++ b/ci/bootstrap_coa_env/virtualbox/git-server-manifest-prereqs.yml
@@ -22,7 +22,7 @@ git_server_manifest:
     - name: concourse-bucc
   stemcells:
   - alias: default
-    os: ubuntu-xenial
+    os: ubuntu-bionic
     version: latest
   update:
     canaries: 1

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,4 +1,17 @@
 ---
+meta:
+  tasks:
+  - &on_failure_alert
+    put: slack-alert
+    params:
+      channel: ((slack-channel))
+      text: |
+        Failed to run <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME/$BUILD_NAME>
+        https://github.com/orange-cloudfoundry/cf-ops-automation/commit/$TEXT_FILE_CONTENT
+      text_file: cf-ops-automation/.git/ref
+      icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
+      username: Concourse
+
 resource_types:
   - name: slack-notification
     type: registry-image
@@ -112,20 +125,32 @@ resources:
     branch: hotfix
     skip_ssl_verification: ((cf-ops-automation-git-insecure))
 
+#- name: coa-ci-secrets
+#  type: git
+#  source:
+#    uri: ((coa-ci-secrets-git-uri))
+#    username: ((coa-ci-secrets-git-username))
+#    password: ((coa-ci-secrets-git-password))
+
 jobs:
+#  - name: auto-update-pipeline
+#    serial: true
+#    on_failure: *on_failure_alert
+#    plan:
+#      - in_parallel:
+#        - get: coa-ci-secrets
+#          trigger: true
+#        - get: cf-ops-automation
+#          resource: ci-develop
+#          trigger: true
+#      - set_pipeline: self
+#        file: cf-ops-automation/ci/pipeline.yml
+#        var_files:
+#          - coa-ci-secrets/flexible-engine-env/credentials-fe-int.yml
 
   - name: build-cached-image
     serial: true
-    on_failure: &on_failure_alert
-      put: slack-alert
-      params:
-        channel: ((slack-channel))
-        text: |
-          Failed to run <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME/$BUILD_NAME>
-          https://github.com/orange-cloudfoundry/cf-ops-automation/commit/$TEXT_FILE_CONTENT
-        text_file: cf-ops-automation/.git/ref
-        icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
-        username: Concourse
+    on_failure: *on_failure_alert
     plan:
     - get: cf-ops-automation
       resource: ci-develop
@@ -623,6 +648,11 @@ jobs:
           params:
             path: pr-develop
             status: failure
+      - put: pr-develop
+        params:
+          path: cf-ops-automation
+          status: success
+          context: unit-test
 
   - name: pull-requests-acceptance-tests
     on_failure: *PR_on_failure_alert
@@ -630,13 +660,12 @@ jobs:
     plan:
       - in_parallel:
         - get: cf-ops-automation-docker-image-pr
-          passed: [pull-requests-unit-tests]
+          passed: [pull-requests-build-cached-image]
           trigger: true
         - get: cf-ops-automation
           resource: pr-develop
           trigger: true
           version: every
-          passed: [pull-requests-unit-tests]
       - task: acceptance-test-pr
         attempts: 2
         image: cf-ops-automation-docker-image-pr
@@ -647,6 +676,12 @@ jobs:
           params:
             path: cf-ops-automation
             status: failure
+      - put: pr-develop
+        params:
+          path: cf-ops-automation
+          status: success
+          context: acceptance-tests
+
   - name: pull-requests-integration-tests
     on_failure: *PR_on_failure_alert
     serial_groups: [integration]
@@ -681,6 +716,11 @@ jobs:
         image: cf-ops-automation-docker-image-pr
         config: *integration_tests_upload-pipelines_task_config
         on_failure: *PR_coa_failure
+      - put: pr-develop
+        params:
+          path: cf-ops-automation
+          status: success
+          context: integration-tests
 
   - name: pull-requests-success
     plan:
@@ -688,8 +728,8 @@ jobs:
         - get: cf-ops-automation
           resource: pr-develop
           trigger: true
-          version: every
-          passed: [pull-requests-acceptance-tests, pull-requests-integration-tests]
+#          version: every
+          passed: [pull-requests-unit-tests, pull-requests-integration-tests,pull-requests-acceptance-tests]
       - put: pr-develop
         params:
           path: cf-ops-automation
@@ -791,24 +831,7 @@ jobs:
 groups:
   - name: overview
     jobs:
-      - patch
-      - minor
-      - major
-      - build-cached-image
-      - unit-tests
-      - acceptance-tests
-      - integration-tests
-      - update-documentation
-      - merge-to-master
-      - ship-it
-      - merge-changelog-to-develop
-      - pull-requests-build-cached-image
-      - pull-requests-unit-tests
-      - pull-requests-acceptance-tests
-      - pull-requests-integration-tests
-      - pull-requests-success
-      - run-tests-for-hotfix-branch
-      - ship-hotfix
+      - "*"
 
   - name: releases
     jobs:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,17 +1,17 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
       repository: cfcommunity/slack-notification-resource
 
   - name: pull-request
-    type: docker-image
+    type: registry-image
     source:
       repository: teliaoss/github-pr-resource
 
   - name: meta
-    type: docker-image
+    type: registry-image
     source:
       repository: olhtbr/metadata-resource
       tag: 2.0.1
@@ -35,7 +35,7 @@ resources:
     password: ((dockerhub-password))
     tag: develop-latest
 
-- name: cf-ops-automation-docker-image-PR
+- name: cf-ops-automation-docker-image-pr
   icon: docker
   type: docker-image
   source:
@@ -75,7 +75,7 @@ resources:
     branch: master
     skip_ssl_verification: ((cf-ops-automation-git-insecure))
 
-- name: PR-develop
+- name: pr-develop
   icon: source-pull
   type: pull-request
   source:
@@ -292,7 +292,7 @@ jobs:
         config: &integration_tests_setup_credhub_pre_requisites_task_config
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: governmentpaas/bosh-cli-v2
               tag: bca975d14888e2e587d6df3e2af7c45d94507454
@@ -396,7 +396,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: orangecloudfoundry/cf-ops-automation
               tag: develop-latest
@@ -421,7 +421,7 @@ jobs:
               CHANGE_DETECTED_COUNTER=$(git status --porcelain|wc -l)
               if [ ${CHANGE_DETECTED_COUNTER} -gt 0 ]
               then
-                 git commit -m "[ci skip] Living documentation auto-update"
+                 git commit -m "Living documentation auto-update"
               else
                  echo "No change detected, skip commit"
               fi
@@ -467,7 +467,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: orangecloudfoundry/cf-ops-automation
               tag: develop-latest
@@ -512,7 +512,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: orangecloudfoundry/cf-ops-automation
               tag: develop-latest
@@ -561,7 +561,7 @@ jobs:
         params:
           repository: cf-ops-automation
 
-  - name: PullRequests-build-cached-image
+  - name: pull-requests-build-cached-image
     on_failure: &PR_on_failure_alert
       put: slack-alert
       params:
@@ -573,96 +573,96 @@ jobs:
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
     plan:
-      - get: PR-develop
+      - get: pr-develop
         trigger: true
         version: every
-      - put: PR-develop
+      - put: pr-develop
         params:
-          path: PR-develop
+          path: pr-develop
           status: pending
-      - put: cf-ops-automation-docker-image-PR
+      - put: cf-ops-automation-docker-image-pr
         attempts: 5
         get_params: {skip_download: true}
         params:
-          build: PR-develop
-          tag: PR-develop/.git/resource/pr
+          build: pr-develop
+          tag: pr-develop/.git/resource/pr
           tag_prefix: PR-
         on_failure:
-          put: PR-develop
+          put: pr-develop
           params:
-            path: PR-develop
+            path: pr-develop
             status: failure
 
-  - name: PullRequests-UnitTests
+  - name: pull-requests-unit-tests
     on_failure: *PR_on_failure_alert
     serial: true
     plan:
       - in_parallel:
         - put: concourse-meta
-        - get: cf-ops-automation-docker-image-PR
-          passed: [PullRequests-build-cached-image]
+        - get: cf-ops-automation-docker-image-pr
+          passed: [pull-requests-build-cached-image]
           trigger: true
         - get: cf-ops-automation
-          resource: PR-develop
+          resource: pr-develop
           trigger: true
           version: every
-      - put: PR-develop
+      - put: pr-develop
         params:
           path: cf-ops-automation
           status: pending
       - task: test-pr
         attempts: 2
-        image: cf-ops-automation-docker-image-PR
+        image: cf-ops-automation-docker-image-pr
         timeout: 30m
         config: *unit_tests_config
         params:
           GIT_SHA_CMD: cat .git/resource/head_sha
           GIT_BRANCH_CMD: cat .git/resource/head_name
         on_failure:
-          put: PR-develop
+          put: pr-develop
           params:
-            path: PR-develop
+            path: pr-develop
             status: failure
 
-  - name: PullRequests-AcceptanceTests
+  - name: pull-requests-acceptance-tests
     on_failure: *PR_on_failure_alert
     serial: true
     plan:
       - in_parallel:
-        - get: cf-ops-automation-docker-image-PR
-          passed: [PullRequests-UnitTests]
+        - get: cf-ops-automation-docker-image-pr
+          passed: [pull-requests-unit-tests]
           trigger: true
         - get: cf-ops-automation
-          resource: PR-develop
+          resource: pr-develop
           trigger: true
           version: every
-          passed: [PullRequests-UnitTests]
+          passed: [pull-requests-unit-tests]
       - task: acceptance-test-pr
         attempts: 2
-        image: cf-ops-automation-docker-image-PR
+        image: cf-ops-automation-docker-image-pr
         timeout: 30m
         config: *acceptance_tests_config
         on_failure: &PR_coa_failure
-          put: PR-develop
+          put: pr-develop
           params:
             path: cf-ops-automation
             status: failure
-  - name: PullRequests-IntegrationTests
+  - name: pull-requests-integration-tests
     on_failure: *PR_on_failure_alert
     serial_groups: [integration]
     serial: true
     plan:
       - in_parallel:
-        - get: cf-ops-automation-docker-image-PR
-          passed: [PullRequests-build-cached-image]
+        - get: cf-ops-automation-docker-image-pr
+          passed: [pull-requests-build-cached-image]
           trigger: true
         - get: cf-ops-automation
-          resource: PR-develop
+          resource: pr-develop
           trigger: true
           version: every
       - task: setup-pre-requisites
         attempts: 1
-        image: cf-ops-automation-docker-image-PR
+        image: cf-ops-automation-docker-image-pr
         config: *integration_tests_setup_pre_requisites_task_config
         on_failure: *PR_coa_failure
         # it is not possible to include it as config param, otherwise we get an deserialization error
@@ -678,19 +678,19 @@ jobs:
         on_failure: *PR_coa_failure
       - task: upload-pipelines
         attempts: 2
-        image: cf-ops-automation-docker-image-PR
+        image: cf-ops-automation-docker-image-pr
         config: *integration_tests_upload-pipelines_task_config
         on_failure: *PR_coa_failure
 
-  - name: PullRequests-Success
+  - name: pull-requests-success
     plan:
       - in_parallel:
         - get: cf-ops-automation
-          resource: PR-develop
+          resource: pr-develop
           trigger: true
           version: every
-          passed: [PullRequests-AcceptanceTests, PullRequests-IntegrationTests]
-      - put: PR-develop
+          passed: [pull-requests-acceptance-tests, pull-requests-integration-tests]
+      - put: pr-develop
         params:
           path: cf-ops-automation
           status: success
@@ -731,7 +731,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: alpine
           inputs:
@@ -789,7 +789,7 @@ jobs:
       params: {file: version/version}
 
 groups:
-  - name: Overview
+  - name: overview
     jobs:
       - patch
       - minor
@@ -802,15 +802,15 @@ groups:
       - merge-to-master
       - ship-it
       - merge-changelog-to-develop
-      - PullRequests-build-cached-image
-      - PullRequests-UnitTests
-      - PullRequests-AcceptanceTests
-      - PullRequests-IntegrationTests
-      - PullRequests-Success
+      - pull-requests-build-cached-image
+      - pull-requests-unit-tests
+      - pull-requests-acceptance-tests
+      - pull-requests-integration-tests
+      - pull-requests-success
       - run-tests-for-hotfix-branch
       - ship-hotfix
 
-  - name: Releases
+  - name: releases
     jobs:
       - patch
       - minor
@@ -824,15 +824,15 @@ groups:
       - ship-it
       - merge-changelog-to-develop
 
-  - name: Pull-Requests
+  - name: pull-requests
     jobs:
-      - PullRequests-build-cached-image
-      - PullRequests-UnitTests
-      - PullRequests-AcceptanceTests
-      - PullRequests-IntegrationTests
-      - PullRequests-Success
+      - pull-requests-build-cached-image
+      - pull-requests-unit-tests
+      - pull-requests-acceptance-tests
+      - pull-requests-integration-tests
+      - pull-requests-success
 
-  - name: Hotfixes
+  - name: hotfixes
     jobs:
       - build-cached-image
       - run-tests-for-hotfix-branch

--- a/ci/tasks/run-ITs/task.yml
+++ b/ci/tasks/run-ITs/task.yml
@@ -14,7 +14,7 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source: {repository: orangecloudfoundry/cf-ops-automation, tag: develop-latest}
 inputs:
   - name: cf-ops-automation

--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -1,15 +1,15 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
       # use latest as no other recent tag available
 
 resources:
@@ -97,9 +97,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))library/ruby
+          repository: library/ruby
           tag: 2.7.1
       inputs:
         - name: concourse-teams
@@ -155,9 +155,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))library/alpine
+          repository: library/alpine
           tag: "3.9"
       inputs:
         - name: cf-ops-automation
@@ -187,9 +187,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: final-control-plane-pipeline
@@ -254,9 +254,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+          repository: governmentpaas/bosh-cli-v2
           tag: bca975d14888e2e587d6df3e2af7c45d94507454
       inputs:
         - name: scripts-resource
@@ -349,9 +349,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
       - name: concourse-teams
@@ -435,9 +435,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
       - name: all-pipelines

--- a/concourse/pipelines/control-plane.yml
+++ b/concourse/pipelines/control-plane.yml
@@ -1,24 +1,24 @@
 ---
 resource_types:
   - name: concourse-5-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      repository: concourse/concourse-pipeline-resource
       tag: 5.0.0
   - name: concourse-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))orangecloudfoundry/concourse-pipeline-resource
+      repository: orangecloudfoundry/concourse-pipeline-resource
       tag: 6.5.0
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: meta
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))olhtbr/metadata-resource
+      repository: olhtbr/metadata-resource
       tag: 2.0.1
 resources:
 - name: concourse-meta
@@ -127,9 +127,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
       - name: concourse-micro
@@ -144,9 +144,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))library/ruby
+          repository: library/ruby
           tag: 2.7.1
       inputs:
       - name: concourse-micro
@@ -197,9 +197,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))library/ruby
+            repository: library/ruby
             tag: 2.7.1
         inputs:
           - name: concourse-micro-legacy
@@ -281,9 +281,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
       - name: config-resource
@@ -307,10 +307,10 @@ jobs:
         config: &success_tag
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               # from https://hub.docker.com/r/governmentpaas/git-ssh/tags
-              repository: ((docker-registry-url))governmentpaas/git-ssh
+              repository: governmentpaas/git-ssh
               tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
           outputs:
             - name: success-tag
@@ -333,10 +333,10 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           # from https://hub.docker.com/r/governmentpaas/git-ssh/tags
-          repository: ((docker-registry-url))governmentpaas/git-ssh
+          repository: governmentpaas/git-ssh
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: concourse-micro-success
@@ -414,9 +414,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/git-ssh
+          repository: governmentpaas/git-ssh
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
       - name: secrets-writer
@@ -460,9 +460,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/git-ssh
+          repository: governmentpaas/git-ssh
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
       - name: paas-templates-full

--- a/concourse/pipelines/micro-bosh-init-pipeline.yml
+++ b/concourse/pipelines/micro-bosh-init-pipeline.yml
@@ -1,14 +1,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
 
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
 
 resources:
 
@@ -90,9 +90,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))orangecloudfoundry/terraform
+            repository: orangecloudfoundry/terraform
             tag: 10505f812181d02e8be344a943a28a8af24f9e01
         inputs:
           - name: spec-resource
@@ -146,9 +146,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))library/ruby
+            repository: library/ruby
             tag: 2.7.1-slim
         inputs:
           - name: scripts-resource
@@ -190,7 +190,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: ((docker-registry-url))library/alpine
             tag: "3.9"

--- a/concourse/pipelines/micro-depls-terraform-pipeline.yml
+++ b/concourse/pipelines/micro-depls-terraform-pipeline.yml
@@ -1,19 +1,19 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
 
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
 
   - name: bosh-config
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))dellemcdojo/bosh-config-resource
+      repository: dellemcdojo/bosh-config-resource
 
 resources:
 
@@ -152,7 +152,7 @@ jobs:
 #      config:
 #        platform: linux
 #        image_resource:
-#          type: docker-image
+#          type: registry-image
 #          source: {repository: hashicorp/terraform, tag: 0.8.7}
 #        inputs:
 #          - name: paas-bootstrap
@@ -205,8 +205,8 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
-          source: {repository: "((docker-registry-url))orangecloudfoundry/orange-cf-bosh-cli"}
+          type: registry-image
+          source: {repository: "orangecloudfoundry/orange-cf-bosh-cli"}
         inputs:
           - name: paas-bootstrap
           - name: secrets

--- a/concourse/pipelines/sync-feature-branches.yml
+++ b/concourse/pipelines/sync-feature-branches.yml
@@ -1,15 +1,15 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 
   - name: git-branch-heads
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))orangecloudfoundry/git-branch-heads-resource
+      repository: orangecloudfoundry/git-branch-heads-resource
       tag: 1.1.0
 
 resources:
@@ -97,9 +97,9 @@ jobs:
     - task: merge-commit
       config:
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/git-ssh
+            repository: governmentpaas/git-ssh
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         platform: linux
         inputs:
@@ -181,9 +181,9 @@ jobs:
           - task: display-conficts
             config:
               image_resource:
-                type: docker-image
+                type: registry-image
                 source:
-                  repository: ((docker-registry-url))governmentpaas/git-ssh
+                  repository: governmentpaas/git-ssh
                   tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
               platform: linux
               inputs:
@@ -261,9 +261,9 @@ jobs:
           - task: display-conficts
             config:
               image_resource:
-                type: docker-image
+                type: registry-image
                 source:
-                  repository: ((docker-registry-url))governmentpaas/git-ssh
+                  repository: governmentpaas/git-ssh
                   tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
               platform: linux
               inputs:
@@ -321,9 +321,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/git-ssh
+            repository: governmentpaas/git-ssh
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: reference-resource

--- a/concourse/pipelines/sync-hotfix-branches.yml
+++ b/concourse/pipelines/sync-hotfix-branches.yml
@@ -1,15 +1,15 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 
   - name: git-branch-heads
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))orangecloudfoundry/git-branch-heads-resource
+      repository: orangecloudfoundry/git-branch-heads-resource
       tag: 1.1.0
 
 resources:

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -51,26 +51,26 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 
 - name: bosh-errand
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/bosh2-errand-resource
+    repository: cfcommunity/bosh2-errand-resource
     tag: v0.1.2
 
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 
 resources:
@@ -343,9 +343,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: repackaged-releases-fallback
@@ -843,9 +843,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: final-release-manifest
@@ -1035,9 +1035,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir
@@ -1113,9 +1113,9 @@ jobs:
     config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+            repository: governmentpaas/bosh-cli-v2
             tag: bca975d14888e2e587d6df3e2af7c45d94507454
         inputs:
           - name: scripts-resource
@@ -1166,9 +1166,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir

--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -39,14 +39,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 
 resources:
@@ -266,9 +266,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))governmentpaas/curl-ssl
+              repository: governmentpaas/curl-ssl
               tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
           inputs:
             - name: repackaged-releases-fallback
@@ -396,9 +396,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -427,9 +427,9 @@ jobs:
           config:
             platform: linux
             image_resource:
-              type: docker-image
+              type: registry-image
               source:
-                repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+                repository: governmentpaas/bosh-cli-v2
                 tag: bca975d14888e2e587d6df3e2af7c45d94507454
             inputs:
               - name: releases-to-upload
@@ -466,9 +466,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -501,9 +501,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: release
@@ -568,9 +568,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: compiled-release
@@ -618,9 +618,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         outputs:
           - name: result-dir

--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -12,9 +12,9 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 
@@ -97,9 +97,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         outputs:
           - name: result-dir

--- a/concourse/pipelines/template/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/template/concourse-pipeline.yml.erb
@@ -10,21 +10,21 @@
 ---
 resource_types:
   - name: concourse-5-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      repository: concourse/concourse-pipeline-resource
       tag: 5.0.0
 
   - name: concourse-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))orangecloudfoundry/concourse-pipeline-resource
+      repository: orangecloudfoundry/concourse-pipeline-resource
       tag: 6.5.0
 
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 
 resources:
@@ -211,9 +211,9 @@ jobs:
         config: &success_tag
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))governmentpaas/git-ssh
+              repository: governmentpaas/git-ssh
               tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
           outputs:
             - name: success-tag
@@ -236,9 +236,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/git-ssh
+          repository: governmentpaas/git-ssh
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: concourse-micro-success

--- a/concourse/pipelines/template/k8s-pipeline.yml.erb
+++ b/concourse/pipelines/template/k8s-pipeline.yml.erb
@@ -35,14 +35,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 
 resources:
@@ -387,9 +387,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir

--- a/concourse/pipelines/template/news-pipeline.yml.erb
+++ b/concourse/pipelines/template/news-pipeline.yml.erb
@@ -25,15 +25,15 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
       # use latest as no other recent tag available
 
 resources:
@@ -135,9 +135,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: boshrelease

--- a/concourse/pipelines/template/tf-pipeline.yml.erb
+++ b/concourse/pipelines/template/tf-pipeline.yml.erb
@@ -9,9 +9,9 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 
 resources:

--- a/concourse/pipelines/template/update-pipeline.yml.erb
+++ b/concourse/pipelines/template/update-pipeline.yml.erb
@@ -9,14 +9,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: meta
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))olhtbr/metadata-resource
+      repository: olhtbr/metadata-resource
       tag: 2.0.1
 resources:
 
@@ -112,9 +112,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-            repository: ((docker-registry-url))library/ruby
+            repository: library/ruby
             tag: 2.7.1-slim
       inputs:
       - name: cf-ops-automation

--- a/concourse/tasks/apply_iaas_type_and_profiles/task.yml
+++ b/concourse/tasks/apply_iaas_type_and_profiles/task.yml
@@ -1,8 +1,8 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))orangecloudfoundry/k8s-tools
+    repository: orangecloudfoundry/k8s-tools
     tag: 10505f812181d02e8be344a943a28a8af24f9e01
 inputs:
   - name: paas-templates-resource

--- a/concourse/tasks/bootstrap_init_pipelines.yml
+++ b/concourse/tasks/bootstrap_init_pipelines.yml
@@ -14,9 +14,8 @@
 
 platform: linux
 image_resource:
-  type: docker-image
-#  source: {repository: ((docker-registry-url))orangecloudfoundry/orange-cf-bosh-cli, tag: 2.0.3}
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1}
 
 inputs:
 - name: scripts-resource

--- a/concourse/tasks/bosh_cancel_all_tasks/task.yml
+++ b/concourse/tasks/bosh_cancel_all_tasks/task.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/bosh_delete_apply/task.yml
+++ b/concourse/tasks/bosh_delete_apply/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/bosh_delete_plan/task.yml
+++ b/concourse/tasks/bosh_delete_plan/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/bosh_interpolate/task.yml
+++ b/concourse/tasks/bosh_interpolate/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: bosh-inputs

--- a/concourse/tasks/bosh_update_config/task.yml
+++ b/concourse/tasks/bosh_update_config/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: config-manifest

--- a/concourse/tasks/bosh_upload_releases/task.yml
+++ b/concourse/tasks/bosh_upload_releases/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: releases-to-upload

--- a/concourse/tasks/bosh_upload_stemcell/task.yml
+++ b/concourse/tasks/bosh_upload_stemcell/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: stemcell

--- a/concourse/tasks/bosh_variables/task.yml
+++ b/concourse/tasks/bosh_variables/task.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/cf_push.yml
+++ b/concourse/tasks/cf_push.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/cf-cli
+    repository: governmentpaas/cf-cli
     tag: 0cba745d6d0e417423bd651beeda6b896687429a
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/check_configuration/task.yml
+++ b/concourse/tasks/check_configuration/task.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/spruce
+    repository: governmentpaas/spruce
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/coa-upgrade/task.yml
+++ b/concourse/tasks/coa-upgrade/task.yml
@@ -14,8 +14,8 @@
 
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1}
 inputs:
   - name: cf-ops-automation
   - name: templates

--- a/concourse/tasks/copy_deployment_required_files.yml
+++ b/concourse/tasks/copy_deployment_required_files.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/download_stemcell/task.yml
+++ b/concourse/tasks/download_stemcell/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/awscli
+    repository: governmentpaas/awscli
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: templates-resource

--- a/concourse/tasks/execute_deploy_script.yml
+++ b/concourse/tasks/execute_deploy_script.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/execute_k8s_shells/task.yml
+++ b/concourse/tasks/execute_k8s_shells/task.yml
@@ -1,8 +1,8 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))orangecloudfoundry/k8s-tools
+    repository: orangecloudfoundry/k8s-tools
     tag: 10505f812181d02e8be344a943a28a8af24f9e01
 inputs:
   - name: paas-templates-resource

--- a/concourse/tasks/extract_terraform_outputs.yml
+++ b/concourse/tasks/extract_terraform_outputs.yml
@@ -1,8 +1,8 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1-slim}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1-slim}
 inputs:
   - name: scripts-resource
   - name: state-file-resource

--- a/concourse/tasks/fly_execute_commands.yml
+++ b/concourse/tasks/fly_execute_commands.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/curl-ssl
+    repository: governmentpaas/curl-ssl
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
 - name: fly-cmd

--- a/concourse/tasks/generate-all-pipelines.yml
+++ b/concourse/tasks/generate-all-pipelines.yml
@@ -1,8 +1,8 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1-slim}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1-slim}
 inputs:
   - name: scripts-resource
   - name: secrets-resource

--- a/concourse/tasks/generate_coa_env_bootstrap_private_prereqs.yml
+++ b/concourse/tasks/generate_coa_env_bootstrap_private_prereqs.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))orangecloudfoundry/cf-ops-automation
+    repository: orangecloudfoundry/cf-ops-automation
 
 inputs:
 - name: cf-ops-automation

--- a/concourse/tasks/generate_concourse_pipeline_config/task.yml
+++ b/concourse/tasks/generate_concourse_pipeline_config/task.yml
@@ -14,8 +14,8 @@
 
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1-slim}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1-slim}
 inputs:
   - name: cf-ops-automation
   - name: config-resource

--- a/concourse/tasks/generate_depls/task.yml
+++ b/concourse/tasks/generate_depls/task.yml
@@ -14,8 +14,8 @@
 
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1-slim}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1-slim}
 inputs:
   - name: scripts-resource
   - name: templates

--- a/concourse/tasks/generate_manifest/task.yml
+++ b/concourse/tasks/generate_manifest/task.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/spruce
+    repository: governmentpaas/spruce
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/generate_single_concourse_pipeline_config/task.yml
+++ b/concourse/tasks/generate_single_concourse_pipeline_config/task.yml
@@ -14,8 +14,8 @@
 
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1-slim}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1-slim}
 inputs:
   - name: cf-ops-automation
   - name: config-resource

--- a/concourse/tasks/git_append_a_dir_from_generated/task.yml
+++ b/concourse/tasks/git_append_a_dir_from_generated/task.yml
@@ -13,9 +13,9 @@
 #
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: reference-resource

--- a/concourse/tasks/git_hard_reset_wip/task.yml
+++ b/concourse/tasks/git_hard_reset_wip/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: reference-resource

--- a/concourse/tasks/git_rebase_status/task.yml
+++ b/concourse/tasks/git_rebase_status/task.yml
@@ -13,9 +13,9 @@
 #
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: reference-resource

--- a/concourse/tasks/git_reset_wip.yml
+++ b/concourse/tasks/git_reset_wip.yml
@@ -14,10 +14,10 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     # from https://hub.docker.com/r/governmentpaas/git-ssh/tags
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: reference-resource

--- a/concourse/tasks/git_squash_branches/task.yml
+++ b/concourse/tasks/git_squash_branches/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: reference-resource

--- a/concourse/tasks/git_update_a_dir_from_generated.yml
+++ b/concourse/tasks/git_update_a_dir_from_generated.yml
@@ -14,8 +14,8 @@
 
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))governmentpaas/git-ssh, tag: 19d32c252e328a762f75417fcee7cab6dbac9e97}
+  type: registry-image
+  source: {repository: governmentpaas/git-ssh, tag: 19d32c252e328a762f75417fcee7cab6dbac9e97}
 inputs:
   - name: reference-resource
   - name: generated-resource

--- a/concourse/tasks/git_update_a_file_from_generated.yml
+++ b/concourse/tasks/git_update_a_file_from_generated.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: reference-resource

--- a/concourse/tasks/git_update_all_files_from_generated.yml
+++ b/concourse/tasks/git_update_all_files_from_generated.yml
@@ -14,10 +14,10 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     # from https://hub.docker.com/r/governmentpaas/git-ssh/tags
-    repository: ((docker-registry-url))governmentpaas/git-ssh
+    repository: governmentpaas/git-ssh
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: reference-resource

--- a/concourse/tasks/list_used_ci_team/task.yml
+++ b/concourse/tasks/list_used_ci_team/task.yml
@@ -1,8 +1,8 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1-slim}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1-slim}
 inputs:
   - name: secrets
   - name: cf-ops-automation

--- a/concourse/tasks/post_bosh_deploy.yml
+++ b/concourse/tasks/post_bosh_deploy.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/cf-cli
+    repository: governmentpaas/cf-cli
     tag: 0cba745d6d0e417423bd651beeda6b896687429a
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/pre_bosh_deploy.yml
+++ b/concourse/tasks/pre_bosh_deploy.yml
@@ -1,9 +1,9 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+    repository: orangecloudfoundry/bosh-cli-v2-cf-cli
     tag: 10505f812181d02e8be344a943a28a8af24f9e01
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/reformat_expected_boshreleases_list/task.yml
+++ b/concourse/tasks/reformat_expected_boshreleases_list/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: templates-resource

--- a/concourse/tasks/repackage_boshreleases/task.yml
+++ b/concourse/tasks/repackage_boshreleases/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: cf-ops-automation

--- a/concourse/tasks/repackage_boshreleases_fallback/task.yml
+++ b/concourse/tasks/repackage_boshreleases_fallback/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: cf-ops-automation

--- a/concourse/tasks/resolve_manifest_versions/resolve_manifest_urls.rb
+++ b/concourse/tasks/resolve_manifest_versions/resolve_manifest_urls.rb
@@ -94,7 +94,7 @@ class PrecompileOfflineReleaseUrlResolver < AbstractReleaseUrlResolver
   def resolve(release_name, release_version, release_repository)
     return {} unless valid?
 
-    # Minio download url format for compiled release:  https://private-s3.internal.paas/compiled-releases/minio/minio-2020-06-18T02-23-35Z-ubuntu-xenial-621.89.tgz
+    # Minio download url format for compiled release:  https://private-s3.internal.paas/compiled-releases/minio/minio-2020-06-18T02-23-35Z-ubuntu-bionic-621.89.tgz
     puts "Resolving #{release_name}-#{release_version} using Compiled Offline resolver"
     namespace = release_repository.split('/').first
     resolved_url = "#{download_server_url.delete_suffix('/')}/#{namespace}/#{release_name}-#{release_version}-#{@stemcell_os}-#{@stemcell_version}.tgz"

--- a/concourse/tasks/resolve_manifest_versions/task.yml
+++ b/concourse/tasks/resolve_manifest_versions/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+    repository: governmentpaas/bosh-cli-v2
     tag: bca975d14888e2e587d6df3e2af7c45d94507454
 inputs:
   - name: templates-resource

--- a/concourse/tasks/run-ruby-script.yml
+++ b/concourse/tasks/run-ruby-script.yml
@@ -1,8 +1,8 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
-  source: {repository: ((docker-registry-url))library/ruby, tag: 2.7.1-slim}
+  type: registry-image
+  source: {repository: library/ruby, tag: 2.7.1-slim}
 inputs:
   - name: scripts-resource
 outputs:

--- a/concourse/tasks/s3_boshreleases_upload/task.yml
+++ b/concourse/tasks/s3_boshreleases_upload/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/awscli
+    repository: governmentpaas/awscli
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: local-files-dir

--- a/concourse/tasks/s3_missing_boshreleases/task.yml
+++ b/concourse/tasks/s3_missing_boshreleases/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/awscli
+    repository: governmentpaas/awscli
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: templates-resource

--- a/concourse/tasks/s3_stemcells_upload/task.yml
+++ b/concourse/tasks/s3_stemcells_upload/task.yml
@@ -14,9 +14,9 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))governmentpaas/awscli
+    repository: governmentpaas/awscli
     tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
 inputs:
   - name: templates-resource

--- a/concourse/tasks/terraform_apply_cloudfoundry.yml
+++ b/concourse/tasks/terraform_apply_cloudfoundry.yml
@@ -15,9 +15,9 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   # Maintained in https://github.com/orange-cloudfoundry/paas-docker-cloudfoundry-tools
-  source: {repository: ((docker-registry-url))orangecloudfoundry/terraform, tag: 10505f812181d02e8be344a943a28a8af24f9e01}
+  source: {repository: orangecloudfoundry/terraform, tag: 10505f812181d02e8be344a943a28a8af24f9e01}
 
 inputs:
   - name: secret-state-resource

--- a/concourse/tasks/terraform_plan_cloudfoundry.yml
+++ b/concourse/tasks/terraform_plan_cloudfoundry.yml
@@ -15,9 +15,9 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   # Maintained in https://github.com/orange-cloudfoundry/paas-docker-cloudfoundry-tools
-  source: {repository: ((docker-registry-url))orangecloudfoundry/terraform, tag: 10505f812181d02e8be344a943a28a8af24f9e01}
+  source: {repository: orangecloudfoundry/terraform, tag: 10505f812181d02e8be344a943a28a8af24f9e01}
 
 inputs:
   - name: secret-state-resource

--- a/docs/reference_dataset/another-world-root-depls.md
+++ b/docs/reference_dataset/another-world-root-depls.md
@@ -100,17 +100,6 @@ another-world-root-depls
 * another-world-root-depls-bosh-generated.yml
 * another-world-root-depls-k8s-generated.yml
 
-### docker-registry-url
-
-* another-world-root-depls-bosh-generated.yml
-* another-world-root-depls-bosh-precompile-generated.yml
-* another-world-root-depls-cf-apps-generated.yml
-* another-world-root-depls-concourse-generated.yml
-* another-world-root-depls-k8s-generated.yml
-* another-world-root-depls-news-generated.yml
-* another-world-root-depls-tf-generated.yml
-* another-world-root-depls-update-generated.yml
-
 ### iaas-type
 
 * another-world-root-depls-bosh-generated.yml
@@ -187,7 +176,6 @@ another-world-root-depls
 * credhub-client
 * credhub-secret
 * credhub-server
-* docker-registry-url
 * iaas-type
 * paas-templates-branch
 * paas-templates-uri
@@ -204,15 +192,15 @@ another-world-root-depls
 
 ### another-world-root-depls-bosh-precompile-generated.yml
 
-* docker-registry-url
+No credentials required
 
 ### another-world-root-depls-cf-apps-generated.yml
 
-* docker-registry-url
+No credentials required
 
 ### another-world-root-depls-concourse-generated.yml
 
-* docker-registry-url
+No credentials required
 
 ### another-world-root-depls-k8s-generated.yml
 
@@ -222,7 +210,6 @@ another-world-root-depls
 * credhub-client
 * credhub-secret
 * credhub-server
-* docker-registry-url
 * iaas-type
 * paas-templates-branch
 * paas-templates-uri
@@ -237,13 +224,13 @@ another-world-root-depls
 
 ### another-world-root-depls-news-generated.yml
 
-* docker-registry-url
+No credentials required
 
 ### another-world-root-depls-tf-generated.yml
 
-* docker-registry-url
+No credentials required
 
 ### another-world-root-depls-update-generated.yml
 
-* docker-registry-url
+No credentials required
 

--- a/docs/reference_dataset/config_repository/private-config.yml
+++ b/docs/reference_dataset/config_repository/private-config.yml
@@ -14,7 +14,7 @@
 #    recreate: false # Optional. Recreate all VMs in deployment. Defaults to false.
 #    skip_drain: # Optional. A collection of instance group names to skip running drain scripts for. Defaults to empty.
 #  stemcell:
-#    name: bosh-openstack-kvm-ubuntu-xenial-go_agent  # Default: bosh-openstack-kvm-ubuntu-xenial-go_agent
+#    name: bosh-openstack-kvm-ubuntu-bionic-go_agent  # Default: bosh-openstack-kvm-ubuntu-bionic-go_agent
 #  concourse:
 #    parallel_execution_limit: 5 # Default: -1, ie unlimited
 #    serial_group_naming_strategy: SerialGroupMd5NamingStrategy #Default: SerialGroupRoundRobinNamingStrategy

--- a/docs/reference_dataset/hello-world-root-depls.md
+++ b/docs/reference_dataset/hello-world-root-depls.md
@@ -25,8 +25,8 @@ hello-world-root-depls
 │       └── secrets.yml
 ├── cf-apps-deployments
 │   └── generic-app
-│       ├── Readme.md
 │       ├── enable-cf-app.yml
+│       ├── Readme.md
 │       ├── secrets
 │       │   └── secrets.yml
 │       └── spruce-file-sample-from-secrets.txt
@@ -44,10 +44,10 @@ hello-world-root-depls
 ├── k8s-sample
 │   └── enable-deployment.yml
 ├── pipeline-sample
-│   ├── Readme.md
 │   ├── concourse-pipeline-config
 │   │   └── virtualbox
 │   ├── enable-deployment.yml
+│   ├── Readme.md
 │   └── secrets
 │       └── secrets.yml
 ├── runtime-config.yml
@@ -113,8 +113,8 @@ hello-world-root-depls
 │           ├── pre-cf-push.sh
 │           ├── spruce-file-sample-from-templates.txt
 │           └── static-app
-│               ├── Staticfile
-│               └── index.html
+│               ├── index.html
+│               └── Staticfile
 ├── hooks
 │   └── k8s
 │       └── deploy.sh
@@ -254,17 +254,6 @@ hello-world-root-depls
 
 * hello-world-root-depls-bosh-generated.yml
 * hello-world-root-depls-k8s-generated.yml
-
-### docker-registry-url
-
-* hello-world-root-depls-bosh-generated.yml
-* hello-world-root-depls-bosh-precompile-generated.yml
-* hello-world-root-depls-cf-apps-generated.yml
-* hello-world-root-depls-concourse-generated.yml
-* hello-world-root-depls-k8s-generated.yml
-* hello-world-root-depls-news-generated.yml
-* hello-world-root-depls-tf-generated.yml
-* hello-world-root-depls-update-generated.yml
 
 ### iaas-type
 
@@ -426,7 +415,6 @@ hello-world-root-depls
 * credhub-client
 * credhub-secret
 * credhub-server
-* docker-registry-url
 * iaas-type
 * paas-templates-branch
 * paas-templates-uri
@@ -453,7 +441,6 @@ hello-world-root-depls
 * concourse-hello-world-root-depls-password
 * concourse-hello-world-root-depls-target
 * concourse-hello-world-root-depls-username
-* docker-registry-url
 * paas-templates-precompile-branch
 * paas-templates-uri
 * secrets-branch
@@ -474,7 +461,6 @@ hello-world-root-depls
 * concourse-hello-world-root-depls-password
 * concourse-hello-world-root-depls-target
 * concourse-hello-world-root-depls-username
-* docker-registry-url
 * paas-templates-branch
 * paas-templates-uri
 * profiles
@@ -495,7 +481,6 @@ hello-world-root-depls
 * concourse-hello-world-root-depls-password
 * concourse-hello-world-root-depls-target
 * concourse-hello-world-root-depls-username
-* docker-registry-url
 * iaas-type
 * paas-templates-branch
 * paas-templates-uri
@@ -519,7 +504,6 @@ hello-world-root-depls
 * credhub-client
 * credhub-secret
 * credhub-server
-* docker-registry-url
 * iaas-type
 * k8s-configs-repository-branch
 * k8s-configs-repository-password
@@ -542,7 +526,6 @@ hello-world-root-depls
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
-* docker-registry-url
 * paas-templates-branch
 * paas-templates-uri
 * slack-channel
@@ -556,7 +539,6 @@ hello-world-root-depls
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
-* docker-registry-url
 * iaas-type
 * paas-templates-branch
 * paas-templates-uri
@@ -574,7 +556,6 @@ hello-world-root-depls
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
-* docker-registry-url
 * iaas-type
 * paas-templates-branch
 * paas-templates-uri

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
@@ -2,24 +2,24 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 - name: bosh-errand
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/bosh2-errand-resource
+    repository: cfcommunity/bosh2-errand-resource
     tag: v0.1.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: concourse-meta
@@ -105,9 +105,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: repackaged-releases-fallback

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-precompile-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-precompile-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 resources:
 jobs:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-cf-apps-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-cf-apps-generated.yml
@@ -2,9 +2,9 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 jobs:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-concourse-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-concourse-generated.yml
@@ -2,19 +2,19 @@
 ---
 resource_types:
   - name: concourse-5-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      repository: concourse/concourse-pipeline-resource
       tag: 5.0.0
   - name: concourse-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))orangecloudfoundry/concourse-pipeline-resource
+      repository: orangecloudfoundry/concourse-pipeline-resource
       tag: 6.5.0
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 jobs:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: failure-alert

--- a/docs/reference_dataset/pipelines/another-world-root-depls-news-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-news-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
       # use latest as no other recent tag available
 resources:
 jobs:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-tf-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-tf-generated.yml
@@ -2,9 +2,9 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 resources:
 jobs:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-update-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-update-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: meta
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))olhtbr/metadata-resource
+      repository: olhtbr/metadata-resource
       tag: 2.0.1
 resources:
 jobs:

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
@@ -2,24 +2,24 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 - name: bosh-errand
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/bosh2-errand-resource
+    repository: cfcommunity/bosh2-errand-resource
     tag: v0.1.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: concourse-meta
@@ -186,9 +186,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: repackaged-releases-fallback
@@ -631,9 +631,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: final-release-manifest
@@ -768,9 +768,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir
@@ -836,9 +836,9 @@ jobs:
     config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+            repository: governmentpaas/bosh-cli-v2
             tag: bca975d14888e2e587d6df3e2af7c45d94507454
         inputs:
           - name: scripts-resource
@@ -885,9 +885,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-precompile-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-precompile-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 resources:
   - name: failure-alert
@@ -169,9 +169,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))governmentpaas/curl-ssl
+              repository: governmentpaas/curl-ssl
               tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
           inputs:
             - name: repackaged-releases-fallback
@@ -264,9 +264,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -294,9 +294,9 @@ jobs:
           config:
             platform: linux
             image_resource:
-              type: docker-image
+              type: registry-image
               source:
-                repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+                repository: governmentpaas/bosh-cli-v2
                 tag: bca975d14888e2e587d6df3e2af7c45d94507454
             inputs:
               - name: releases-to-upload
@@ -326,9 +326,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -384,9 +384,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -414,9 +414,9 @@ jobs:
           config:
             platform: linux
             image_resource:
-              type: docker-image
+              type: registry-image
               source:
-                repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+                repository: governmentpaas/bosh-cli-v2
                 tag: bca975d14888e2e587d6df3e2af7c45d94507454
             inputs:
               - name: releases-to-upload
@@ -446,9 +446,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -504,9 +504,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -534,9 +534,9 @@ jobs:
           config:
             platform: linux
             image_resource:
-              type: docker-image
+              type: registry-image
               source:
-                repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+                repository: governmentpaas/bosh-cli-v2
                 tag: bca975d14888e2e587d6df3e2af7c45d94507454
             inputs:
               - name: releases-to-upload
@@ -566,9 +566,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -625,9 +625,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         outputs:
           - name: result-dir

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-cf-apps-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-cf-apps-generated.yml
@@ -2,9 +2,9 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 - name: failure-alert
@@ -73,9 +73,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         outputs:
           - name: result-dir

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-concourse-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-concourse-generated.yml
@@ -2,19 +2,19 @@
 ---
 resource_types:
   - name: concourse-5-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      repository: concourse/concourse-pipeline-resource
       tag: 5.0.0
   - name: concourse-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))orangecloudfoundry/concourse-pipeline-resource
+      repository: orangecloudfoundry/concourse-pipeline-resource
       tag: 6.5.0
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 - name: failure-alert
@@ -159,9 +159,9 @@ jobs:
         config: &success_tag
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))governmentpaas/git-ssh
+              repository: governmentpaas/git-ssh
               tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
           outputs:
             - name: success-tag
@@ -183,9 +183,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/git-ssh
+          repository: governmentpaas/git-ssh
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: concourse-micro-success

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: failure-alert
@@ -276,9 +276,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-news-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-news-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
       # use latest as no other recent tag available
 resources:
 - name: failure-alert
@@ -98,9 +98,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: boshrelease
@@ -155,9 +155,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: boshrelease
@@ -212,9 +212,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: boshrelease

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-tf-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-tf-generated.yml
@@ -2,9 +2,9 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 resources:
 - name: failure-alert

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-update-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-update-generated.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: meta
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))olhtbr/metadata-resource
+      repository: olhtbr/metadata-resource
       tag: 2.0.1
 resources:
 - name: concourse-meta
@@ -93,9 +93,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-            repository: ((docker-registry-url))library/ruby
+            repository: library/ruby
             tag: 2.7.1-slim
       inputs:
       - name: cf-ops-automation

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/bosh-deployment-sample-tpl.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/bosh-deployment-sample-tpl.yml
@@ -9,8 +9,8 @@ releases: [] # defined in a operators file
 update: {} # defined in a operators file
 
 stemcells:
-- alias: trusty
-  os: ubuntu-xenial
+- alias: default
+  os: ubuntu-bionic
   version: latest
 
 instance_groups:
@@ -19,7 +19,7 @@ instance_groups:
   azs: [z1]
   vm_type: default
   persistent_disk: 0
-  stemcell: trusty
+  stemcell: default
   networks:
   - name: concourse-bucc
   jobs:

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/openstack/ntp-job-configuration-operators.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/openstack/ntp-job-configuration-operators.yml
@@ -17,6 +17,6 @@
           restrict 127.0.0.0 mask 255.0.0.0
           restrict -6 ::1
     vm_type: default
-    stemcell: trusty
+    stemcell: default
     networks:
     - name: concourse-bucc

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/generic-app_manifest-tpl.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/cf-apps-deployments/generic-app/template/generic-app_manifest-tpl.yml
@@ -22,7 +22,7 @@ applications:
 
     meta-inf-support: (( grab meta-inf.status ))
 
-secrets: # you may define temporary keys in this section, that will be pruned upon spruce invocation, ie won't endup in spruce-generated files
+secrets: # you may define temporary keys in this section, that will be pruned upon spruce invocation, ie won't end in spruce-generated files
   path_to_my_file: (( concat "../../../../" $CUSTOM_SCRIPT_DIR "/spruce-file-sample-from-templates.txt" ))
 
 

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/pipeline-sample/concourse-pipeline-config/pipeline-sample-tpl.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/pipeline-sample/concourse-pipeline-config/pipeline-sample-tpl.yml
@@ -42,7 +42,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: ((docker-image-repository))
             tag: ((docker-image-tag))
@@ -71,7 +71,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: ((docker-image-repository))
             tag: ((docker-image-tag))
@@ -94,7 +94,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: ((docker-image-repository))
             tag: ((docker-image-tag))

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/root-deployment.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/root-deployment.yml
@@ -2,7 +2,7 @@
 name: hello-world-root-depls
 
 stemcell:
-  version: "621.76" # Mandatory
+  version: "1.1" # Mandatory
   sha1: # Optional
 
 releases:

--- a/docs/reference_dataset/template_repository/shared-config.yml
+++ b/docs/reference_dataset/template_repository/shared-config.yml
@@ -14,7 +14,7 @@ default:
     # recreate: false # Optional. Recreate all VMs in deployment. Defaults to false.
     # skip_drain: # Optional. A collection of instance group names to skip running drain scripts for. Defaults to empty.
   stemcell:
-    name: 56  # Default: bosh-openstack-kvm-ubuntu-xenial-go_agent
+    name: 56  # Default: bosh-openstack-kvm-ubuntu-bionic-go_agent
   concourse:
     # You can limit job execution per pipeline, static jobs are not affected by this restriction. Only jobs that are
     #  added or removed are limited. You can defined the maximum number of jobs executed in parallel.

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -6,7 +6,7 @@ require_relative 'extended_config'
 # Manage configuration shared by root-deployments. A public config file can be overridden by a private config file and
 # an extended configuration (based on environment variables)
 class Config
-  DEFAULT_STEMCELL = 'bosh-openstack-kvm-ubuntu-xenial-go_agent'.freeze
+  DEFAULT_STEMCELL = 'bosh-openstack-kvm-ubuntu-bionic-go_agent'.freeze
   DEFAULT_PROFILES = [].freeze
   DEFAULT_STEMCELL_PREFIX = 'bosh'.freeze
   EMPTY_BOSH_OPTIONS = {}.freeze

--- a/spec/lib/coa/utils/bosh/client_spec.rb
+++ b/spec/lib/coa/utils/bosh/client_spec.rb
@@ -65,7 +65,7 @@ describe Coa::Utils::Bosh::Client do
     end
 
     context "when the stemcell is not uploaded" do
-      let(:command_response) { "bosh-warden-boshlite-ubuntu-xenial-go_agent	70.1*" }
+      let(:command_response) { "bosh-warden-boshlite-ubuntu-bionic-go_agent	70.1*" }
 
       it "returns true" do
         allow(command_runner).to receive(:execute).and_return(command_response)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -19,7 +19,7 @@ describe Config do
         'iaas' => 'my_custom_iaas',
         'profiles' => [],
         'stemcell' => {
-          'name' => 'bosh-openstack-kvm-ubuntu-xenial-go_agent'
+          'name' => 'bosh-openstack-kvm-ubuntu-bionic-go_agent'
         },
         'concourse' => {
           'parallel_execution_limit' => 5
@@ -55,7 +55,7 @@ describe Config do
           {
             'bosh-options' => { 'cleanup' => true, 'dry_run' => false, 'fix' => true, 'max_in_flight' => 10, 'no_redact' => false, 'recreate' => false, 'skip_drain' => [] },
             'concourse' => {'parallel_execution_limit' => 5 },
-            'iaas' => 'extended', 'profiles' => ['x-profile'], 'stemcell' => { 'name' => 'bosh-openstack-kvm-ubuntu-xenial-go_agent' }
+            'iaas' => 'extended', 'profiles' => ['x-profile'], 'stemcell' => { 'name' => 'bosh-openstack-kvm-ubuntu-bionic-go_agent' }
           },
           'offline-mode' => { 'boshreleases' => false, 'docker-images' => false, 'stemcells' => true },
           :private => true, :shared => true }

--- a/spec/lib/deployment_factory_spec.rb
+++ b/spec/lib/deployment_factory_spec.rb
@@ -410,7 +410,7 @@ describe DeploymentFactory do
       end
 
       it 'creates an enhanced deployment' do
-        expect(loaded_deployments.first).to have_attributes(name: deployment_name, details: include('stemcells' => { 'bosh-openstack-kvm-ubuntu-xenial-go_agent' => {} }))
+        expect(loaded_deployments.first).to have_attributes(name: deployment_name, details: include('stemcells' => { 'bosh-openstack-kvm-ubuntu-bionic-go_agent' => {} }))
       end
     end
   end

--- a/spec/lib/fixtures/root-deployment-overview-enhancer/expected-ops-depls.yml
+++ b/spec/lib/fixtures/root-deployment-overview-enhancer/expected-ops-depls.yml
@@ -31,7 +31,7 @@ guardian-uaa-prod:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -80,7 +80,7 @@ mongodb:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -112,7 +112,7 @@ kafka:
       base_location: https://github.com/
   errands:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -129,7 +129,7 @@ io-bench:
   errands:
     vm_to_benchmark:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -163,7 +163,7 @@ vault:
       repository: cloudfoundry-community/broker-registrar-boshrelease
       base_location: https://github.com/
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -213,7 +213,7 @@ cf-redis:
     deprecate-dedicated-vm-plan:
     cleanup-metadata-if-dedicated-disabled:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -285,7 +285,7 @@ cf-rabbit37:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -329,7 +329,7 @@ guardian-uaa:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -380,7 +380,7 @@ cf-redis-osb:
     deprecate-dedicated-vm-plan:
     cleanup-metadata-if-dedicated-disabled:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -438,7 +438,7 @@ cloudfoundry-mysql:
   manual-errands:
     bootstrap:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -464,7 +464,7 @@ nfs-volume:
       repository: cloudfoundry/routing-release
       base_location: https://github.com/
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -525,7 +525,7 @@ cloudfoundry-mysql-osb:
   manual-errands:
     bootstrap:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -568,7 +568,7 @@ cassandra:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -594,7 +594,7 @@ memcache:
       repository: cloudfoundry-community/memcache-release
       base_location: https://github.com/
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -636,7 +636,7 @@ postgresql-docker:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -663,7 +663,7 @@ concourse-dev:
       repository: cloudfoundry/postgres-release
       base_location: https://github.com/
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -700,7 +700,7 @@ neo4j-docker:
       repository: cloudfoundry-incubator/docker-boshrelease
       base_location: https://github.com/
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false

--- a/spec/lib/fixtures/root-deployment/ops-depls-overview.yml
+++ b/spec/lib/fixtures/root-deployment/ops-depls-overview.yml
@@ -30,7 +30,7 @@ guardian-uaa-prod:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -77,7 +77,7 @@ mongodb:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -109,7 +109,7 @@ kafka:
       version: 0.0.10
   errands:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -126,7 +126,7 @@ io-bench:
   errands:
     vm_to_benchmark:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -160,7 +160,7 @@ vault:
       repository: cloudfoundry-community/broker-registrar-boshrelease
       version: 3.4.0
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -210,7 +210,7 @@ cf-redis:
     deprecate-dedicated-vm-plan:
     cleanup-metadata-if-dedicated-disabled:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -282,7 +282,7 @@ cf-rabbit37:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -326,7 +326,7 @@ guardian-uaa:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -377,7 +377,7 @@ cf-redis-osb:
     deprecate-dedicated-vm-plan:
     cleanup-metadata-if-dedicated-disabled:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -435,7 +435,7 @@ cloudfoundry-mysql:
   manual-errands:
     bootstrap:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -461,7 +461,7 @@ nfs-volume:
       repository: cloudfoundry/routing-release
       version: 0.197.0
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -521,7 +521,7 @@ cloudfoundry-mysql-osb:
   manual-errands:
     bootstrap:
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -564,7 +564,7 @@ cassandra:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -590,7 +590,7 @@ memcache:
       repository: cloudfoundry-community/memcache-release
       version: 6.0.0
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -632,7 +632,7 @@ postgresql-docker:
     import:
       display-name: shield-provisioning
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -659,7 +659,7 @@ concourse-dev:
       repository: cloudfoundry/postgres-release
       version: '40'
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false
@@ -693,7 +693,7 @@ neo4j-docker:
       repository: cloudfoundry-incubator/docker-boshrelease
       version: 35.3.4
   stemcells:
-    bosh-openstack-kvm-ubuntu-xenial-go_agent: {}
+    bosh-openstack-kvm-ubuntu-bionic-go_agent: {}
   bosh-options:
     cleanup: true
     no_redact: false

--- a/spec/lib/fixtures/version-reference/default.yml
+++ b/spec/lib/fixtures/version-reference/default.yml
@@ -1,3 +1,3 @@
 stemcell:
-  name: bosh-openstack-kvm-ubuntu-xenial-go_agent
+  name: bosh-openstack-kvm-ubuntu-bionic-go_agent
   version: 12

--- a/spec/lib/pipeline_helpers_spec.rb
+++ b/spec/lib/pipeline_helpers_spec.rb
@@ -9,7 +9,7 @@ describe PipelineHelpers do
     let(:shield_overview) do
       deps_yaml = <<~YAML
         stemcells:
-        bosh-openstack-kvm-ubuntu-xenial-go_agent:
+        bosh-openstack-kvm-ubuntu-bionic-go_agent:
         releases:
           cf-routing-release:
             base_location: https://bosh.io/d/github.com/

--- a/spec/lib/tasks/bosh/list_deployments_spec.rb
+++ b/spec/lib/tasks/bosh/list_deployments_spec.rb
@@ -20,40 +20,40 @@ describe Tasks::Bosh::ListDeployments do
                   "Rows": [
                       { "name": "concourse",
                           "release_s": "bosh-dns/1.11.0\nbpm/1.1.5\nconcourse/5.3.0\ngeneric-scripting/2\nhaproxy/9.8.0\nminio/2019-06-27T21-13-50Z\nnode-exporter/4.2.0\nos-conf/21.0.0\npostgres/39\nprometheus/26.1.0\nrouting/0.195.0\nshield/8.5.0\nsyslog/11.6.0\nturbulence/0.10.0+dev.2",
-                          "stemcell_s": "bosh-openstack-kvm-ubuntu-xenial-go_agent/456.69",
+                          "stemcell_s": "bosh-openstack-kvm-ubuntu-bionic-go_agent/456.69",
                           "team_s": "" },
                       { "name": "credhub-ha",
                           "release_s": "bpm/1.1.5\ncredhub/2.5.6\nhaproxy/9.8.0\nnode-exporter/4.2.0\nos-conf/21.0.0\npostgres/39\nshield/7.0.2\nsyslog/11.6.0\nuaa/74.8.0",
-                          "stemcell_s": "bosh-openstack-kvm-ubuntu-xenial-go_agent/456.77",
+                          "stemcell_s": "bosh-openstack-kvm-ubuntu-bionic-go_agent/456.77",
                           "team_s": "" },
                       {
                           "name": "dns-recursor",
                           "release_s": "bosh-dns/1.11.0\nbpm/1.1.5\nnode-exporter/4.2.0\nntp/4.2.8p12\nos-conf/21.0.0\nsyslog/11.6.0",
-                          "stemcell_s": "bosh-openstack-kvm-ubuntu-xenial-go_agent/456.77",
+                          "stemcell_s": "bosh-openstack-kvm-ubuntu-bionic-go_agent/456.77",
                           "team_s": ""
                       },
                       {
                           "name": "docker-bosh-cli",
                           "release_s": "bosh-dns/1.11.0\nbpm/1.1.5\ncron/1.1.3\ndocker/35.3.4\ngeneric-scripting/2\nnode-exporter/4.2.0\nos-conf/21.0.0\nrouting/0.195.0\nsyslog/11.6.0\nweave-scope/0.0.18",
-                          "stemcell_s": "bosh-openstack-kvm-ubuntu-xenial-go_agent/456.77",
+                          "stemcell_s": "bosh-openstack-kvm-ubuntu-bionic-go_agent/456.77",
                           "team_s": ""
                       },
                       {
                           "name": "gitlab",
                           "release_s": "bosh-dns/1.11.0\nbpm/1.1.5\ndocker/35.3.4\ngeneric-scripting/2\nminio/2019-06-27T21-13-50Z\nnode-exporter/4.2.0\nos-conf/21.0.0\nrouting/0.195.0\nshield/8.5.0\nsyslog/11.6.0\nweave-scope/0.0.18",
-                          "stemcell_s": "bosh-openstack-kvm-ubuntu-xenial-go_agent/456.77",
+                          "stemcell_s": "bosh-openstack-kvm-ubuntu-bionic-go_agent/456.77",
                           "team_s": ""
                       },
                       {
                           "name": "minio-private-s3",
                           "release_s": "bosh-dns/1.11.0\nbpm/1.1.5\nhaproxy/9.8.0\nminio/2019-06-27T21-13-50Z\nnode-exporter/4.2.0\nos-conf/21.0.0\nrouting/0.195.0\nsyslog/11.6.0\nweave-scope/0.0.18",
-                          "stemcell_s": "bosh-openstack-kvm-ubuntu-xenial-go_agent/456.77",
+                          "stemcell_s": "bosh-openstack-kvm-ubuntu-bionic-go_agent/456.77",
                           "team_s": ""
                       },
                       {
                           "name": "prometheus-exporter-master",
                           "release_s": "bosh-dns/1.11.0\nbosh-dns-aliases/0.0.3\nbpm/1.1.5\nnode-exporter/4.2.0\nos-conf/21.0.0\nprometheus/26.1.0\nrouting/0.195.0\nsyslog/11.6.0\nweave-scope/0.0.18",
-                          "stemcell_s": "bosh-openstack-kvm-ubuntu-xenial-go_agent/456.77",
+                          "stemcell_s": "bosh-openstack-kvm-ubuntu-bionic-go_agent/456.77",
                           "team_s": ""
                       }
                   ],

--- a/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
@@ -30,7 +30,7 @@ describe 'BoshPipelineTemplateProcessing' do
         status: disabled
       shield-expe:
         stemcells:
-          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          bosh-openstack-kvm-ubuntu-bionic-go_agent:
         releases:
           cf-routing-release:
             base_location: https://bosh.io/d/github.com/
@@ -49,7 +49,7 @@ describe 'BoshPipelineTemplateProcessing' do
         status: enabled
       bui:
         stemcells:
-          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          bosh-openstack-kvm-ubuntu-bionic-go_agent:
         releases:
           route-registrar-boshrelease:
             base_location: https://bosh.io/d/github.com/
@@ -245,7 +245,7 @@ describe 'BoshPipelineTemplateProcessing' do
         shield_only = <<~YAML
           shield-expe:
             stemcells:
-              bosh-openstack-kvm-ubuntu-xenial-go_agent:
+              bosh-openstack-kvm-ubuntu-bionic-go_agent:
             releases:
               cf-routing-release:
                 base_location: https://bosh.io/d/github.com/
@@ -306,7 +306,7 @@ describe 'BoshPipelineTemplateProcessing' do
         shield_only = <<~YAML
           custom-shield:
             stemcells:
-              bosh-openstack-kvm-ubuntu-xenial-go_agent:
+              bosh-openstack-kvm-ubuntu-bionic-go_agent:
             releases:
               cf-routing-release:
                 base_location: https://bosh.io/d/github.com/
@@ -320,7 +320,7 @@ describe 'BoshPipelineTemplateProcessing' do
             status: enabled
           default-shield:
             stemcells:
-              bosh-openstack-kvm-ubuntu-xenial-go_agent:
+              bosh-openstack-kvm-ubuntu-bionic-go_agent:
             releases:
               cf-routing-release:
                 base_location: https://bosh.io/d/github.com/
@@ -380,7 +380,7 @@ describe 'BoshPipelineTemplateProcessing' do
         shield_only = <<~YAML
           shield-expe:
             stemcells:
-              bosh-openstack-kvm-ubuntu-xenial-go_agent:
+              bosh-openstack-kvm-ubuntu-bionic-go_agent:
             releases:
               cf-routing-release:
                 base_location: https://bosh.io/d/github.com/
@@ -908,7 +908,7 @@ describe 'BoshPipelineTemplateProcessing' do
       deps_yaml = <<~YAML
         shield-expe:
           stemcells:
-            bosh-openstack-kvm-ubuntu-xenial-go_agent:
+            bosh-openstack-kvm-ubuntu-bionic-go_agent:
           releases:
             cf-routing-release:
               base_location: https://bosh.io/d/github.com/
@@ -919,7 +919,7 @@ describe 'BoshPipelineTemplateProcessing' do
           status: enabled
         bui:
           stemcells:
-            bosh-openstack-kvm-ubuntu-xenial-go_agent:
+            bosh-openstack-kvm-ubuntu-bionic-go_agent:
           releases:
             cf-routing-release:
               base_location: https://bosh.io/d/github.com/

--- a/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
@@ -79,24 +79,24 @@ describe 'BoshPipelineTemplateProcessing' do
   let(:expected_resource_types) do
     resource_types_yaml = <<~YAML
       - name: slack-notification
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+          repository: cfcommunity/slack-notification-resource
           tag: v1.4.2
       - name: bosh-deployment-v2
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+          repository: cloudfoundry/bosh-deployment-resource
           tag: v2.12.0
       - name: bosh-errand
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cfcommunity/bosh2-errand-resource
+          repository: cfcommunity/bosh2-errand-resource
           tag: v0.1.2
       - name: meta
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))olhtbr/metadata-resource
+          repository: olhtbr/metadata-resource
           tag: 2.0.1
 
     YAML

--- a/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
@@ -89,14 +89,14 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
   let(:expected_resource_types) do
     resource_types_yaml = <<~YAML
       - name: slack-notification
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+          repository: cfcommunity/slack-notification-resource
           tag: v1.4.2
       - name: bosh-deployment-v2
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+          repository: cloudfoundry/bosh-deployment-resource
           tag: v2.12.0
     YAML
     YAML.safe_load(resource_types_yaml)

--- a/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
@@ -27,7 +27,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
       bosh-bats:
         status: disabled
         stemcells:
-          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          bosh-openstack-kvm-ubuntu-bionic-go_agent:
         bosh-deployment: {}
         releases:
           bosh:
@@ -38,7 +38,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
         status: disabled
       shield-expe:
         stemcells:
-          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          bosh-openstack-kvm-ubuntu-bionic-go_agent:
         releases:
           cf-routing-release:
             base_location: https://bosh.io/d/github.com/
@@ -57,7 +57,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
         status: enabled
       bui:
         stemcells:
-          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          bosh-openstack-kvm-ubuntu-bionic-go_agent:
         releases:
           route-registrar-boshrelease:
             base_location: https://bosh.io/d/github.com/
@@ -586,7 +586,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
       deps_yaml = <<~YAML
         shield-expe:
           stemcells:
-            bosh-openstack-kvm-ubuntu-xenial-go_agent:
+            bosh-openstack-kvm-ubuntu-bionic-go_agent:
           releases:
             cf-routing-release:
               base_location: https://bosh.io/d/github.com/
@@ -597,7 +597,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
           status: enabled
         bui:
           stemcells:
-            bosh-openstack-kvm-ubuntu-xenial-go_agent:
+            bosh-openstack-kvm-ubuntu-bionic-go_agent:
           releases:
             cf-routing-release:
               base_location: https://bosh.io/d/github.com/

--- a/spec/lib/template_processor/template_processor_for_cf_apps_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_cf_apps_pipeline_spec.rb
@@ -75,9 +75,9 @@ describe 'CfAppsPipelineTemplateProcessing' do
   let(:expected_resource_types) do
     resource_types_yaml = <<~YAML
       - name: slack-notification
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+          repository: cfcommunity/slack-notification-resource
           tag: v1.4.2
     YAML
     YAML.safe_load(resource_types_yaml)

--- a/spec/lib/template_processor/template_processor_for_concourse_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_concourse_pipeline_spec.rb
@@ -30,7 +30,7 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
           status: disabled
       shield-expe:
           stemcells:
-          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          bosh-openstack-kvm-ubuntu-bionic-go_agent:
           releases:
             cf-routing-release:
               base_location: https://bosh.io/d/github.com/
@@ -41,7 +41,7 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
           status: enabled
       bui:
           stemcells:
-          bosh-openstack-kvm-ubuntu-xenial-go_agent:
+          bosh-openstack-kvm-ubuntu-bionic-go_agent:
           releases:
             route-registrar-boshrelease:
               base_location: https://bosh.io/d/github.com/

--- a/spec/lib/template_processor/template_processor_for_concourse_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_concourse_pipeline_spec.rb
@@ -76,19 +76,19 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
   let(:expected_resource_types) do
     resource_types_yaml = <<~YAML
       - name: slack-notification
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+          repository: cfcommunity/slack-notification-resource
           tag: v1.4.2
       - name: concourse-5-pipeline
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+          repository: concourse/concourse-pipeline-resource
           tag: 5.0.0
       - name: concourse-pipeline
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))orangecloudfoundry/concourse-pipeline-resource
+          repository: orangecloudfoundry/concourse-pipeline-resource
           tag: 6.5.0
     YAML
     YAML.safe_load(resource_types_yaml)
@@ -444,9 +444,9 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
                   config:
                     platform: linux
                     image_resource:
-                      type: docker-image
+                      type: registry-image
                       source:
-                        repository: ((docker-registry-url))governmentpaas/git-ssh
+                        repository: governmentpaas/git-ssh
                         tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
                     outputs:
                       - name: success-tag
@@ -466,9 +466,9 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
                     config:
                       platform: linux
                       image_resource:
-                        type: docker-image
+                        type: registry-image
                         source:
-                          repository: ((docker-registry-url))governmentpaas/git-ssh
+                          repository: governmentpaas/git-ssh
                           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
                       outputs:
                         - name: success-tag

--- a/spec/lib/template_processor/template_processor_spec.rb
+++ b/spec/lib/template_processor/template_processor_spec.rb
@@ -108,7 +108,7 @@ describe TemplateProcessor do
             ---
             resource_types:
             - name: slack-notification
-              type: docker-image
+              type: registry-image
               source:
                 repository: cfcommunity/slack-notification-resource
             resources: []

--- a/spec/lib/template_processor/test_fixtures/resource_types_fixture.rb
+++ b/spec/lib/template_processor/test_fixtures/resource_types_fixture.rb
@@ -3,15 +3,15 @@ module Coa
     RESOURCE_TYPES = YAML.safe_load <<~YAML
       slack-notification:
         name: slack-notification
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+          repository: cfcommunity/slack-notification-resource
           tag: v1.4.2
       meta:
         name: meta
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))olhtbr/metadata-resource
+          repository: olhtbr/metadata-resource
           tag: 2.0.1
     YAML
   end

--- a/spec/pipelines/static_pipelines_spec.rb
+++ b/spec/pipelines/static_pipelines_spec.rb
@@ -45,11 +45,21 @@ describe 'static concourse pipelines spec' do
       expect(resource_types).not_to be_empty
     end
 
-    it 'ensures resource-type use custom docker registry' do
+    it 'ensures docker-image resource-type use custom docker registry' do
       invalid_resource_type = []
-      resource_types.each do |resource_type|
+      resource_types.select {|resource_type| resource_type.dig('type') == 'docker-image' }.each do |resource_type|
         docker_image_raw = resource_type['source']['repository'].to_s
         invalid_resource_type << docker_image_raw unless docker_image_raw.start_with?(DOCKER_REGISTRY_PREFIX)
+      end
+
+      expect(invalid_resource_type).to be_empty
+    end
+
+    it 'ensures registry-image resource-type does not override docker registry' do
+      invalid_resource_type = []
+      resource_types.select {|resource_type| resource_type.dig('type') == 'registry-image' }.each do |resource_type|
+        docker_image_raw = resource_type['source']['repository'].to_s
+        invalid_resource_type << docker_image_raw if docker_image_raw.start_with?(DOCKER_REGISTRY_PREFIX)
       end
 
       expect(invalid_resource_type).to be_empty

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -2,9 +2,9 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 - name: failure-alert
@@ -73,9 +73,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         outputs:
           - name: result-dir

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
@@ -2,24 +2,24 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 - name: bosh-errand
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/bosh2-errand-resource
+    repository: cfcommunity/bosh2-errand-resource
     tag: v0.1.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: concourse-meta
@@ -120,9 +120,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: repackaged-releases-fallback

--- a/spec/scripts/generate-depls/fixtures/references/empty-bosh-precompile.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-bosh-precompile.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 resources:
 jobs:

--- a/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
@@ -2,9 +2,9 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 jobs:

--- a/spec/scripts/generate-depls/fixtures/references/empty-concourse.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-concourse.yml
@@ -2,19 +2,19 @@
 ---
 resource_types:
   - name: concourse-5-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))concourse/concourse-pipeline-resource
+      repository: concourse/concourse-pipeline-resource
       tag: 5.0.0
   - name: concourse-pipeline
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))orangecloudfoundry/concourse-pipeline-resource
+      repository: orangecloudfoundry/concourse-pipeline-resource
       tag: 6.5.0
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
 resources:
 jobs:

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -2,24 +2,24 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 - name: bosh-errand
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/bosh2-errand-resource
+    repository: cfcommunity/bosh2-errand-resource
     tag: v0.1.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: concourse-meta
@@ -105,9 +105,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: repackaged-releases-fallback

--- a/spec/scripts/generate-depls/fixtures/references/empty-k8s.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-k8s.yml
@@ -1,14 +1,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: failure-alert

--- a/spec/scripts/generate-depls/fixtures/references/empty-news.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-news.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
       # use latest as no other recent tag available
 resources:
 jobs:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 resources:
   - name: failure-alert
@@ -157,9 +157,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))governmentpaas/curl-ssl
+              repository: governmentpaas/curl-ssl
               tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
           inputs:
             - name: repackaged-releases-fallback
@@ -248,9 +248,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -278,9 +278,9 @@ jobs:
           config:
             platform: linux
             image_resource:
-              type: docker-image
+              type: registry-image
               source:
-                repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+                repository: governmentpaas/bosh-cli-v2
                 tag: bca975d14888e2e587d6df3e2af7c45d94507454
             inputs:
               - name: releases-to-upload
@@ -310,9 +310,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -368,9 +368,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -398,9 +398,9 @@ jobs:
           config:
             platform: linux
             image_resource:
-              type: docker-image
+              type: registry-image
               source:
-                repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+                repository: governmentpaas/bosh-cli-v2
                 tag: bca975d14888e2e587d6df3e2af7c45d94507454
             inputs:
               - name: releases-to-upload
@@ -430,9 +430,9 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: ((docker-registry-url))orangecloudfoundry/bosh-cli-v2-cf-cli
+              repository: orangecloudfoundry/bosh-cli-v2-cf-cli
               tag: 10505f812181d02e8be344a943a28a8af24f9e01
           inputs:
             - name: stemcell
@@ -489,9 +489,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         outputs:
           - name: result-dir

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -2,24 +2,24 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: bosh-deployment-v2
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cloudfoundry/bosh-deployment-resource
+    repository: cloudfoundry/bosh-deployment-resource
     tag: v2.12.0
 - name: bosh-errand
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/bosh2-errand-resource
+    repository: cfcommunity/bosh2-errand-resource
     tag: v0.1.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: concourse-meta
@@ -194,9 +194,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: repackaged-releases-fallback
@@ -562,9 +562,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: final-release-manifest
@@ -772,9 +772,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       inputs:
         - name: final-release-manifest
@@ -908,9 +908,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir
@@ -977,9 +977,9 @@ jobs:
     config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+            repository: governmentpaas/bosh-cli-v2
             tag: bca975d14888e2e587d6df3e2af7c45d94507454
         inputs:
           - name: scripts-resource
@@ -1028,9 +1028,9 @@ jobs:
     config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/bosh-cli-v2
+            repository: governmentpaas/bosh-cli-v2
             tag: bca975d14888e2e587d6df3e2af7c45d94507454
         inputs:
           - name: scripts-resource
@@ -1077,9 +1077,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
@@ -1,14 +1,14 @@
 ---
 resource_types:
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+    repository: cfcommunity/slack-notification-resource
     tag: v1.4.2
 - name: meta
-  type: docker-image
+  type: registry-image
   source:
-    repository: ((docker-registry-url))olhtbr/metadata-resource
+    repository: olhtbr/metadata-resource
     tag: 2.0.1
 resources:
 - name: failure-alert
@@ -268,9 +268,9 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
-          repository: ((docker-registry-url))governmentpaas/curl-ssl
+          repository: governmentpaas/curl-ssl
           tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
       outputs:
         - name: result-dir

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
@@ -2,14 +2,14 @@
 ---
 resource_types:
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cfcommunity/slack-notification-resource
+      repository: cfcommunity/slack-notification-resource
       tag: v1.4.2
   - name: cron-resource
-    type: docker-image
+    type: registry-image
     source:
-      repository: ((docker-registry-url))cftoolsmiths/cron-resource
+      repository: cftoolsmiths/cron-resource
       # use latest as no other recent tag available
 resources:
 - name: failure-alert
@@ -91,9 +91,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: boshrelease
@@ -148,9 +148,9 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
-            repository: ((docker-registry-url))governmentpaas/curl-ssl
+            repository: governmentpaas/curl-ssl
             tag: 19d32c252e328a762f75417fcee7cab6dbac9e97
         inputs:
           - name: boshrelease

--- a/spec/scripts/generate-depls/fixtures/templates/simple-depls/concourse-deployer-sample/concourse-pipeline-config/concourse-deployer-sample.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/simple-depls/concourse-deployer-sample/concourse-pipeline-config/concourse-deployer-sample.yml
@@ -13,7 +13,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: alpine}
       run:
         path: echo

--- a/spec/tasks/all_tasks_spec.rb
+++ b/spec/tasks/all_tasks_spec.rb
@@ -25,7 +25,7 @@ describe 'all tasks' do
                          images[name] << task_filename
                        else
                          [task_filename]
-                        end
+                       end
       end
       images
     end
@@ -55,14 +55,26 @@ describe 'all tasks' do
       expect(docker_images_with_task.keys).to match_array(expected_task_images)
     end
 
-    it 'ensures image resource use custom docker registry' do
+    it 'ensures docker-image based resource use custom docker registry' do
       invalid_tasks = {}
       tasks.each do |task_filename|
         task = YAML.load_file task_filename
         docker_image = task.dig('image_resource', 'source', 'repository').to_s
-        next if docker_image.empty?
+        next if docker_image.empty? || task.dig('image_resource', 'type') != 'docker-image'
 
         invalid_tasks[task_filename] = docker_image unless docker_image.start_with?(DOCKER_REGISTRY_PREFIX)
+      end
+      expect(invalid_tasks).to be_empty
+    end
+
+    it 'ensures registry-image based resource use custom docker registry' do
+      invalid_tasks = {}
+      tasks.each do |task_filename|
+        task = YAML.load_file task_filename
+        docker_image = task.dig('image_resource', 'source', 'repository').to_s
+        next if docker_image.empty? || task.dig('image_resource','type') != 'registry-image'
+
+        invalid_tasks[task_filename] = docker_image if docker_image.start_with?(DOCKER_REGISTRY_PREFIX)
       end
       expect(invalid_tasks).to be_empty
     end

--- a/spec/tasks/resolve_manifest_versions/resolve_manifest_urls_spec.rb
+++ b/spec/tasks/resolve_manifest_versions/resolve_manifest_urls_spec.rb
@@ -78,7 +78,7 @@ describe ResolveManifestUrls do
       YAML
       YAML.safe_load(yaml_content)
     end
-    let(:stemcell_name) { "my-stemcell-ubuntu-xenial-go_agent" }
+    let(:stemcell_name) { "my-stemcell-ubuntu-bionic-go_agent" }
 
     context "when valid versions in online mode and manifest are provided" do
       let(:download_server_url) { 'https://bosh.io/d/github.com' }

--- a/spec/tasks/resolve_manifest_versions/resolve_manifest_versions_spec.rb
+++ b/spec/tasks/resolve_manifest_versions/resolve_manifest_versions_spec.rb
@@ -19,7 +19,7 @@ describe ResolveManifestVersions do
         version: latest
       stemcells:
       - alias: default
-        os: ubuntu-xenial
+        os: ubuntu-bionic
         version: latest
       update:
         canaries: 1
@@ -58,7 +58,7 @@ describe ResolveManifestVersions do
       YAML
       YAML.safe_load(yaml_content)
     end
-    let(:stemcell_name) { "my-stemcell-ubuntu-xenial-go_agent" }
+    let(:stemcell_name) { "my-stemcell-ubuntu-bionic-go_agent" }
 
     context "when no stemcell version is defined" do
       let(:versions) do
@@ -73,8 +73,7 @@ describe ResolveManifestVersions do
       end
 
       it "raises an error" do
-
-        expect{run_process}.to raise_error(RuntimeError, "Missing version for stemcell my-stemcell-ubuntu-xenial-go_agent. Please fix 'root-deployment.yml' or this manifest")
+        expect { run_process }.to raise_error(RuntimeError, "Missing version for stemcell my-stemcell-ubuntu-bionic-go_agent. Please fix 'root-deployment.yml' or this manifest")
       end
     end
 
@@ -89,7 +88,7 @@ describe ResolveManifestVersions do
               version: "1.5.9"
           stemcells:
             - alias: default
-              os: ubuntu-xenial
+              os: ubuntu-bionic
               version: "621.76"
           update:
             canaries: 1
@@ -118,7 +117,7 @@ describe ResolveManifestVersions do
             version: 0.2
           stemcells:
           - alias: default
-            os: ubuntu-xenial
+            os: ubuntu-bionic
             version: 0.3
           update:
             canaries: 1
@@ -139,7 +138,7 @@ describe ResolveManifestVersions do
               version: "1.5.9"
           stemcells:
             - alias: default
-              os: ubuntu-xenial
+              os: ubuntu-bionic
               version: 0.3
           update:
             canaries: 1
@@ -169,7 +168,7 @@ describe ResolveManifestVersions do
             version: 0.2
           stemcells:
           - alias: default
-            os: ubuntu-xenial
+            os: ubuntu-bionic
             version: 0.3
           update:
             canaries: 1
@@ -190,7 +189,7 @@ describe ResolveManifestVersions do
               version: 0.2
           stemcells:
             - alias: default
-              os: ubuntu-xenial
+              os: ubuntu-bionic
               version: 0.3
           update:
             canaries: 1
@@ -232,7 +231,7 @@ describe ResolveManifestVersions do
               version: latest
           stemcells:
             - alias: default
-              os: ubuntu-xenial
+              os: ubuntu-bionic
               version: latest
           update:
             canaries: 1
@@ -265,10 +264,10 @@ describe ResolveManifestVersions do
             version: latest
           stemcells:
           - alias: default
-            os: ubuntu-xenial
+            os: ubuntu-bionic
             version: latest
           - alias: openstack-hws
-            name: bosh-openstack-kvm-ubuntu-xenial-go_agent
+            name: bosh-openstack-kvm-ubuntu-bionic-go_agent
             version: latest
           update:
             canaries: 1
@@ -293,10 +292,10 @@ describe ResolveManifestVersions do
               version: 33.3.3
           stemcells:
             - alias: default
-              os: ubuntu-xenial
+              os: ubuntu-bionic
               version: '621.76'
             - alias: openstack-hws
-              name: bosh-openstack-kvm-ubuntu-xenial-go_agent
+              name: bosh-openstack-kvm-ubuntu-bionic-go_agent
               version: '621.76'
           update:
             canaries: 1
@@ -325,13 +324,13 @@ describe ResolveManifestVersions do
             version: latest
           stemcells:
           - alias: default
-            os: ubuntu-xenial
-            version: latest
-          - alias: default-bionic
             os: ubuntu-bionic
             version: latest
+          - alias: default-xenial
+            os: ubuntu-xenial
+            version: latest
           - alias: openstack-hws
-            name: bosh-openstack-kvm-ubuntu-xenial-go_agent
+            name: bosh-openstack-kvm-ubuntu-bionic-go_agent
             version: latest
           update:
             canaries: 1
@@ -349,13 +348,13 @@ describe ResolveManifestVersions do
               version: 1.5.9
           stemcells:
             - alias: default
-              os: ubuntu-xenial
-              version: '621.76'
-            - alias: default-bionic
               os: ubuntu-bionic
+              version: '621.76'
+            - alias: default-xenial
+              os: ubuntu-xenial
               version: 'latest'
             - alias: openstack-hws
-              name: bosh-openstack-kvm-ubuntu-xenial-go_agent
+              name: bosh-openstack-kvm-ubuntu-bionic-go_agent
               version: '621.76'
           update:
             canaries: 1


### PR DESCRIPTION
We replace 'docker-image' by 'registry-image' to leverage concourse default docker registry feature.
Next step would be to remove ((docker-registry-url)) reference.