### PR TITLE
pipeline(bosh): fix meta-inf.yml detection

### DIFF
--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -172,7 +172,7 @@ resources:
     git_submodules: git_submodules,
     config: boshrelease,
     config_key: 'templates',
-    defaults: ["#{root_deployment_name}/#{name}"])
+    defaults: ["#{root_deployment_name}/#{name}", "meta-inf.yml"])
   paas_templates_selected_paths << "#{root_deployment_name}/root-deployment.yml" if paas_templates_selected_paths
 %>
 <% deployment_details = PipelineHelpers::DeploymentDetails.new(name, boshrelease) %>
@@ -748,7 +748,7 @@ jobs:
       git_submodules: git_submodules,
       config: boshrelease,
       config_key: 'templates',
-      defaults: ["#{root_deployment_name}/#{name}"]
+      defaults: ["#{root_deployment_name}/#{name}", "meta-inf.yml"]
     )
     submodules = PipelineHelpers.git_resource_loaded_submodules(
       depls: root_deployment_name,

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -101,7 +101,7 @@ resources:
   type: git
   source:
     uri: ((paas-templates-uri))
-    paths: ["simple-depls/ntp-with-scan", "simple-depls/root-deployment.yml"]
+    paths: ["simple-depls/ntp-with-scan", "meta-inf.yml", "simple-depls/root-deployment.yml"]
     branch: pipeline-current-((paas-templates-branch))
     skip_ssl_verification: true
 - name: ntp-with-scan-deployment
@@ -118,7 +118,7 @@ resources:
   type: git
   source:
     uri: ((paas-templates-uri))
-    paths: ["simple-depls/zookeeper-without-scan", "simple-depls/root-deployment.yml"]
+    paths: ["simple-depls/zookeeper-without-scan", "meta-inf.yml", "simple-depls/root-deployment.yml"]
     branch: pipeline-current-((paas-templates-branch))
     skip_ssl_verification: true
 - name: zookeeper-without-scan-deployment
@@ -500,7 +500,7 @@ jobs:
     params:
       ROOT_DEPLOYMENT: simple-depls
       DEPLOYMENT: ntp-with-scan
-      SCAN_PATHS: simple-depls/ntp-with-scan
+      SCAN_PATHS: simple-depls/ntp-with-scan meta-inf.yml
       GIT_SUBMODULES: 
       LOCAL_SECRETS_SCAN: true
   - task: generate-ntp-with-scan-manifest
@@ -735,7 +735,7 @@ jobs:
     params:
       ROOT_DEPLOYMENT: simple-depls
       DEPLOYMENT: zookeeper-without-scan
-      SCAN_PATHS: simple-depls/zookeeper-without-scan
+      SCAN_PATHS: simple-depls/zookeeper-without-scan meta-inf.yml
       GIT_SUBMODULES: 
       LOCAL_SECRETS_SCAN: false
   - task: generate-zookeeper-without-scan-manifest


### PR DESCRIPTION
Paas-template resources include meta-inf.yml in scan path, except for paas-templates-full (already included) and paas-templates-<xxx>-versions dedicated to 'root-deployment.yml' file

related to orange-cloudfoundry/paas-templates#1366.