### PR TITLE
feature(configure-concourse-retry): enhance concourse retry management

### DIFF
--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -44,6 +44,7 @@
 
   enabled_parallel_execution_limit = configurer.parallel_execution_limit.overridden?
   git_shallow_clone_depth = configurer.git_shallow_clone_depth.get
+  concourse_retry = configurer.concourse_retry
 
   current_team = CiDeployment.team(all_ci_deployments, root_deployment_name, "#{root_deployment_name}-bosh-generated")
 %>
@@ -388,19 +389,19 @@ jobs:
   plan:
     - in_parallel:
       - get: cf-ops-automation
-        attempts: 2
+        attempts: <%= concourse_retry[:pull] %>
         params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
         trigger: true
       - get : secrets-<%= root_deployment_name %>-limited
-        attempts: 2
+        attempts: <%= concourse_retry[:pull] %>
         params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
         trigger: true
       - get: paas-templates-<%= root_deployment_name %>
-        attempts: 2
+        attempts: <%= concourse_retry[:pull] %>
         params: { submodules: none }
         trigger: true
     - task: s3-upload-stemcells
-      attempts: 2
+      attempts: <%= concourse_retry[:task] %>
       input_mapping: { templates-resource: paas-templates-<%= root_deployment_name %> }
       file:  cf-ops-automation/concourse/tasks/s3_stemcells_upload/task.yml
       params:
@@ -423,22 +424,22 @@ jobs:
   plan:
     - in_parallel:
         - get: cf-ops-automation
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
           params: { submodules: none }
           trigger: true
         - get : secrets-<%= root_deployment_name %>-limited
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
           params: { submodules: none }
         - get: ((stemcell-main-name))
           trigger: true
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
     <% if !offline_stemcells_enabled || !precompile_pipeline_enabled %>
         - get: paas-templates-<%= root_deployment_name %>
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
           params: { submodules: none }
           trigger: true
     - task: download-stemcell
-      attempts: 2
+      attempts: <%= concourse_retry[:task] %>
       input_mapping: { templates-resource: paas-templates-<%= root_deployment_name %> }
       output_mapping: { stemcell: ((stemcell-main-name)) }
       file:  cf-ops-automation/concourse/tasks/download_stemcell/task.yml
@@ -450,7 +451,7 @@ jobs:
     <% end %>
 
     - task: upload-to-director
-      attempts: 2
+      attempts: <%= concourse_retry[:task] %>
       input_mapping: { stemcell: ((stemcell-main-name)), config-resource: secrets-<%= root_deployment_name %>-limited }
       file:  cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml
       params:
@@ -595,7 +596,7 @@ jobs:
 
     - in_parallel:
       - task: update-cloud-config-for-<%= root_deployment_name %>
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-<%= root_deployment_name %>-limited}
         output_mapping: {deployed-config: deployed-cloud-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -634,7 +635,7 @@ jobs:
               rebase: true
 
       - task: update-runtime-config-for-<%= root_deployment_name %>
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-<%= root_deployment_name %>-limited}
         output_mapping: {deployed-config: deployed-runtime-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -673,7 +674,7 @@ jobs:
               rebase: true
 
       - task: update-cpi-config-for-<%= root_deployment_name %>
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-<%= root_deployment_name %>-limited}
         output_mapping: {deployed-config: deployed-cpi-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -730,7 +731,7 @@ jobs:
       trigger: true
       params:
         <%= "tarball: false" unless offline_stemcells_enabled %>
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
     - get: cf-ops-automation
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
       trigger: true
@@ -739,7 +740,7 @@ jobs:
       trigger: true
       params:
         <%= "tarball: false" unless offline_boshreleases_enabled %>
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
   <% end %>
   <% if deployment_details.local_deployment_secrets_scan? %>
     - get: secrets-<%= name %>
@@ -876,7 +877,7 @@ jobs:
       OFFLINE_MODE_ENABLED: <%= offline_boshreleases_enabled %>
       PRECOMPILE_MODE_ENABLED: <%= precompile_pipeline_enabled %>
   - put: <%= name %>-deployment
-    attempts: 2
+    attempts: <%= concourse_retry[:bosh_push] %>
     on_failure:
       do:
         - task: update-<%= name %>-files
@@ -932,7 +933,7 @@ jobs:
       PROFILES: ((profiles))
       COMMIT_MESSAGE: "<%= name %> generated manifest auto update.\nDeployment information: $(cat additional-resource/deployment_information.txt)\nActive profiles: ${PROFILES}\n[skip ci]"
   - put: secrets-full-writer
-    attempts: 2
+    attempts: <%= concourse_retry[:push] %>
     get_params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
     params:
       repository: updated-<%= name %>-secrets
@@ -1037,14 +1038,14 @@ jobs:
   - in_parallel:
     - get: cf-ops-automation
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
 #      trigger: true
     - get: secrets-<%= root_deployment_name %>-trigger
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
     - get: paas-templates-<%= root_deployment_name %>-versions
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
       trigger: true
   - task: generate-<%= root_deployment_name %>-flight-plan
     output_mapping: {result-dir: init-<%= root_deployment_name %>-plan}

--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -31,6 +31,7 @@
 
   pipeline_options = PipelineHelpers::PipelineConfigurerOptions.new.with_config(config).with_root_deployment(root_deployment_name).build
   configurer = PipelineHelpers::PipelineConfigurer.new(pipeline_options)
+  concourse_retry = configurer.concourse_retry
 
   current_team = CiDeployment.team(all_ci_deployments, root_deployment_name, "#{root_deployment_name}-bosh-precompile-generated") || root_deployment_name
 
@@ -258,7 +259,7 @@ jobs:
       <% end %>
       - task: upload-to-director
         # this is required to manage runtime config bosh release upload
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: { releases-to-upload: repackaged-releases-fallback, config-resource: secrets-full-writer }
         file:  cf-ops-automation/concourse/tasks/bosh_upload_releases/task.yml
         params:
@@ -318,7 +319,7 @@ jobs:
             params: { submodules: none }
             trigger: true
       - task: upload-stemcells
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: { templates-resource: paas-templates-<%= root_deployment_name %>-limited }
         file:  cf-ops-automation/concourse/tasks/s3_stemcells_upload/task.yml
         params:
@@ -347,13 +348,13 @@ jobs:
             params: { submodules: none }
           - get: ((stemcell-main-name))
             trigger: true
-            attempts: 2
+            attempts: <%= concourse_retry[:pull] %>
     <% unless offline_stemcells_enabled %>
           - get: paas-templates-<%= root_deployment_name %>-limited
             params: { submodules: none }
             trigger: true
       - task: download-stemcell
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: { templates-resource: paas-templates-<%= root_deployment_name %>-limited }
         output_mapping: { stemcell: ((stemcell-main-name)) }
         file:  cf-ops-automation/concourse/tasks/download_stemcell/task.yml
@@ -364,7 +365,7 @@ jobs:
           STEMCELL_BASE_LOCATION: https://bosh.io/d/stemcells
     <% end %>
       - task: upload-to-director
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: { stemcell: ((stemcell-main-name)), config-resource: secrets-full-writer }
         file:  cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml
         params:
@@ -385,13 +386,13 @@ jobs:
       - in_parallel:
           - get: <%= release %>
             trigger: true
-            attempts: 2
+            attempts: <%= concourse_retry[:pull] %>
           - get: secrets-full-writer
             params: { submodules: none}
           - get: ((stemcell-main-name))
             passed: [ upload-stemcell-to-director ]
             trigger: true
-            attempts: 2
+            attempts: <%= concourse_retry[:pull] %>
       - task: generate-<%= release %>-deployment-manifest
         <%
         manifest = {'name' => "#{release}-deployment", 'instance_groups' => [], 'update' => { 'canaries' => 1, 'max_in_flight' => 1, 'canary_watch_time' => '1000-90000', 'update_watch_time' => '1000-90000' }, 'releases' => [] }
@@ -430,7 +431,7 @@ jobs:
       - try:
           # this step may fail when boshrelease have been already uploaded to director with another sha1. Indeed, everytime we repackage a bosh release a new sha1 is produced
           task: upload-to-director
-          attempts: 2
+          attempts: <%= concourse_retry[:task] %>
           input_mapping: { releases-to-upload: <%= release %>, config-resource: secrets-full-writer }
           config:
             platform: linux
@@ -456,13 +457,13 @@ jobs:
             BOSH_CA_CERT: config-resource/<%= PipelineGenerator::BOSH_CERT_LOCATIONS[root_deployment_name] %>
 
       - put: <%= release %>-deployment
-        attempts: 2
+        attempts: <%= concourse_retry[:bosh_push] %>
         params:
           manifest: final-release-manifest/<%= release %>-deployment.yml
           cleanup: true
 
       - task: compile-and-export-<%= release %>
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: {secrets: secrets-full-writer, stemcell: ((stemcell-main-name))}
         output_mapping: {exported-release: <%= release %>-exported-release}
         config:
@@ -497,7 +498,7 @@ jobs:
             RELEASE_VERSION: ((releases.<%= release %>.version))
     <% if offline_boshreleases_enabled %>
       - task: generate-<%= release %>-name
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: {release: <%= release %>-exported-release, stemcell: ((stemcell-main-name))}
         output_mapping: {result-dir: compiled-<%= release %>}
         config:
@@ -526,7 +527,7 @@ jobs:
 
                 cp release/*.tgz result-dir/"${RELEASE_NAME}-${RELEASE_VERSION}-${STEMCELL_OS}-${STEMCELL_VERSION}.tgz"
       - put: compiled-<%= release %>
-        attempts: 2
+        attempts: <%= concourse_retry[:push] %>
         params:
           file: compiled-<%= release %>/*.tgz
           acl: public-read
@@ -550,16 +551,16 @@ jobs:
       - in_parallel:
         - get: cf-ops-automation
           params: { submodules: none}
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
           #trigger: true
         - get: secrets-full-writer
           params: { submodules: none}
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
         - get: compiled-<%= release %>
           trigger: true
         - get: ((stemcell-main-name))
       - task: upload-<%= release %>
-        attempts: 2
+        attempts: <%= concourse_retry[:task] %>
         input_mapping: {secrets: secrets-full-writer, compiled-release: compiled-<%= release %>}
         config:
           platform: linux
@@ -594,14 +595,14 @@ jobs:
     - in_parallel:
         - get: cf-ops-automation
           params: { submodules: none}
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
           #trigger: true
         - get: secrets-<%= root_deployment_name %>-trigger
           params: { submodules: none}
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
         - get: paas-templates-<%= root_deployment_name %>-versions
           params: { submodules: none}
-          attempts: 2
+          attempts: <%= concourse_retry[:pull] %>
           trigger: true
     - task: generate-<%= root_deployment_name %>-flight-plan
       output_mapping: {result-dir: init-<%= root_deployment_name %>-plan}

--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -6,6 +6,7 @@
 
   enabled_parallel_execution_limit = configurer.parallel_execution_limit.overridden?
   git_shallow_clone_depth = configurer.git_shallow_clone_depth.get
+  concourse_retry = configurer.concourse_retry
 
   current_team = CiDeployment.team(all_ci_deployments, depls, "#{depls}-cf-apps-generated")
 %>
@@ -167,7 +168,7 @@ jobs:
             ./additional-resource/meta-inf.yml
         CUSTOM_SCRIPT_DIR: additional-resource/<%= cf_app_info["base-dir"] %>/template
     - task: push-<%= app_name %>
-      attempts: 2
+      attempts: <%= concourse_retry[:push] %>
       input_mapping: {scripts-resource: cf-ops-automation, templates-resource: paas-template-<%= app_name %>, credentials-resource: secrets-<%= app_name %>, additional-resource: release-manifest}
       output_mapping: {generated-files: final-release-manifest}
       file: cf-ops-automation/concourse/tasks/cf_push.yml

--- a/concourse/pipelines/template/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/template/concourse-pipeline.yml.erb
@@ -6,6 +6,7 @@
 
   enabled_parallel_execution_limit = configurer.parallel_execution_limit.overridden?
   git_shallow_clone_depth = configurer.git_shallow_clone_depth.get
+  concourse_retry = configurer.concourse_retry
 %>
 ---
 resource_types:
@@ -136,15 +137,15 @@ jobs:
     - get: paas-templates-<%= name %>
       <% current_git_submodule = git_submodules[depls][name] if git_submodules[depls] %>
       params: { submodules: <%= current_git_submodule || 'none' %>, depth: <%= current_git_submodule ? 0 : git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
       trigger: true
     - get: secrets-<%= name %>
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
       trigger: true
     - get: cf-ops-automation
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
       trigger: false
 
   - task: spruce-processing-<%= name %>

--- a/concourse/pipelines/template/k8s-pipeline.yml.erb
+++ b/concourse/pipelines/template/k8s-pipeline.yml.erb
@@ -28,6 +28,7 @@
 
   enabled_parallel_execution_limit = configurer.parallel_execution_limit.overridden?
   git_shallow_clone_depth = configurer.git_shallow_clone_depth.get
+  concourse_retry = configurer.concourse_retry
 
   current_team = CiDeployment.team(all_ci_deployments, root_deployment_name, "#{root_deployment_name}-k8s-generated")
 %>
@@ -223,7 +224,7 @@ jobs:
         FILE_EXECUTION_FILTER: "deploy*.sh"
 
     - put: k8s-configs-repository
-      attempts: 2
+      attempts: <%= concourse_retry[:push] %>
       get_params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
       params:
         repository: updated-k8s-repo
@@ -341,7 +342,7 @@ jobs:
       IAAS_TYPE: ((iaas-type))
       PROFILES: ((profiles))
   - put: k8s-configs-repository
-    attempts: 2
+    attempts: <%= concourse_retry[:push] %>
     get_params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
     params:
       repository: updated-k8s-repo

--- a/concourse/pipelines/template/news-pipeline.yml.erb
+++ b/concourse/pipelines/template/news-pipeline.yml.erb
@@ -21,6 +21,7 @@
 
   enabled_parallel_execution_limit = configurer.parallel_execution_limit.overridden?
   git_shallow_clone_depth = configurer.git_shallow_clone_depth.get
+  concourse_retry = configurer.concourse_retry
 %>
 ---
 resource_types:
@@ -115,7 +116,7 @@ jobs:
       - get: monday
         trigger: true
       - get: <%= release %>
-        attempts: 2
+        attempts: <%= concourse_retry[:pull] %>
         params: {tarball: false}
       - get: paas-templates-full
         params: { submodules: none, depth: <%= git_shallow_clone_depth %> }

--- a/concourse/pipelines/template/tf-pipeline.yml.erb
+++ b/concourse/pipelines/template/tf-pipeline.yml.erb
@@ -5,6 +5,7 @@
   configurer = PipelineHelpers::PipelineConfigurer.new(pipeline_options)
 
   git_shallow_clone_depth = configurer.git_shallow_clone_depth.get
+  concourse_retry = configurer.concourse_retry
 %>
 ---
 resource_types:

--- a/concourse/pipelines/template/update-pipeline.yml.erb
+++ b/concourse/pipelines/template/update-pipeline.yml.erb
@@ -5,6 +5,7 @@
   configurer = PipelineHelpers::PipelineConfigurer.new(pipeline_options)
 
   git_shallow_clone_depth = configurer.git_shallow_clone_depth.get
+  concourse_retry = configurer.concourse_retry
 %>
 ---
 resource_types:
@@ -87,15 +88,15 @@ jobs:
     - put: concourse-meta
     - get: paas-templates-<%= depls %>
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
       trigger: true
     - get: secrets-<%= depls %>-for-pipeline
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
       trigger: true
     - get: cf-ops-automation
       params: { submodules: none, depth: <%= git_shallow_clone_depth %> }
-      attempts: 2
+      attempts: <%= concourse_retry[:pull] %>
       trigger: true
 
   - task: generate-<%= depls %>-pipelines
@@ -172,7 +173,7 @@ jobs:
       COMMIT_MESSAGE: "Generated pipelines update for <%= depls %>"
       OLD_DIR: "coa/pipelines/generated"
   - put: secrets-writer
-    attempts: 2
+    attempts: <%= concourse_retry[:push] %>
     params:
       repository: generated-pipelines
       rebase: true

--- a/docs/reference_dataset/template_repository/shared-config.yml
+++ b/docs/reference_dataset/template_repository/shared-config.yml
@@ -5,10 +5,15 @@ offline-mode:
    stemcells: false # Choose where stemcells are downloaded from. Default: true
 
 default:
+  #retry: # Configure how to handle retries in various context
+    # task: 2 # Optional. You may override number of retry when running concourse tasks (except put, get and bosh deploy)
+    # pull: 2 # Optional. You may override number of retry when getting data from external system like git, s3, etc...
+    # push: 2 # Optional. You may override number of retry when sending data to external system like git, s3, etc...
+    # bosh-push: 2 # Optional. You may override number of retry when sending data to bosh
   #bosh-options: # Optional. You may override bosh deploy default options for all deployments. To customize only a specific deployment, see 'deployment-dependencies.yml'
     # cleanup: true # Optional. An boolean that specifies if a bosh cleanup should be run after deployment. Defaults to true.
     # no_redact: false # Optional. Removes redacted from Bosh output. Defaults to false.
-    # dry_run: false # Optional. Shows the deployment diff without running a deploy. Defaults to false.
+    # dry_run: false # Optional. Shows the deployment diff without running a bosh deploy. Defaults to false.
     # fix: false # Optional. Recreate an instance with an unresponsive agent instead of erroring. Defaults to false.
     # max_in_flight: # Optional. A number of max in flight option. Default: unset, use bosh max in flight
     # recreate: false # Optional. Recreate all VMs in deployment. Defaults to false.
@@ -17,11 +22,11 @@ default:
     name: 56  # Default: bosh-openstack-kvm-ubuntu-bionic-go_agent
   concourse:
     # You can limit job execution per pipeline, static jobs are not affected by this restriction. Only jobs that are
-    #  added or removed are limited. You can defined the maximum number of jobs executed in parallel.
+    #  added or removed are limited. You can define the maximum number of jobs executed in parallel.
     parallel_execution_limit: 5 # Default: -1, ie unlimited
     # when parallel execution limit is active, you can choose the placement strategy used to group jobs.
     #   - SerialGroupRoundRobinNamingStrategy: each job is dispatched to a dedicated pool using round-robin strategy. We
-    #           have a non deterministic allocation, but good repartition.
+    #           have a non-deterministic allocation, but good repartition.
     #   - SerialGroupMd5NamingStrategy: each job is dispatched to a dedicated pool using md5 hash and some computation.
     #           we have a deterministic allocation, but repartition cannot be guarantied. Recommended for on-demand services
     serial_group_naming_strategy: SerialGroupRoundRobinNamingStrategy #Default: SerialGroupRoundRobinNamingStrategy
@@ -29,6 +34,11 @@ default:
     # shallow-clone-depth: 1 # Default: 0, ie disabled
 
 #<root-deployment-name>: # override per root-deployment
+#  retry:
+#    task: 1 # Default: 2
+#    pull: 3 # Default: 2
+#    push: 4 # Default: 2
+#    bosh-push: 5 # Default: 2
 #  stemcell:
 #    name: my-region-stemcell # Can be useful with multiple regions
 #  git:

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -18,6 +18,17 @@ class Config
   DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT = 5
   CONFIG_GIT_KEY = 'git'.freeze
   CONFIG_SHALLOW_CLONE_DEPTH_KEY = 'shallow-clone-depth'.freeze
+  CONFIG_RETRY_KEY = 'retry'.freeze
+  CONFIG_PULL_KEY = 'pull'.freeze
+  CONFIG_TASK_KEY = 'task'.freeze
+  DEFAULT_CONFIG_RETRY_TASK_LIMIT = 2
+  DEFAULT_CONFIG_RETRY_PULL_LIMIT = 2
+  DEFAULT_CONFIG_RETRY_PUSH_LIMIT = 2
+  DEFAULT_CONFIG_RETRY_BOSH_PUSH_LIMIT = DEFAULT_CONFIG_RETRY_PUSH_LIMIT
+  CONFIG_PUSH_KEY = 'push'.freeze
+  CONFIG_BOSH_PUSH_KEY = 'bosh-push'.freeze
+  DEFAULT_RETRY = { CONFIG_TASK_KEY => DEFAULT_CONFIG_RETRY_TASK_LIMIT,CONFIG_PULL_KEY => DEFAULT_CONFIG_RETRY_PULL_LIMIT, CONFIG_PUSH_KEY => DEFAULT_CONFIG_RETRY_PUSH_LIMIT, CONFIG_BOSH_PUSH_KEY => DEFAULT_CONFIG_RETRY_BOSH_PUSH_LIMIT }
+
   attr_reader :loaded_config
 
   def initialize(public_yaml_location = '', private_yaml_location = '', extended_config = ExtendedConfigBuilder.new.build)
@@ -39,7 +50,8 @@ class Config
         CONFIG_CONCOURSE_KEY => { CONFIG_PARALLEL_EXECUTION_LIMIT_KEY => DEFAULT_CONFIG_PARALLEL_EXECUTION_LIMIT },
         CONFIG_BOSH_OPTIONS_KEY => {
           'cleanup' => true, 'no_redact' => false, 'dry_run' => false, 'fix' => false, 'recreate' => false, 'max_in_flight' => nil, 'skip_drain' => []
-        }
+        },
+        CONFIG_RETRY_KEY => DEFAULT_RETRY
       }
     }.deep_merge(@extended_config.default_format)
   end

--- a/lib/pipeline_helpers.rb
+++ b/lib/pipeline_helpers.rb
@@ -4,6 +4,7 @@ module PipelineHelpers
   require_relative './pipeline_helpers/configured_git_shallow_clone_depth'
   require_relative './pipeline_helpers/configured_parallel_execution_limit'
   require_relative './pipeline_helpers/configured_serial_group_naming_strategy'
+  require_relative './pipeline_helpers/configured_concourse_retry'
   require_relative './pipeline_helpers/deployment_details'
   require_relative './pipeline_helpers/pipeline_configurer'
   require_relative './pipeline_helpers/serial_group_naming_strategy'

--- a/lib/pipeline_helpers/configured_concourse_retry.rb
+++ b/lib/pipeline_helpers/configured_concourse_retry.rb
@@ -1,0 +1,45 @@
+module PipelineHelpers
+  # this class looks for retry config on bosh pull
+  class ConfiguredRetryPull < ConfigGetter
+    def default_value
+      Config::DEFAULT_CONFIG_RETRY_PULL_LIMIT
+    end
+
+    def extract(root_level_name)
+      config.dig(root_level_name, Config::CONFIG_RETRY_KEY, Config::CONFIG_PULL_KEY)
+    end
+  end
+
+  # this class looks for retry config on push
+  class ConfiguredRetryPush < ConfigGetter
+    def default_value
+      Config::DEFAULT_CONFIG_RETRY_PUSH_LIMIT
+    end
+
+    def extract(root_level_name)
+      config.dig(root_level_name, Config::CONFIG_RETRY_KEY, Config::CONFIG_PUSH_KEY)
+    end
+  end
+
+  # this class looks for retry config on bosh push
+  class ConfiguredRetryBoshPush < ConfigGetter
+    def default_value
+      Config::DEFAULT_CONFIG_RETRY_BOSH_PUSH_LIMIT
+    end
+
+    def extract(root_level_name)
+      config.dig(root_level_name, Config::CONFIG_RETRY_KEY, Config::CONFIG_BOSH_PUSH_KEY)
+    end
+  end
+
+  # this class looks for retry config on tasks
+  class ConfiguredRetryTask < ConfigGetter
+    def default_value
+      Config::DEFAULT_CONFIG_RETRY_TASK_LIMIT
+    end
+
+    def extract(root_level_name)
+      config.dig(root_level_name, Config::CONFIG_RETRY_KEY, Config::CONFIG_TASK_KEY)
+    end
+  end
+end

--- a/lib/pipeline_helpers/configured_git_shallow_clone_depth.rb
+++ b/lib/pipeline_helpers/configured_git_shallow_clone_depth.rb
@@ -1,5 +1,5 @@
 module PipelineHelpers
-  # this class looks for ParallelExecutionLimit
+  # this class looks for GitShallowCloneDepth
   class ConfiguredGitShallowCloneDepth < ConfigGetter
     NO_SHALLOW_CLONE = 0
     def default_value

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -21,6 +21,12 @@ describe Config do
         'stemcell' => {
           'name' => 'bosh-openstack-kvm-ubuntu-bionic-go_agent'
         },
+        'retry' => {
+          'task' => 2,
+          'bosh-push' => 2,
+          'pull' => 2,
+          'push' => 2
+        },
         'concourse' => {
           'parallel_execution_limit' => 5
         }
@@ -48,14 +54,15 @@ describe Config do
 
       let(:shared_config_result) { { 'default' => { 'iaas' => 'shared', 'profiles' => %w[shared-profile], 'bosh-options' => { 'fix' => true } }, shared: true } }
       let(:private_config_result) { { 'default' => { 'iaas' => 'private', 'profiles' => %w[private-profile], 'bosh-options' => { 'max_in_flight' => 10 } }, private: true } }
-      let(:extended_config_result) { { 'default' => { 'iaas' => 'extended', 'profiles' => %w[x-profile] } } }
+      let(:extended_config_result) { { 'default' => { 'iaas' => 'extended', 'profiles' => %w[x-profile], 'retry' => { 'bosh-push' => 1 } } } }
       let(:extended_config) { instance_double(ExtendedConfig) }
       let(:expected_loaded_config) do
         { 'default' =>
           {
             'bosh-options' => { 'cleanup' => true, 'dry_run' => false, 'fix' => true, 'max_in_flight' => 10, 'no_redact' => false, 'recreate' => false, 'skip_drain' => [] },
             'concourse' => {'parallel_execution_limit' => 5 },
-            'iaas' => 'extended', 'profiles' => ['x-profile'], 'stemcell' => { 'name' => 'bosh-openstack-kvm-ubuntu-bionic-go_agent' }
+            'iaas' => 'extended', 'profiles' => ['x-profile'], 'stemcell' => { 'name' => 'bosh-openstack-kvm-ubuntu-bionic-go_agent' },
+            'retry'=> { 'task' => 2, 'bosh-push'=> 1, 'pull'=> 2, 'push'=> 2 }
           },
           'offline-mode' => { 'boshreleases' => false, 'docker-images' => false, 'stemcells' => true },
           :private => true, :shared => true }

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -133,7 +133,7 @@ jobs:
             ./additional-resource/meta-inf.yml
         CUSTOM_SCRIPT_DIR: additional-resource/apps-depls/my_cf_app/template
     - task: push-test-app
-      attempts: 2
+      attempts: 6
       input_mapping: {scripts-resource: cf-ops-automation, templates-resource: paas-template-test-app, credentials-resource: secrets-test-app, additional-resource: release-manifest}
       output_mapping: {generated-files: final-release-manifest}
       file: cf-ops-automation/concourse/tasks/cf_push.yml

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
@@ -161,19 +161,19 @@ jobs:
   plan:
     - in_parallel:
       - get: cf-ops-automation
-        attempts: 2
+        attempts: 4
         params: { submodules: none, depth: 0 }
         trigger: true
       - get : secrets-delete-depls-limited
-        attempts: 2
+        attempts: 4
         params: { submodules: none, depth: 0 }
         trigger: true
       - get: paas-templates-delete-depls
-        attempts: 2
+        attempts: 4
         params: { submodules: none }
         trigger: true
     - task: s3-upload-stemcells
-      attempts: 2
+      attempts: 3
       input_mapping: { templates-resource: paas-templates-delete-depls }
       file:  cf-ops-automation/concourse/tasks/s3_stemcells_upload/task.yml
       params:
@@ -193,17 +193,17 @@ jobs:
   plan:
     - in_parallel:
         - get: cf-ops-automation
-          attempts: 2
+          attempts: 4
           params: { submodules: none }
           trigger: true
         - get : secrets-delete-depls-limited
-          attempts: 2
+          attempts: 4
           params: { submodules: none }
         - get: ((stemcell-main-name))
           trigger: true
-          attempts: 2
+          attempts: 4
     - task: upload-to-director
-      attempts: 2
+      attempts: 3
       input_mapping: { stemcell: ((stemcell-main-name)), config-resource: secrets-delete-depls-limited }
       file:  cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml
       params:
@@ -335,7 +335,7 @@ jobs:
         PROFILES: ((profiles))
     - in_parallel:
       - task: update-cloud-config-for-delete-depls
-        attempts: 2
+        attempts: 3
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-delete-depls-limited}
         output_mapping: {deployed-config: deployed-cloud-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -373,7 +373,7 @@ jobs:
               repository: updated-cloud-config
               rebase: true
       - task: update-runtime-config-for-delete-depls
-        attempts: 2
+        attempts: 3
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-delete-depls-limited}
         output_mapping: {deployed-config: deployed-runtime-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -411,7 +411,7 @@ jobs:
               repository: updated-runtime-config
               rebase: true
       - task: update-cpi-config-for-delete-depls
-        attempts: 2
+        attempts: 3
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-delete-depls-limited}
         output_mapping: {deployed-config: deployed-cpi-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
@@ -148,7 +148,7 @@ jobs:
         file:  cf-ops-automation/concourse/tasks/repackage_boshreleases_fallback/task.yml
       - task: upload-to-director
         # this is required to manage runtime config bosh release upload
-        attempts: 2
+        attempts: 3
         input_mapping: { releases-to-upload: repackaged-releases-fallback, config-resource: secrets-full-writer }
         file:  cf-ops-automation/concourse/tasks/bosh_upload_releases/task.yml
         params:
@@ -206,7 +206,7 @@ jobs:
             params: { submodules: none }
             trigger: true
       - task: upload-stemcells
-        attempts: 2
+        attempts: 3
         input_mapping: { templates-resource: paas-templates-simple-depls-limited }
         file:  cf-ops-automation/concourse/tasks/s3_stemcells_upload/task.yml
         params:
@@ -231,9 +231,9 @@ jobs:
             params: { submodules: none }
           - get: ((stemcell-main-name))
             trigger: true
-            attempts: 2
+            attempts: 4
       - task: upload-to-director
-        attempts: 2
+        attempts: 3
         input_mapping: { stemcell: ((stemcell-main-name)), config-resource: secrets-full-writer }
         file:  cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml
         params:
@@ -248,13 +248,13 @@ jobs:
       - in_parallel:
           - get: ntp_boshrelease
             trigger: true
-            attempts: 2
+            attempts: 4
           - get: secrets-full-writer
             params: { submodules: none}
           - get: ((stemcell-main-name))
             passed: [ upload-stemcell-to-director ]
             trigger: true
-            attempts: 2
+            attempts: 4
       - task: generate-ntp_boshrelease-deployment-manifest
         input_mapping: {stemcell: ((stemcell-main-name))}
         output_mapping: {generated-files: final-release-manifest}
@@ -286,7 +286,7 @@ jobs:
       - try:
           # this step may fail when boshrelease have been already uploaded to director with another sha1. Indeed, everytime we repackage a bosh release a new sha1 is produced
           task: upload-to-director
-          attempts: 2
+          attempts: 3
           input_mapping: { releases-to-upload: ntp_boshrelease, config-resource: secrets-full-writer }
           config:
             platform: linux
@@ -310,12 +310,12 @@ jobs:
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CA_CERT: config-resource/shared/certs/internal_paas-ca/server-ca.crt
       - put: ntp_boshrelease-deployment
-        attempts: 2
+        attempts: 5
         params:
           manifest: final-release-manifest/ntp_boshrelease-deployment.yml
           cleanup: true
       - task: compile-and-export-ntp_boshrelease
-        attempts: 2
+        attempts: 3
         input_mapping: {secrets: secrets-full-writer, stemcell: ((stemcell-main-name))}
         output_mapping: {exported-release: ntp_boshrelease-exported-release}
         config:
@@ -361,13 +361,13 @@ jobs:
       - in_parallel:
           - get: zookeeper_boshrelease
             trigger: true
-            attempts: 2
+            attempts: 4
           - get: secrets-full-writer
             params: { submodules: none}
           - get: ((stemcell-main-name))
             passed: [ upload-stemcell-to-director ]
             trigger: true
-            attempts: 2
+            attempts: 4
       - task: generate-zookeeper_boshrelease-deployment-manifest
         input_mapping: {stemcell: ((stemcell-main-name))}
         output_mapping: {generated-files: final-release-manifest}
@@ -399,7 +399,7 @@ jobs:
       - try:
           # this step may fail when boshrelease have been already uploaded to director with another sha1. Indeed, everytime we repackage a bosh release a new sha1 is produced
           task: upload-to-director
-          attempts: 2
+          attempts: 3
           input_mapping: { releases-to-upload: zookeeper_boshrelease, config-resource: secrets-full-writer }
           config:
             platform: linux
@@ -423,12 +423,12 @@ jobs:
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CA_CERT: config-resource/shared/certs/internal_paas-ca/server-ca.crt
       - put: zookeeper_boshrelease-deployment
-        attempts: 2
+        attempts: 5
         params:
           manifest: final-release-manifest/zookeeper_boshrelease-deployment.yml
           cleanup: true
       - task: compile-and-export-zookeeper_boshrelease
-        attempts: 2
+        attempts: 3
         input_mapping: {secrets: secrets-full-writer, stemcell: ((stemcell-main-name))}
         output_mapping: {exported-release: zookeeper_boshrelease-exported-release}
         config:
@@ -473,14 +473,14 @@ jobs:
     - in_parallel:
         - get: cf-ops-automation
           params: { submodules: none}
-          attempts: 2
+          attempts: 4
           #trigger: true
         - get: secrets-simple-depls-trigger
           params: { submodules: none}
-          attempts: 2
+          attempts: 4
         - get: paas-templates-simple-depls-versions
           params: { submodules: none}
-          attempts: 2
+          attempts: 4
           trigger: true
     - task: generate-simple-depls-flight-plan
       output_mapping: {result-dir: init-simple-depls-plan}

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -235,19 +235,19 @@ jobs:
   plan:
     - in_parallel:
       - get: cf-ops-automation
-        attempts: 2
+        attempts: 4
         params: { submodules: none, depth: 0 }
         trigger: true
       - get : secrets-simple-depls-limited
-        attempts: 2
+        attempts: 4
         params: { submodules: none, depth: 0 }
         trigger: true
       - get: paas-templates-simple-depls
-        attempts: 2
+        attempts: 4
         params: { submodules: none }
         trigger: true
     - task: s3-upload-stemcells
-      attempts: 2
+      attempts: 3
       input_mapping: { templates-resource: paas-templates-simple-depls }
       file:  cf-ops-automation/concourse/tasks/s3_stemcells_upload/task.yml
       params:
@@ -267,17 +267,17 @@ jobs:
   plan:
     - in_parallel:
         - get: cf-ops-automation
-          attempts: 2
+          attempts: 4
           params: { submodules: none }
           trigger: true
         - get : secrets-simple-depls-limited
-          attempts: 2
+          attempts: 4
           params: { submodules: none }
         - get: ((stemcell-main-name))
           trigger: true
-          attempts: 2
+          attempts: 4
     - task: upload-to-director
-      attempts: 2
+      attempts: 3
       input_mapping: { stemcell: ((stemcell-main-name)), config-resource: secrets-simple-depls-limited }
       file:  cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml
       params:
@@ -358,7 +358,7 @@ jobs:
         PROFILES: ((profiles))
     - in_parallel:
       - task: update-cloud-config-for-simple-depls
-        attempts: 2
+        attempts: 3
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-simple-depls-limited}
         output_mapping: {deployed-config: deployed-cloud-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -396,7 +396,7 @@ jobs:
               repository: updated-cloud-config
               rebase: true
       - task: update-runtime-config-for-simple-depls
-        attempts: 2
+        attempts: 3
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-simple-depls-limited}
         output_mapping: {deployed-config: deployed-runtime-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -434,7 +434,7 @@ jobs:
               repository: updated-runtime-config
               rebase: true
       - task: update-cpi-config-for-simple-depls
-        attempts: 2
+        attempts: 3
         input_mapping: {scripts-resource: cf-ops-automation, secrets: secrets-simple-depls-limited}
         output_mapping: {deployed-config: deployed-cpi-config}
         file: cf-ops-automation/concourse/tasks/bosh_update_config/task.yml
@@ -484,7 +484,7 @@ jobs:
       passed: [ upload-stemcell-to-director ]
       trigger: true
       params:
-      attempts: 2
+      attempts: 4
     - get: cf-ops-automation
       params: { submodules: none, depth: 0 }
       trigger: true
@@ -492,7 +492,7 @@ jobs:
       trigger: true
       params:
         tarball: false
-      attempts: 2
+      attempts: 4
     - get: secrets-ntp-with-scan
       params: { submodules: none, depth: 0 }
       trigger: true
@@ -610,7 +610,7 @@ jobs:
       OFFLINE_MODE_ENABLED: false
       PRECOMPILE_MODE_ENABLED: true
   - put: ntp-with-scan-deployment
-    attempts: 2
+    attempts: 5
     on_failure:
       do:
         - task: update-ntp-with-scan-files
@@ -663,7 +663,7 @@ jobs:
       PROFILES: ((profiles))
       COMMIT_MESSAGE: "ntp-with-scan generated manifest auto update.\nDeployment information: $(cat additional-resource/deployment_information.txt)\nActive profiles: ${PROFILES}\n[skip ci]"
   - put: secrets-full-writer
-    attempts: 2
+    attempts: 6
     get_params: { submodules: none, depth: 0 }
     params:
       repository: updated-ntp-with-scan-secrets
@@ -692,7 +692,7 @@ jobs:
       passed: [ upload-stemcell-to-director ]
       trigger: true
       params:
-      attempts: 2
+      attempts: 4
     - get: cf-ops-automation
       params: { submodules: none, depth: 0 }
       trigger: true
@@ -700,7 +700,7 @@ jobs:
       trigger: true
       params:
         tarball: false
-      attempts: 2
+      attempts: 4
     - get: paas-templates-zookeeper-without-scan
       trigger: true
       params:
@@ -815,7 +815,7 @@ jobs:
       OFFLINE_MODE_ENABLED: false
       PRECOMPILE_MODE_ENABLED: true
   - put: zookeeper-without-scan-deployment
-    attempts: 2
+    attempts: 5
     on_failure:
       do:
         - task: update-zookeeper-without-scan-files
@@ -868,7 +868,7 @@ jobs:
       PROFILES: ((profiles))
       COMMIT_MESSAGE: "zookeeper-without-scan generated manifest auto update.\nDeployment information: $(cat additional-resource/deployment_information.txt)\nActive profiles: ${PROFILES}\n[skip ci]"
   - put: secrets-full-writer
-    attempts: 2
+    attempts: 6
     get_params: { submodules: none, depth: 0 }
     params:
       repository: updated-zookeeper-without-scan-secrets
@@ -927,14 +927,14 @@ jobs:
   - in_parallel:
     - get: cf-ops-automation
       params: { submodules: none, depth: 0 }
-      attempts: 2
+      attempts: 4
 #      trigger: true
     - get: secrets-simple-depls-trigger
       params: { submodules: none, depth: 0 }
-      attempts: 2
+      attempts: 4
     - get: paas-templates-simple-depls-versions
       params: { submodules: none, depth: 0 }
-      attempts: 2
+      attempts: 4
       trigger: true
   - task: generate-simple-depls-flight-plan
     output_mapping: {result-dir: init-simple-depls-plan}

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
@@ -136,7 +136,7 @@ jobs:
         PROFILES: ((profiles))
         FILE_EXECUTION_FILTER: "deploy*.sh"
     - put: k8s-configs-repository
-      attempts: 2
+      attempts: 6
       get_params: { submodules: none, depth: 0 }
       params:
         repository: updated-k8s-repo
@@ -228,7 +228,7 @@ jobs:
       IAAS_TYPE: ((iaas-type))
       PROFILES: ((profiles))
   - put: k8s-configs-repository
-    attempts: 2
+    attempts: 6
     get_params: { submodules: none, depth: 0 }
     params:
       repository: updated-k8s-repo

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
@@ -73,7 +73,7 @@ jobs:
       - get: monday
         trigger: true
       - get: ntp_boshrelease
-        attempts: 2
+        attempts: 4
         params: {tarball: false}
       - get: paas-templates-full
         params: { submodules: none, depth: 0 }
@@ -130,7 +130,7 @@ jobs:
       - get: monday
         trigger: true
       - get: zookeeper_boshrelease
-        attempts: 2
+        attempts: 4
         params: {tarball: false}
       - get: paas-templates-full
         params: { submodules: none, depth: 0 }

--- a/spec/scripts/generate-depls/fixtures/templates/shared-config.yml
+++ b/spec/scripts/generate-depls/fixtures/templates/shared-config.yml
@@ -2,3 +2,8 @@
 default:
   stemcell:
     name: bosh-dummy-stemcell
+  retry:
+    task: 3
+    pull: 4
+    bosh-push: 5
+    push: 6


### PR DESCRIPTION
We can tune the number of concourse retries in multiple cases. When not specified, it will use values below:
```
default:
  retry: # Configure how to handle retries in various context
    task: 2 # Optional. You may override number of retry when running concourse tasks (except put, get and bosh deploy)
    pull: 2 # Optional. You may override number of retry when getting data from external system like git, s3, etc...
    push: 2 # Optional. You may override number of retry when sending data to external system like git, s3, etc...
    bosh-push: 2 # Optional. You may override number of retry when sending data to bosh
```

But you can override default value using `paas-templates/shared-config.yml` or `secrets/private-config.yml`.