### PR TITLE
pipelines(bosh): remove commit message from bosh tags

### DIFF
--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -821,7 +821,7 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: governmentpaas/spruce
+          repository: governmentpaas/curl-ssl
           tag: 469ceea7a619b0abdd6cb27efd4d3bd5e9be3ddb
       inputs:
         - name: final-release-manifest
@@ -846,11 +846,6 @@ jobs:
             echo '- type: replace'
             echo '  path: /tags?/coa-templates-commit-author?'
             echo '  value: "((''coa-templates-commit-author))"'
-
-            echo '- type: replace'
-            echo '  path: /tags?/coa-templates-commit-message?'
-            echo '  value: |'
-            echo '    ((''coa-templates-commit-message))'
           } > result-dir/operators/0-coa-templates-reference-operators.yml
           echo "Done - file '0-coa-templates-reference-operators.yml'"
 
@@ -858,10 +853,7 @@ jobs:
           {
             echo 'coa-templates-commit-id: "'"$(cat  template-resource/.git/ref)"'"'
             echo 'coa-templates-commit-author: "'"$(cat template-resource/.git/committer)"'"'
-            echo  'coa-templates-commit-message: ((file "template-resource/.git/commit_message"))'
-
-          } > coa-vars.spruce
-          spruce merge coa-vars.spruce >result-dir/vars/0-coa-templates-reference-vars.yml
+          } > result-dir/operators/0-coa-templates-reference-vars.yml
           echo "Done - file '0-coa-templates-reference-vars.yml'"
 
   - task: display-<%= name %>-manifest

--- a/spec/pipelines/static_pipelines_spec.rb
+++ b/spec/pipelines/static_pipelines_spec.rb
@@ -89,7 +89,6 @@ describe 'static concourse pipelines spec' do
        { "repository" => TaskSpecHelper.ruby_image, "tag" => TaskSpecHelper.ruby_slim_image_version },
        { "repository" => TaskSpecHelper.alpine_image, "tag" => TaskSpecHelper.alpine_image_version },
        { "repository" => TaskSpecHelper.curl_image, "tag" => TaskSpecHelper.curl_image_version },
-       { "repository" => TaskSpecHelper.spruce_image, "tag" => TaskSpecHelper.spruce_image_version },
        { "repository" => TaskSpecHelper.git_image, "tag" => TaskSpecHelper.git_image_version },
        { "repository" => TaskSpecHelper.bosh_cli_v2_image, "tag" => TaskSpecHelper.bosh_cli_v2_image_version },
        { "repository" => TaskSpecHelper.bosh_cf_cli_image, "tag" => TaskSpecHelper.bosh_cf_cli_image_version },

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -550,7 +550,7 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: governmentpaas/spruce
+          repository: governmentpaas/curl-ssl
           tag: 469ceea7a619b0abdd6cb27efd4d3bd5e9be3ddb
       inputs:
         - name: final-release-manifest
@@ -574,19 +574,13 @@ jobs:
             echo '- type: replace'
             echo '  path: /tags?/coa-templates-commit-author?'
             echo '  value: "((''coa-templates-commit-author))"'
-            echo '- type: replace'
-            echo '  path: /tags?/coa-templates-commit-message?'
-            echo '  value: |'
-            echo '    ((''coa-templates-commit-message))'
           } > result-dir/operators/0-coa-templates-reference-operators.yml
           echo "Done - file '0-coa-templates-reference-operators.yml'"
           echo "Generating '0-coa-templates-reference-vars.yml'"
           {
             echo 'coa-templates-commit-id: "'"$(cat  template-resource/.git/ref)"'"'
             echo 'coa-templates-commit-author: "'"$(cat template-resource/.git/committer)"'"'
-            echo  'coa-templates-commit-message: ((file "template-resource/.git/commit_message"))'
-          } > coa-vars.spruce
-          spruce merge coa-vars.spruce >result-dir/vars/0-coa-templates-reference-vars.yml
+          } > result-dir/operators/0-coa-templates-reference-vars.yml
           echo "Done - file '0-coa-templates-reference-vars.yml'"
   - task: display-ntp-with-scan-manifest
     input_mapping:
@@ -777,7 +771,7 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: governmentpaas/spruce
+          repository: governmentpaas/curl-ssl
           tag: 469ceea7a619b0abdd6cb27efd4d3bd5e9be3ddb
       inputs:
         - name: final-release-manifest
@@ -801,19 +795,13 @@ jobs:
             echo '- type: replace'
             echo '  path: /tags?/coa-templates-commit-author?'
             echo '  value: "((''coa-templates-commit-author))"'
-            echo '- type: replace'
-            echo '  path: /tags?/coa-templates-commit-message?'
-            echo '  value: |'
-            echo '    ((''coa-templates-commit-message))'
           } > result-dir/operators/0-coa-templates-reference-operators.yml
           echo "Done - file '0-coa-templates-reference-operators.yml'"
           echo "Generating '0-coa-templates-reference-vars.yml'"
           {
             echo 'coa-templates-commit-id: "'"$(cat  template-resource/.git/ref)"'"'
             echo 'coa-templates-commit-author: "'"$(cat template-resource/.git/committer)"'"'
-            echo  'coa-templates-commit-message: ((file "template-resource/.git/commit_message"))'
-          } > coa-vars.spruce
-          spruce merge coa-vars.spruce >result-dir/vars/0-coa-templates-reference-vars.yml
+          } > result-dir/operators/0-coa-templates-reference-vars.yml
           echo "Done - file '0-coa-templates-reference-vars.yml'"
   - task: display-zookeeper-without-scan-manifest
     input_mapping:


### PR DESCRIPTION
We remove git commit message from bosh tags, to avoid issues with unexpected characters included in commit messages.
It may generate Flexible Engine (openstack iaas) tag API burst on WIP recreate.

Related to orange-cloudfoundry/paas-templates#1435 (bosh: too many tag update request)

Changes proposed in this pull-request:
- do not include commit message in tags