### PR TITLE
pipeline(precompile): fix missing release upload without precompile

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -484,6 +484,10 @@ The exact stemcell version (say `3586.25`) is used within a root-deployment as d
 
 See [github issues](https://github.com/orange-cloudfoundry/cf-ops-automation/issues).
 
+## Interns
+
+[Readme.md](docs/Readme.md)
+
 ## Running the Test Suite
 
 Prereqs:

--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -301,7 +301,7 @@ jobs:
           ENDPOINT: ((s3-br-endpoint))
           SKIP_SSL_VERIFICATION: ((s3-br-skip-ssl-verification))
       <% end %>
-      - task: upload-to-director
+      - task: upload-to-director-for-runtime-config
         # this is required to manage runtime config bosh release upload
         attempts: <%= concourse_retry[:task] %>
         input_mapping: { releases-to-upload: repackaged-releases-fallback, config-resource: secrets-full-writer }

--- a/docs/BoshReleases_upload.puml
+++ b/docs/BoshReleases_upload.puml
@@ -1,0 +1,105 @@
+@startuml
+ actor DevOpsTeam as team
+
+ entity Git
+ box COA
+    participant "bosh-pipeline"
+    participant "precompile-pipeline"
+ end box
+
+ entity "Bosh Director" as bosh
+ entity "S3 Server" as s3
+ entity "Bosh IO" as boshio
+
+ team -> Git: update bosh-release
+ note right: bump bosh release version | add new bosh release
+ Git -> "bosh-pipeline": propagate changes
+ note right
+  Going through:
+    **sync-feature-branch** and **shared-control-plane-generated**
+ end note
+
+
+group prepare bosh releases (push-boshreleases step)
+     group when bosh-release offline mode
+         "bosh-pipeline" -> "bosh-pipeline": reformat-root-deployment-yml
+         "precompile-pipeline" -> "precompile-pipeline": reformat-root-deployment-yml
+         "bosh-pipeline" -> s3: missing-s3-boshreleases
+         "precompile-pipeline" -> s3: missing-s3-boshreleases
+     end group
+     "bosh-pipeline" -> "bosh-pipeline": repackage-releases
+     "precompile-pipeline" -> "precompile-pipeline": repackage-releases
+     "bosh-pipeline" -> "bosh-pipeline": repackage-releases-fallback
+     "precompile-pipeline" -> "precompile-pipeline": repackage-releases-fallback
+     group when bosh-release offline mode
+         "bosh-pipeline" -> s3: upload-repackaged-releases
+         "precompile-pipeline" -> s3: upload-repackaged-releases
+     end group
+
+     group when bosh-release offline mode disabled OR precompile disabled
+        "bosh-pipeline" -> bosh: upload-to-director
+     end group
+    "bosh-pipeline" -> "bosh-pipeline": check-repackaging-errors
+    "precompile-pipeline" -> bosh:  upload-to-director-for-runtime-config
+    "precompile-pipeline" -> "precompile-pipeline":  check-repackaging-errors
+end group
+
+    group precompile
+        loop for each bosh-release
+        "precompile-pipeline" -> bosh: deploy standalone release
+        bosh -> "precompile-pipeline": done
+        "precompile-pipeline" -> bosh: export release
+        bosh -> "precompile-pipeline": done
+        end
+
+    end
+
+ group deploy-<my_deployment>
+    note over "bosh-pipeline": does not include stemcell, neither bosh releases
+    loop for each deployment
+        "bosh-pipeline" -> bosh: deploy-<my_deployment> manifest
+        bosh -> "bosh-pipeline": done
+
+         group offline bosh-releases
+            loop for each boshrelease
+                bosh -> s3: download bosh-releases
+                s3 -> bosh: release.tgz
+            end
+
+         end group
+
+    end
+
+  end group
+== ==
+  group online bosh-releases mode with precompile
+    note over "precompile-pipeline", "bosh-pipeline": It makes sense only for COA CI, to be able to test precompile pipelines
+    autonumber
+    group prepare bosh releases (push-boshreleases step)
+     "bosh-pipeline" -> "bosh-pipeline": repackage-releases
+     "precompile-pipeline" -> "precompile-pipeline": repackage-releases
+     "bosh-pipeline" -> "bosh-pipeline": repackage-releases-fallback
+     "precompile-pipeline" -> "precompile-pipeline": repackage-releases-fallback
+
+    "bosh-pipeline" -> bosh: upload-to-director
+    bosh -> "bosh-pipeline": done
+    "bosh-pipeline" -> "bosh-pipeline": check-repackaging-errors
+    "precompile-pipeline" -> bosh:  upload-to-director-for-runtime-config
+    bosh -> "precompile-pipeline": done
+    "precompile-pipeline" -> "precompile-pipeline":  check-repackaging-errors
+    end group
+
+    loop for each bosh-release
+        "precompile-pipeline" -> bosh: deploy standalone release
+        bosh -> "precompile-pipeline": done
+        "precompile-pipeline" -> bosh: export release
+        bosh -> "precompile-pipeline": done
+    end
+
+    loop for each deployment
+        "bosh-pipeline" -> bosh: deploy manifest
+        bosh -> "bosh-pipeline": done
+    end
+  end
+
+@enduml

--- a/docs/COA-Mechanisms.md
+++ b/docs/COA-Mechanisms.md
@@ -1,4 +1,7 @@
 # COA mechanisms
 
+## Bosh releases upload overview
+![View of BoshReleases_upload.puml](http://www.plantuml.com/plantuml/proxy?src=https://raw.github.com/orange-cloudfoundry/cf-ops-automation/develop/docs/BoshReleases_upload.puml&fmt=svg)
+
 ## Stemcell upload overview
-![View of InternalModel.puml](http://www.plantuml.com/plantuml/proxy?src=https://raw.github.com/orange-cloudfoundry/cf-ops-automation/develop/docs/Stemcell_upload.puml&fmt=svg)
+![View of Stemcell_upload.puml](http://www.plantuml.com/plantuml/proxy?src=https://raw.github.com/orange-cloudfoundry/cf-ops-automation/develop/docs/Stemcell_upload.puml&fmt=svg)

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -1,3 +1,3 @@
 # Documentation Overview
 
-Additional details about [COA mechanisms](COA-Mechanisms.md) (like stemcell upload) or about [Internal Model](InternalModel.md).
+Additional details about [COA mechanisms](COA-Mechanisms.md) (like stemcell upload, or bosh releases upload) or about [Internal Model](InternalModel.md).

--- a/docs/Stemcell_upload.puml
+++ b/docs/Stemcell_upload.puml
@@ -54,13 +54,30 @@
 == ==
   group stemcell online mode with precompile
     note over "precompile-pipeline", "bosh-pipeline": It makes sense only for COA CI, to be able to test precompile pipelines
-    autonumber
-     "bosh-pipeline" -> boshio: download stemcell
-     boshio --> "bosh-pipeline": stemcell.tgz
-     "precompile-pipeline" -> s3: upload stemcell
-     s3 --> "precompile-pipeline": done
-     "precompile-pipeline" -> bosh: upload stemcell
-     bosh --> "precompile-pipeline": done
-    end
+    group "Precompile-pipeline"
+        autonumber
+        group task download stemcell
+             "precompile-pipeline" -> boshio: download stemcell
+             boshio --> "precompile-pipeline": stemcell.tgz
+         end
+         group task download stemcell
+             "precompile-pipeline" -> bosh: upload stemcell if missing
+             bosh --> "precompile-pipeline": done
+         end
+
+     end
+
+    group "Bosh-Pipeline"
+        autonumber
+        group task download stemcell
+             "bosh-pipeline" -> boshio: download stemcell
+             boshio --> "bosh-pipeline": stemcell.tgz
+         end
+         group task download stemcell
+             "bosh-pipeline" -> bosh: upload stemcell if missing
+             bosh --> "bosh-pipeline": done
+         end
+
+     end
 
 @enduml

--- a/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
@@ -337,7 +337,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
         YAML.safe_load expected_yaml
       end
       let(:expected_push_stemcell_to_director_tasks) { %w[upload-to-director] }
-      let(:expected_push_boshreleases_tasks) { %w[reformat-root-deployment-yml missing-s3-boshreleases repackage-releases repackage-releases-fallback upload-repackaged-releases upload-to-director check-repackaging-errors] }
+      let(:expected_push_boshreleases_tasks) { %w[reformat-root-deployment-yml missing-s3-boshreleases repackage-releases repackage-releases-fallback upload-repackaged-releases upload-to-director-for-runtime-config check-repackaging-errors] }
 
       it 'generates s3 precompiled resources (ie use precompile bucket)' do
         s3_precompiled_boshreleases = generated_pipeline['resources'].select { |resource| resource['type'] == 's3' && resource['name'].start_with?('compiled-') }
@@ -427,7 +427,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
 
       let(:expected_push_stemcell_to_director_tasks) { %w[upload-to-director] }
       let(:expected_upload_stemcell_to_s3_tasks) { %w[upload-stemcells] }
-      let(:expected_push_boshreleases_tasks) { %w[repackage-releases repackage-releases-fallback upload-to-director check-repackaging-errors] }
+      let(:expected_push_boshreleases_tasks) { %w[repackage-releases repackage-releases-fallback upload-to-director-for-runtime-config check-repackaging-errors] }
       let(:expected_stemcell_init) { 'echo "check-resource -r $BUILD_PIPELINE_NAME/((stemcell-main-name)) --from path:((stemcell-name-prefix))((stemcell-main-name))/bosh-stemcell-((stemcell.version))-((stemcell-main-name)).tgz' }
 
       it 'generates s3 stemcell with pinned version' do

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
@@ -148,7 +148,7 @@ jobs:
           ROOT_DEPLOYMENT_NAME: simple-depls
       - task: repackage-releases-fallback
         file:  cf-ops-automation/concourse/tasks/repackage_boshreleases_fallback/task.yml
-      - task: upload-to-director
+      - task: upload-to-director-for-runtime-config
         # this is required to manage runtime config bosh release upload
         attempts: 3
         input_mapping: { releases-to-upload: repackaged-releases-fallback, config-resource: secrets-full-writer }


### PR DESCRIPTION
when no precompile releases are available (due to cache mechanism, or there is nothing to compile), we still need `push-boshrelease` step to ensure bosh-releases related to runtime-config are processed.


Related to orange-cloudfoundry/paas-templates#1888