### PR TITLE
add-display-background: support pipeline background customization

### DIFF
--- a/ci/bootstrap_coa_env/pipeline-vars-background-image-prereqs.yml
+++ b/ci/bootstrap_coa_env/pipeline-vars-background-image-prereqs.yml
@@ -1,0 +1,3 @@
+pipeline_vars:
+  background-image-url: https://upload.wikimedia.org/wikipedia/commons/7/76/Creative-Tail-test_tube.svg
+  background-image-url-description: used by concourse to display a backgound image on each pipelines

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,6 +16,24 @@ meta:
     params:
       path: cf-ops-automation
       status: failure
+  - &coa-failure-acceptance-pr
+    put: pr-develop
+    params:
+      path: cf-ops-automation
+      status: failure
+      context: acceptance-tests
+  - &coa-failure-it-pr
+    put: pr-develop
+    params:
+      path: cf-ops-automation
+      status: failure
+      context: integration-tests
+  - &coa-failure-ut-pr
+    put: pr-develop
+    params:
+      path: cf-ops-automation
+      status: failure
+      context: unit-tests
   - &coa-pending-pr
     put: pr-develop
     params:
@@ -32,7 +50,8 @@ meta:
     params:
       path: pr-develop
       status: failure
-
+display:
+  background_image: https://wallpapercave.com/download/pirate-flag-wallpapers-wp2022142
 resource_types:
   - name: slack-notification
     type: registry-image
@@ -361,8 +380,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 469ceea7a619b0abdd6cb27efd4d3bd5e9be3ddb
+              repository: orangecloudfoundry/bosh-cli-v2
+              tag: 317bf1656840ce57682039109ce93b701ffa6a32
           inputs:
             - name: cf-ops-automation
           params:
@@ -704,7 +723,9 @@ jobs:
           GIT_SHA_CMD: cat .git/resource/head_sha
           GIT_BRANCH_CMD: cat .git/resource/head_name
         on_failure:
-          *failed-pr
+          in_parallel:
+            - *coa-failure-pr
+            - *coa-failure-ut-pr
       - put: pr-develop
         params:
           path: cf-ops-automation
@@ -736,11 +757,17 @@ jobs:
         image: cf-ops-automation-docker-image-pr
         timeout: 30m
         config: *acceptance_tests_config
-        on_failure: *coa-failure-pr
+        on_failure:
+          in_parallel:
+            - *coa-failure-pr
+            - *coa-failure-acceptance-pr
       - task: ensure-changelog-is-working
         image: cf-ops-automation-docker-image-pr
         config: *changelog_working
-        on_failure: *coa-failure-pr
+        on_failure:
+          in_parallel:
+            - *coa-failure-pr
+            - *coa-failure-acceptance-pr
       - put: pr-develop
         params:
           path: cf-ops-automation
@@ -770,7 +797,10 @@ jobs:
         attempts: 1
         image: cf-ops-automation-docker-image-pr
         config: *integration_tests_setup_pre_requisites_task_config
-        on_failure: *coa-failure-pr
+        on_failure:
+          in_parallel:
+            - *coa-failure-pr
+            - *coa-failure-it-pr
         # it is not possible to include it as config param, otherwise we get an deserialization error
         params: *integration_tests_setup_pre_requisites_task_config_params
 #          INTEGRATION_TEST_PREREQS: ((integration-test-prereqs))
@@ -781,12 +811,18 @@ jobs:
       - task: setup-credhub-pre-requisites
         attempts: 1
         config: *integration_tests_setup_credhub_pre_requisites_task_config
-        on_failure: *coa-failure-pr
+        on_failure:
+          in_parallel:
+            - *coa-failure-pr
+            - *coa-failure-it-pr
       - task: upload-pipelines
         attempts: 2
         image: cf-ops-automation-docker-image-pr
         config: *integration_tests_upload-pipelines_task_config
-        on_failure: *coa-failure-pr
+        on_failure:
+          in_parallel:
+            - *coa-failure-pr
+            - *coa-failure-it-pr
       - put: pr-develop
         params:
           path: cf-ops-automation

--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -1,4 +1,6 @@
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/concourse/pipelines/control-plane.yml
+++ b/concourse/pipelines/control-plane.yml
@@ -1,4 +1,6 @@
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: concourse-5-pipeline
     type: registry-image

--- a/concourse/pipelines/pipelines-overview.yml
+++ b/concourse/pipelines/pipelines-overview.yml
@@ -1,4 +1,6 @@
 ---
+display:
+  background_image: ((background-image-url))
 resources:
   - name: templates-commit
     type: mock

--- a/concourse/pipelines/sync-feature-branches.yml
+++ b/concourse/pipelines/sync-feature-branches.yml
@@ -1,4 +1,6 @@
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/concourse/pipelines/sync-hotfix-branches.yml
+++ b/concourse/pipelines/sync-hotfix-branches.yml
@@ -1,4 +1,6 @@
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -59,7 +59,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
-
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -48,7 +48,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
-
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -11,6 +11,8 @@
   current_team = CiDeployment.team(all_ci_deployments, depls, "#{depls}-cf-apps-generated")
 %>
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/concourse/pipelines/template/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/template/concourse-pipeline.yml.erb
@@ -9,6 +9,8 @@
   concourse_retry = configurer.concourse_retry
 %>
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: concourse-5-pipeline
     type: registry-image

--- a/concourse/pipelines/template/k8s-pipeline.yml.erb
+++ b/concourse/pipelines/template/k8s-pipeline.yml.erb
@@ -35,6 +35,8 @@
 %>
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/concourse/pipelines/template/news-pipeline.yml.erb
+++ b/concourse/pipelines/template/news-pipeline.yml.erb
@@ -24,6 +24,8 @@
   concourse_retry = configurer.concourse_retry
 %>
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/concourse/pipelines/template/tf-pipeline.yml.erb
+++ b/concourse/pipelines/template/tf-pipeline.yml.erb
@@ -8,6 +8,8 @@
   concourse_retry = configurer.concourse_retry
 %>
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/concourse/pipelines/template/update-pipeline.yml.erb
+++ b/concourse/pipelines/template/update-pipeline.yml.erb
@@ -8,6 +8,8 @@
   concourse_retry = configurer.concourse_retry
 %>
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/concourse/tasks/execute_k8s_shells/run.sh
+++ b/concourse/tasks/execute_k8s_shells/run.sh
@@ -45,6 +45,8 @@ echo "\$BASE_TEMPLATE_DIR: directory containing k8s scripts to execute (set to: 
 echo "\$K8S_GIT_REPO_PATH: directory containing generated files (set to: $K8S_GIT_REPO_PATH)"
 echo "\$PAAS_TEMPLATES_COMMIT_ID, \$PAAS_TEMPLATES_COMMITTER, \$PAAS_TEMPLATES_COMMIT_MESSAGE"
 echo "\$PRE_PROCESSED_MANIFEST_PATH: directory containing files processed during 'generate-<deployment-name>-manifest' step"
+echo "\$IAAS_TYPE: current IaaS type (set to $IAAS_TYPE)"
+echo "\$PROFILES: current active profiles (set to $PROFILES)"
 echo '---------------------'
 
 if [ -z "$PAAS_TEMPLATES_COMMIT_ID" ]; then

--- a/docs/reference_dataset/another-world-root-depls.md
+++ b/docs/reference_dataset/another-world-root-depls.md
@@ -58,6 +58,17 @@ another-world-root-depls
 {:config_repo_name=>"config_repository", :template_repo_name=>"template_repository"}
 ## List of pipelines in which credentials appear for another-world-root-depls
 
+### background-image-url
+
+* another-world-root-depls-bosh-generated.yml
+* another-world-root-depls-bosh-precompile-generated.yml
+* another-world-root-depls-cf-apps-generated.yml
+* another-world-root-depls-concourse-generated.yml
+* another-world-root-depls-k8s-generated.yml
+* another-world-root-depls-news-generated.yml
+* another-world-root-depls-tf-generated.yml
+* another-world-root-depls-update-generated.yml
+
 ### bosh-password
 
 * another-world-root-depls-bosh-generated.yml
@@ -184,6 +195,7 @@ another-world-root-depls
 
 ### another-world-root-depls-bosh-generated.yml
 
+* background-image-url
 * bosh-password
 * bosh-target
 * bosh-username
@@ -209,18 +221,20 @@ another-world-root-depls
 
 ### another-world-root-depls-bosh-precompile-generated.yml
 
+* background-image-url
 * slack-channel
 
 ### another-world-root-depls-cf-apps-generated.yml
 
-No credentials required
+* background-image-url
 
 ### another-world-root-depls-concourse-generated.yml
 
-No credentials required
+* background-image-url
 
 ### another-world-root-depls-k8s-generated.yml
 
+* background-image-url
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
@@ -245,13 +259,13 @@ No credentials required
 
 ### another-world-root-depls-news-generated.yml
 
-No credentials required
+* background-image-url
 
 ### another-world-root-depls-tf-generated.yml
 
-No credentials required
+* background-image-url
 
 ### another-world-root-depls-update-generated.yml
 
-No credentials required
+* background-image-url
 

--- a/docs/reference_dataset/hello-world-root-depls.md
+++ b/docs/reference_dataset/hello-world-root-depls.md
@@ -25,8 +25,8 @@ hello-world-root-depls
 │       └── secrets.yml
 ├── cf-apps-deployments
 │   └── generic-app
-│       ├── Readme.md
 │       ├── enable-cf-app.yml
+│       ├── Readme.md
 │       ├── secrets
 │       │   └── secrets.yml
 │       └── spruce-file-sample-from-secrets.txt
@@ -44,10 +44,10 @@ hello-world-root-depls
 ├── k8s-sample
 │   └── enable-deployment.yml
 ├── pipeline-sample
-│   ├── Readme.md
 │   ├── concourse-pipeline-config
 │   │   └── virtualbox
 │   ├── enable-deployment.yml
+│   ├── Readme.md
 │   └── secrets
 │       └── secrets.yml
 ├── runtime-config.yml
@@ -113,8 +113,8 @@ hello-world-root-depls
 │           ├── pre-cf-push.sh
 │           ├── spruce-file-sample-from-templates.txt
 │           └── static-app
-│               ├── Staticfile
-│               └── index.html
+│               ├── index.html
+│               └── Staticfile
 ├── hooks
 │   └── k8s
 │       └── deploy.sh
@@ -157,6 +157,17 @@ hello-world-root-depls
 
 {:config_repo_name=>"config_repository", :template_repo_name=>"template_repository"}
 ## List of pipelines in which credentials appear for hello-world-root-depls
+
+### background-image-url
+
+* hello-world-root-depls-bosh-generated.yml
+* hello-world-root-depls-bosh-precompile-generated.yml
+* hello-world-root-depls-cf-apps-generated.yml
+* hello-world-root-depls-concourse-generated.yml
+* hello-world-root-depls-k8s-generated.yml
+* hello-world-root-depls-news-generated.yml
+* hello-world-root-depls-tf-generated.yml
+* hello-world-root-depls-update-generated.yml
 
 ### bosh-password
 
@@ -402,6 +413,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-bosh-generated.yml
 
+* background-image-url
 * bosh-password
 * bosh-target
 * bosh-username
@@ -431,6 +443,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-bosh-precompile-generated.yml
 
+* background-image-url
 * bosh-password
 * bosh-target
 * bosh-username
@@ -455,6 +468,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-cf-apps-generated.yml
 
+* background-image-url
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
@@ -474,6 +488,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-concourse-generated.yml
 
+* background-image-url
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
@@ -495,6 +510,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-k8s-generated.yml
 
+* background-image-url
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
@@ -522,6 +538,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-news-generated.yml
 
+* background-image-url
 * bot-github-access-token
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
@@ -536,6 +553,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-tf-generated.yml
 
+* background-image-url
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri
@@ -553,6 +571,7 @@ hello-world-root-depls
 
 ### hello-world-root-depls-update-generated.yml
 
+* background-image-url
 * cf-ops-automation-branch
 * cf-ops-automation-tag-filter
 * cf-ops-automation-uri

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-precompile-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-precompile-generated.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/another-world-root-depls-cf-apps-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-cf-apps-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/docs/reference_dataset/pipelines/another-world-root-depls-concourse-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-concourse-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: concourse-5-pipeline
     type: registry-image

--- a/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/another-world-root-depls-news-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-news-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/docs/reference_dataset/pipelines/another-world-root-depls-tf-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-tf-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/another-world-root-depls-update-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-update-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-precompile-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-precompile-generated.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-cf-apps-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-cf-apps-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-concourse-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-concourse-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: concourse-5-pipeline
     type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-news-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-news-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-tf-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-tf-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-update-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-update-generated.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/spec/pipelines/static_pipelines_spec.rb
+++ b/spec/pipelines/static_pipelines_spec.rb
@@ -8,10 +8,30 @@ describe 'static concourse pipelines spec' do
   let(:pipelines_references_fixture) { 'spec/scripts/generate-depls/fixtures/references/' }
   let(:pipelines_references_dataset) { 'docs/reference_dataset/pipelines/' }
   let(:pipeline_files) do
-    Dir.glob(pipelines_dir + '**/*.yml') + Dir.glob(pipelines_references_fixture + '*.yml') + Dir.glob(pipelines_references_dataset + '*.yml')
+    Dir.glob("#{pipelines_dir}**/*.yml") + Dir.glob("#{pipelines_references_fixture}*.yml") + Dir.glob("#{pipelines_references_dataset}*.yml")
   end
 
-  context 'resource_type exists' do
+  context 'when checking pipelines definition' do
+    let(:pipelines_without_reference_dataset) { Dir.glob("#{pipelines_dir}**/*.yml") + Dir.glob("#{pipelines_references_fixture}*.yml") }
+    let(:pipelines_display) do
+      result = []
+      pipelines_without_reference_dataset.each do |pipeline_filename|
+        pipeline = YAML.load_file(pipeline_filename)
+        result << if pipeline['display']
+                    pipeline['display'].to_yaml
+                  else
+                    "missing display in #{pipeline_filename}"
+                  end
+      end
+      result.uniq
+    end
+
+    it 'has uniq background_display set' do
+      expect(pipelines_display).to match_array("---\nbackground_image: \"((background-image-url))\"\n")
+    end
+  end
+
+  context 'when resource_type exists' do
     let(:resource_types) do
       result = []
       puts "list: #{pipeline_files}"

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/empty-bosh-precompile.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-bosh-precompile.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/empty-concourse.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-concourse.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: concourse-5-pipeline
     type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/empty-k8s.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-k8s.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/empty-news.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-news.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -9,6 +9,8 @@ meta:
         text: Failed to run [[$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME ($BUILD_NAME)]($ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME)].
         icon_url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
         username: Concourse
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
 - name: slack-notification
   type: registry-image

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-news-ref.yml
@@ -1,5 +1,7 @@
 
 ---
+display:
+  background_image: ((background-image-url))
 resource_types:
   - name: slack-notification
     type: registry-image


### PR DESCRIPTION
Changes proposed in this pull-request:
 - include background image into pipelines 


Each pipelines managed by COA can customize it background except pipeline loaded using concourse support. Indeed, as pipeline background is set per pipeline, a pipeline author is expected to add some yaml into each pipeline:
'
display:
  display_background: ((background_image_url))
'

related to orange-cloudfoundry/paas-templates#1336