### PR TITLE
chore(ci): bump to concourse 7.8.2 and bosh-cli 6.4.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM ruby:2.7.1
 
-# 4e0502afbd60d2501c67deef1c640100d2c37ee1c26755138cc24f5d4d527a3a  fly-7.1.0-linux-amd64.tgz
-# 919f79a0c2c94b38738440a1bb9c0dfeb3b2bd126602a2a13e3d12b4830b8a5a  fly-7.3.2-linux-amd64.tgz
 # c264d9cb979d05598e44e0527220e21e2f20564f63cc11f98c8480768997433f  fly-7.6.0-linux-amd64.tgz
+# 92c56cb432c5d86d8687d765bd6d0847dc80edfbab28a878a9c11eec9289b02d  fly-7.8.2-linux-amd64.tgz
 # https://github.com/concourse/concourse/releases/
-ARG CONCOURSE_VERSION=7.6.0
-ARG CONCOURSE_SHA256=c264d9cb979d05598e44e0527220e21e2f20564f63cc11f98c8480768997433f
+ARG CONCOURSE_VERSION=7.8.2
+ARG CONCOURSE_SHA256=92c56cb432c5d86d8687d765bd6d0847dc80edfbab28a878a9c11eec9289b02d
 
 # https://github.com/cloudfoundry/bosh-cli/releases
-ARG BOSH_CLI_VERSION=6.4.7
-ARG BOSH_CLI_SHA256=596abc123ddb676f081d375dc4672359fb1573c38d8dd3e8bdc4f3d2769783a1
+ARG BOSH_CLI_VERSION=6.4.17
+ARG BOSH_CLI_SHA256=d0917d3ad0ff544a4c69a7986e710fe48e8cb2207717f77db31905d639e28c18
 
 RUN apt-get update && \
  apt-get -y install tree vim netcat dnsutils jq

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ ruby '2.7.1'
 gem 'rhcl', '>= 0.1.0'
 
 group :development do
-  gem 'docker_registry2', '>= 1.10.0'
-  gem 'git', '>=1.11.0'
-  gem 'github_changelog_generator', '>= 1.16.4'
+  gem 'docker_registry2', '>= 1.10.0' # https://rubygems.org/gems/docker_registry2
+  gem 'git', '>=1.11.0' # https://rubygems.org/gems/git
+  gem 'github_changelog_generator', '>= 1.16.4' # https://rubygems.org/gems/github_changelog_generator
   gem 'mdl', '>=0.11.0'
   gem 'rake', '>=13.0.6'
   gem 'reek', '>= 6.0.1'


### PR DESCRIPTION
We also add link to some rubygem package to ease compatibility info usage.