### PR TITLE
pipelines(control-plane|update): use fly to format pipelines

### DIFF
--- a/concourse/pipelines/control-plane.yml
+++ b/concourse/pipelines/control-plane.yml
@@ -146,20 +146,20 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: library/ruby
-          tag: 2.7.1
+          repository: teliaoss/concourse-fly
+          tag: '20210905'
       inputs:
       - name: concourse-micro
       outputs:
       - name: sorted-pipelines
       run:
-        path: /bin/bash
+        path: /bin/sh
         args:
           - -ec
           - |
+            echo "We use fly $(fly --version) to format pipelines"
             cp -p concourse-micro/*.yml sorted-pipelines/
-            cd sorted-pipelines
-            ruby -ryaml -e 'Dir["*.yml"].each { |yaml_file| puts "processing #{yaml_file}"; yaml = YAML.load_file(yaml_file); yaml["resources"] = yaml["resources"]&.sort_by { |x| x["name"]}; yaml["resource_types"] = yaml["resource_types"]&.sort_by { |x| x["name"]}; puts "rewriting #{yaml_file}"; File.open(yaml_file, "w") { |file| file.write(yaml.to_yaml) } }'
+            find sorted-pipelines -type f -name "*.yml" -print -exec fly format-pipeline -w -c {} \;
 
   - task: update-git-deployed-pipelines
     input_mapping: {reference-resource: secrets-writer, generated-resource: sorted-pipelines}
@@ -199,20 +199,20 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: library/ruby
-            tag: 2.7.1
+            repository: teliaoss/concourse-fly
+            tag: '20210905'
         inputs:
           - name: concourse-micro-legacy
         outputs:
           - name: sorted-pipelines
         run:
-          path: /bin/bash
+          path: /bin/sh
           args:
             - -ec
             - |
+              echo "We use fly $(fly --version) to format pipelines"
               cp -p concourse-micro-legacy/*.yml sorted-pipelines/
-              cd sorted-pipelines
-              ruby -ryaml -e 'Dir["*.yml"].each { |yaml_file| puts "processing #{yaml_file}"; yaml = YAML.load_file(yaml_file); yaml["resources"] = yaml["resources"]&.sort_by { |x| x["name"]}; yaml["resource_types"] = yaml["resource_types"]&.sort_by { |x| x["name"]}; puts "rewriting #{yaml_file}"; File.open(yaml_file, "w") { |file| file.write(yaml.to_yaml) } }'
+              find sorted-pipelines -type f -name "*.yml" -print -exec fly format-pipeline -w -c {} \;
 
     - task: update-git-deployed-pipelines
       input_mapping: {reference-resource: secrets-writer, generated-resource: sorted-pipelines}

--- a/concourse/pipelines/template/update-pipeline.yml.erb
+++ b/concourse/pipelines/template/update-pipeline.yml.erb
@@ -162,11 +162,30 @@ jobs:
           end
           EOF
           ruby filter_pipelines.rb
-
     params:
       ROOT_DEPLOYMENT: <%= depls %>
+  - task: format-pipelines
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: teliaoss/concourse-fly
+          tag: "20210905"
+      inputs:
+        - name: selected-pipelines
+      outputs:
+        - name: formated-pipelines
+      run:
+        path: /bin/sh
+        args:
+          - -ec
+          - |
+            echo "We use fly $(fly --version) to format pipelines"
+            cp -rp selected-pipelines/* formated-pipelines/
+            find formated-pipelines -type f -name "*.yml" -print -exec fly format-pipeline -w -c {} \;
   - task: update-git-generated-pipelines
-    input_mapping: {reference-resource: secrets-<%= depls %>-for-pipeline, generated-resource: selected-pipelines}
+    input_mapping: {reference-resource: secrets-<%= depls %>-for-pipeline, generated-resource: formated-pipelines}
     output_mapping: {updated-git-resource: generated-pipelines}
     file: cf-ops-automation/concourse/tasks/git_append_a_dir_from_generated/task.yml
     params:

--- a/concourse/tasks/git_append_a_dir_from_generated/task.yml
+++ b/concourse/tasks/git_append_a_dir_from_generated/task.yml
@@ -31,6 +31,7 @@ run:
   - |
     git config --global user.email "$GIT_USER_EMAIL"
     git config --global user.name "$GIT_USER_NAME"
+    git config --global advice.detachedHead false
 
     FINAL_RELEASE_REPO=updated-git-resource
 

--- a/spec/pipelines/static_pipelines_spec.rb
+++ b/spec/pipelines/static_pipelines_spec.rb
@@ -92,7 +92,8 @@ describe 'static concourse pipelines spec' do
        { "repository" => TaskSpecHelper.spruce_image, "tag" => TaskSpecHelper.spruce_image_version },
        { "repository" => TaskSpecHelper.git_image, "tag" => TaskSpecHelper.git_image_version },
        { "repository" => TaskSpecHelper.bosh_cli_v2_image, "tag" => TaskSpecHelper.bosh_cli_v2_image_version },
-       { "repository" => TaskSpecHelper.bosh_cf_cli_image, "tag" => TaskSpecHelper.bosh_cf_cli_image_version }
+       { "repository" => TaskSpecHelper.bosh_cf_cli_image, "tag" => TaskSpecHelper.bosh_cf_cli_image_version },
+       { "repository" => TaskSpecHelper.fly_image, "tag" => TaskSpecHelper.fly_image_version }
       ]
     end
     let(:image_resources) do

--- a/spec/tasks/task_spec_helper.rb
+++ b/spec/tasks/task_spec_helper.rb
@@ -4,6 +4,14 @@ class TaskSpecHelper
     File.absolute_path(relative_path)
   end
 
+  def self.fly_image
+    'teliaoss/concourse-fly'
+  end
+
+  def self.fly_image_version
+    '20210905'
+  end
+
   def self.alpine_image
     'library/alpine'
   end


### PR DESCRIPTION
Changes proposed in this pull-request:
- use `fly format-pipeline` command to format generated or deployed pipelines
