### PR TITLE
pipeline(bosh): fine grain management of compiled download url

### DIFF
--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -10,7 +10,6 @@
     terraform_config_path = all_ci_deployments.dig(root_deployment_name, PipelineHelpers::TERRAFORM_CONFIG_DIRNAME_KEY, 'state_file_path')
     terraform_config_path_value = ", \"#{terraform_config_path}\""
   end
-
   disabled_deployments = all_dependencies.select do |_, deployment_info|
     deployment_info['status'] == 'disabled'
   end
@@ -32,14 +31,9 @@
   offline_boshreleases_enabled = config&.dig('offline-mode', 'boshreleases') && true
   lock_releases_enabled = config&.fetch('lock-releases', false) && true
   precompile_pipeline_enabled = config&.fetch('precompile-mode', true) && true
-  precompile_excluded_deployments = config&.dig(root_deployment_name,'precompile','excluded-deployments') || []
 
-  download_server_url = if offline_boshreleases_enabled
-                          # we expect s3-endpoint to end with '/'
-                          "((s3-#{precompile_pipeline_enabled ? "compiled-release" : "br" }-endpoint))((s3-#{ precompile_pipeline_enabled ? "compiled-release" : "br" }-bucket))"
-                        else
-                          "https://bosh.io/d/github.com/"
-                        end
+  disabled_compiled_download_url_deployments = config&.dig(root_deployment_name,'precompile','disabled_compiled_download_url_deployments') || []
+  disabled_compiled_download_url_deployments_prefix = config&.dig(root_deployment_name,'precompile','disabled_compiled_download_url_deployments_prefix') || []
 
   jobs = Hash.new {|h,k| h[k]=[]}
 
@@ -899,9 +893,19 @@ jobs:
       VERSIONS_FILE:  templates-resource/<%= root_deployment_name %>/root-deployment.yml
       MANIFEST_YAML_FILE: manifest-dir/interpolated-<%= name %>.yml
       DEPLOYMENT_NAME: <%= name %>
+      <%
+        deployment_precompile_enabled = precompile_pipeline_enabled && !disabled_compiled_download_url_deployments.include?(name)
+        disabled_compiled_download_url_deployments_prefix.each { |prefix | deployment_precompile_enabled = deployment_precompile_enabled && !name.start_with?(prefix) }
+        download_server_url = if offline_boshreleases_enabled
+                          # we expect s3-endpoint to end with '/'
+                          "((s3-#{deployment_precompile_enabled ? "compiled-release" : "br" }-endpoint))((s3-#{ deployment_precompile_enabled ? "compiled-release" : "br" }-bucket))"
+                        else
+                          "https://bosh.io/d/github.com/"
+                        end
+       %>
       DOWNLOAD_SERVER_URL: <%= download_server_url %>
       OFFLINE_MODE_ENABLED: <%= offline_boshreleases_enabled %>
-      PRECOMPILE_MODE_ENABLED: <%= precompile_pipeline_enabled %>
+      PRECOMPILE_MODE_ENABLED: <%= deployment_precompile_enabled %>
       LOCK_RELEASES: <%= lock_releases_enabled %>
   - put: <%= name %>-deployment
     attempts: <%= concourse_retry[:bosh_push] %>

--- a/docs/reference_dataset/config_repository/private-config.yml
+++ b/docs/reference_dataset/config_repository/private-config.yml
@@ -54,3 +54,5 @@
 #    shallow-clone-depth: 1 # Default: 0, ie disabled
 #  precompile:
 #    excluded_deployments: [] # Default: [] # List deployments to exclude from precompile. As precompile does not use secrets repository to determine enabled deployments, it might be convenient to exclude a deployment not enabled in secrets.
+#    disabled_compiled_download_url_deployments: [] # Default: [] - List of deployments to exclude from bosh manifest precompile patching
+#    disabled_compiled_download_url_deployments_prefix: [] # Default: [] - List of deployments prefix to exclude from bosh manifest precompile patching

--- a/docs/reference_dataset/template_repository/shared-config.yml
+++ b/docs/reference_dataset/template_repository/shared-config.yml
@@ -1,8 +1,8 @@
 ---
-# When offline-mode is enabled, bytes are retrieved from an S3 compliant location, otherwise download from bosh-io
+# If offline mode is enabled, bytes are fetched from an S3-compatible location, otherwise they are downloaded from bosh-io.
 offline-mode:
-   boshreleases: false # Choose where boshreleases are downloaded from. Default: false
-   stemcells: false # Choose where stemcells are downloaded from. Default: true
+   boshreleases: false # Enable or disable boshreleases offline mode, thus its download location. Default: false (disabled)
+   stemcells: false # Enable or disable stemcells offline mode, thus its download location. Default: true (enabled)
 
 lock-releases: false # Default: false. See https://bosh.io/docs/locking-compiled-releases/
 # Shared pipelines configuration
@@ -59,4 +59,6 @@ default:
 #    parallel_execution_limit: 10 # Default: -1, ie unlimited
 #    serial_group_naming_strategy: SerialGroupMd5NamingStrategy #Default: SerialGroupRoundRobinNamingStrategy
 #  precompile:
-#    excluded_deployments: [] # Default: [] # List deployments to exclude from precompile. As precompile does not use secrets repository to determine enabled deployments, it might be convenient to exclude a deployment not enabled in secrets.
+#    excluded_deployments: [] # Default: [] # List of deployments to exclude from precompile. Since precompile does not use secrets repository to determine enabled deployments, it may be useful to exclude a deployment that is not enabled in secrets.
+#    disabled_compiled_download_url_deployments: [] # Default: [] - List of deployments to exclude from bosh manifest precompile patching
+#    disabled_compiled_download_url_deployments_prefix: [] # Default: [] - List of deployments prefix to exclude from bosh manifest precompile patching


### PR DESCRIPTION
With jammy stemcell we encounter incompatible bosh releases, so we want to keep the old stemcell and still have minimal management by COA, without adding multi stemcell support.

## Usage
See https://github.com/orange-cloudfoundry/cf-ops-automation/blob/e59a0a2fdef16aeb3874ec590edafbb05d36da03/docs/reference_dataset/template_repository/shared-config.yml#L63-L64

 ## Limitations
* Used stemcell should be upload to bosh director by other mean,
* Bosh releases handled by COA (ie described in `root-deployment.yml` and `deployment-dependecies.yml`), must be compiled with active stemcell.
