### PR TITLE
feature(easily-identify-precompile-deployments): restore this feature

### DIFF
--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -187,14 +187,14 @@ resources:
 <% end %>
 
 <% uniq_releases.sort.each do |release, info| %>
-  - name: <%= release %>-deployment
+  - name: precompile-<%= release %>-deployment
     icon: cube-send
     type: bosh-deployment-v2
     source:
       target: ((bosh-target))
       client: ((bosh-username))
       client_secret: "((bosh-password))"
-      deployment: <%= release %>-deployment
+      deployment: precompile-<%= release %>-deployment
       ca_cert: <%= bosh_cert[root_deployment_name]&.dump %>
 
   - name: <%= release %>
@@ -437,7 +437,7 @@ jobs:
             attempts: <%= concourse_retry[:pull] %>
       - task: generate-<%= release %>-deployment-manifest
         <%
-        manifest = {'name' => "#{release}-deployment", 'instance_groups' => [], 'update' => { 'canaries' => 1, 'max_in_flight' => 1, 'canary_watch_time' => '1000-90000', 'update_watch_time' => '1000-90000' }, 'releases' => [] }
+        manifest = {'name' => "precompile-#{release}-deployment", 'instance_groups' => [], 'update' => { 'canaries' => 1, 'max_in_flight' => 1, 'canary_watch_time' => '1000-90000', 'update_watch_time' => '1000-90000' }, 'releases' => [] }
         manifest['releases'] << {'name' => release, 'version' => info.fetch('version', 'latest')}
 
         precompile_manifest = manifest
@@ -468,7 +468,7 @@ jobs:
                 ruby -ryaml -e 'ruby_manifest=eval(ENV["MANIFEST_CONTENT"]); ruby_manifest["stemcells"] = [ "alias" => "default", "os" => ENV["STEMCELL_OS"], "version" => "latest"];File.open(File.join("generated-files", ENV["MANIFEST_NAME"]), "w") { |file| file.write(ruby_manifest.to_yaml) }'
                 cat generated-files/${MANIFEST_NAME}
           params:
-            MANIFEST_NAME: "<%= release %>-deployment.yml"
+            MANIFEST_NAME: "precompile-<%= release %>-deployment.yml"
             MANIFEST_CONTENT: '<%= precompile_manifest %>'
       - try:
           # this step may fail when boshrelease have been already uploaded to director with another sha1. Indeed, everytime we repackage a bosh release a new sha1 is produced
@@ -499,10 +499,10 @@ jobs:
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CA_CERT: config-resource/<%= SharedPipelineGenerator::BOSH_CERT_LOCATIONS[root_deployment_name] %>
 
-      - put: <%= release %>-deployment
+      - put: precompile-<%= release %>-deployment
         attempts: <%= concourse_retry[:bosh_push] %>
         params:
-          manifest: final-release-manifest/<%= release %>-deployment.yml
+          manifest: final-release-manifest/precompile-<%= release %>-deployment.yml
           cleanup: true
 
       - task: compile-and-export-<%= release %>
@@ -532,7 +532,7 @@ jobs:
                 echo "Exporting ${RELEASE_NAME}/${RELEASE_VERSION} - ${STEMCELL_OS}/${STEMCELL_VERSION}"
                 bosh export-release "${RELEASE_NAME}/${RELEASE_VERSION}" "${STEMCELL_OS}/${STEMCELL_VERSION}" --dir=exported-release
           params:
-            BOSH_DEPLOYMENT: <%= release %>-deployment
+            BOSH_DEPLOYMENT: precompile-<%= release %>-deployment
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CLIENT: ((bosh-username))
             BOSH_CLIENT_SECRET: "((bosh-password))"
@@ -575,9 +575,8 @@ jobs:
           file: compiled-<%= release %>/*.tgz
           acl: public-read
   <% end %>
-      - put: <%= release %>-deployment
+      - put: precompile-<%= release %>-deployment
         params:
-          manifest: final-release-manifest/<%= release %>-deployment.yml.yml
           delete:
             enabled: true
             force: true

--- a/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
@@ -25,53 +25,53 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
   let(:root_deployment_versions) { {} }
   let(:multi_root_dependencies) do
     deps_yaml = <<~YAML
-    #{root_deployment_name}:
-      bosh-bats:
-        status: disabled
-        stemcells:
-          bosh-openstack-kvm-ubuntu-bionic-go_agent:
-        bosh-deployment: {}
-        releases:
-          bosh:
-            base_location: https://github.com/
-            repository: cloudfoundry/bosh
-            version: 271.0.0
-      maria-db:
-        status: disabled
-      shield-expe:
-        stemcells:
-          bosh-openstack-kvm-ubuntu-bionic-go_agent:
-        releases:
-          cf-routing-release:
-            base_location: https://bosh.io/d/github.com/
-            repository: cloudfoundry-incubator/cf-routing-release
-            version: 0.169.0
-        errands:
-            import:
-            smoke-tests:
-              display-name: automated-smoke-tests
-        manual-errands:
-            manual-import:
-            manual-smoke-tests:
-              display-name: my-smoke-tests
-        bosh-deployment:
-          active: true
-        status: enabled
-      bui:
-        stemcells:
-          bosh-openstack-kvm-ubuntu-bionic-go_agent:
-        releases:
-          route-registrar-boshrelease:
-            base_location: https://bosh.io/d/github.com/
-            repository: cloudfoundry-community/route-registrar-boshrelease
-            version: '3'
-          haproxy-boshrelease:
-            base_location: https://bosh.io/d/github.com/
-            repository: cloudfoundry-community/haproxy-boshrelease
-            version: 8.0.12
-        bosh-deployment:
-          active: true
-        status: enabled
+      #{root_deployment_name}:
+        bosh-bats:
+          status: disabled
+          stemcells:
+            bosh-openstack-kvm-ubuntu-bionic-go_agent:
+          bosh-deployment: {}
+          releases:
+            bosh:
+              base_location: https://github.com/
+              repository: cloudfoundry/bosh
+              version: 271.0.0
+        maria-db:
+          status: disabled
+        shield-expe:
+          stemcells:
+            bosh-openstack-kvm-ubuntu-bionic-go_agent:
+          releases:
+            cf-routing-release:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-incubator/cf-routing-release
+              version: 0.169.0
+          errands:
+              import:
+              smoke-tests:
+                display-name: automated-smoke-tests
+          manual-errands:
+              manual-import:
+              manual-smoke-tests:
+                display-name: my-smoke-tests
+          bosh-deployment:
+            active: true
+          status: enabled
+        bui:
+          stemcells:
+            bosh-openstack-kvm-ubuntu-bionic-go_agent:
+          releases:
+            route-registrar-boshrelease:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-community/route-registrar-boshrelease
+              version: '3'
+            haproxy-boshrelease:
+              base_location: https://bosh.io/d/github.com/
+              repository: cloudfoundry-community/haproxy-boshrelease
+              version: 8.0.12
+          bosh-deployment:
+            active: true
+          status: enabled
     YAML
     YAML.safe_load(deps_yaml)
   end
@@ -171,11 +171,11 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
     end
 
     before do
-      @processed_template = subject.process(@pipelines_dir + '/*')
+      @processed_template = subject.process("#{@pipelines_dir}/*")
     end
 
     context 'when precompile is enabled without bosh deployment' do
-      let(:multi_root_dependencies) { {root_deployment_name => {} } }
+      let(:multi_root_dependencies) { { root_deployment_name => {} } }
       let(:loaded_config) do
         my_config_yaml = <<~YAML
           offline-mode:
@@ -193,8 +193,8 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
     end
 
     context 'when disabled deployments are presents' do
-      let(:expected_compiled_exported_deployments) { %W[compile-and-export-bosh compile-and-export-route-registrar-boshrelease compile-and-export-haproxy-boshrelease compile-and-export-cf-routing-release] }
-      let(:expected_uploaded_deployments) { %W[upload-compiled-bosh upload-compiled-route-registrar-boshrelease upload-compiled-haproxy-boshrelease upload-compiled-cf-routing-release] }
+      let(:expected_compiled_exported_deployments) { %w[compile-and-export-bosh compile-and-export-route-registrar-boshrelease compile-and-export-haproxy-boshrelease compile-and-export-cf-routing-release] }
+      let(:expected_uploaded_deployments) { %w[upload-compiled-bosh upload-compiled-route-registrar-boshrelease upload-compiled-haproxy-boshrelease upload-compiled-cf-routing-release] }
 
       it 'generates compile and export job for dependencies describe in disabled deployments' do
         filtered_generated_jobs = generated_pipeline['jobs'].select { |job| job['name']&.start_with?('compile-and-export') }.flat_map { |job| job['name'] }
@@ -208,8 +208,8 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
     end
 
     context 'when deployments are excluded' do
-      let(:expected_compiled_exported_deployments) { %W[compile-and-export-bosh compile-and-export-route-registrar-boshrelease compile-and-export-haproxy-boshrelease compile-and-export-cf-routing-release] }
-      let(:expected_uploaded_deployments) { %W[upload-compiled-bosh upload-compiled-route-registrar-boshrelease upload-compiled-haproxy-boshrelease upload-compiled-cf-routing-release] }
+      let(:expected_compiled_exported_deployments) { %w[compile-and-export-bosh compile-and-export-route-registrar-boshrelease compile-and-export-haproxy-boshrelease compile-and-export-cf-routing-release] }
+      let(:expected_uploaded_deployments) { %w[upload-compiled-bosh upload-compiled-route-registrar-boshrelease upload-compiled-haproxy-boshrelease upload-compiled-cf-routing-release] }
       let(:loaded_config) do
         my_config_yaml = <<~YAML
           offline-mode:
@@ -372,7 +372,6 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
         expect(s3_job).not_to be_empty
       end
 
-
       it 'generates push-boshreleases tasks' do
         push_boshreleases_job_tasks = generated_pipeline['jobs']
           .select { |job| job['name'] == "push-boshreleases" }
@@ -380,7 +379,6 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
           .flat_map { |step| step['task'] }.compact
         expect(push_boshreleases_job_tasks).to match(expected_push_boshreleases_tasks)
       end
-
 
       it 'generates init-concourse-boshrelease-and-stemcell-for-ops-depls' do
         expected_init_version = expected_boshreleases.values.flat_map { |get_version| "path:#{get_version}" }
@@ -391,9 +389,15 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
           .flat_map { |task| task['config']['run']['args'] }
         expect(init_args[1]).to include(*expected_init_version)
       end
+      it 'generates a deployment name with "precompile" prefix' do
+        expected_resource_name = expected_boshreleases.keys.flat_map { |name| "precompile-#{name}-deployment" }.sort
+        precompile_resource_names = generated_pipeline['resources']
+          .select { |resource| resource['name'].start_with?("precompile-") && resource['type'] == "bosh-deployment-v2"}
+          .flat_map { |resource| resource['name'] }
+          .sort
+        expect(precompile_resource_names).to match(expected_resource_name)
+      end
     end
-
-
 
     context 'when online boshreleases and offline stemcells are used' do
       let(:loaded_config) do
@@ -502,27 +506,28 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
         YAML.safe_load expected_yaml
       end
       let(:expected_stemcell_upload_task) do
-        [{ "task"=>"download-stemcell",
-           "attempts"=>2,
-           "file"=>"cf-ops-automation/concourse/tasks/download_stemcell/task.yml",
-           "input_mapping"=>{"templates-resource"=>"paas-templates-my-root-depls-limited"},
-           "output_mapping"=>{"stemcell"=>"((stemcell-main-name))"},
-           "params"=>
-                 {"STEMCELL_BASE_LOCATION"=>"https://bosh.io/d/stemcells",
-                       "STEMCELL_MAIN_NAME"=>"((stemcell-main-name))",
-                       "STEMCELL_PREFIX"=>"((stemcell-name-prefix))",
-                  "VERSIONS_FILE"=>"templates-resource/my-root-depls/root-deployment.yml"}
-          },
-         {"task"=>"upload-to-director",
-         "file"=>"cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml",
-         "input_mapping"=> {"config-resource"=>"secrets-full-writer", "stemcell"=>"((stemcell-main-name))"},
-         "attempts" => 2,
-         "params"=>
-            {"BOSH_CA_CERT"=> "config-resource/shared/certs/internal_paas-ca/server-ca.crt",
-             "BOSH_CLIENT"=>"((bosh-username))",
-             "BOSH_CLIENT_SECRET"=>"((bosh-password))",
-             "BOSH_ENVIRONMENT"=>"((bosh-target))"}
-       }]
+        [{ "task" => "download-stemcell",
+           "attempts" => 2,
+           "file" => "cf-ops-automation/concourse/tasks/download_stemcell/task.yml",
+           "input_mapping" => {"templates-resource"=>"paas-templates-my-root-depls-limited"},
+           "output_mapping" => {"stemcell"=>"((stemcell-main-name))"},
+           "params" =>
+                 {"STEMCELL_BASE_LOCATION" => "https://bosh.io/d/stemcells",
+                  "STEMCELL_MAIN_NAME" => "((stemcell-main-name))",
+                  "STEMCELL_PREFIX" => "((stemcell-name-prefix))",
+                  "VERSIONS_FILE" => "templates-resource/my-root-depls/root-deployment.yml"}
+         },
+         {"task" => "upload-to-director",
+          "file" => "cf-ops-automation/concourse/tasks/bosh_upload_stemcell/task.yml",
+          "input_mapping" => {"config-resource"=>"secrets-full-writer", "stemcell"=>"((stemcell-main-name))"},
+          "attempts" => 2,
+          "params" =>
+            {"BOSH_CA_CERT" => "config-resource/shared/certs/internal_paas-ca/server-ca.crt",
+             "BOSH_CLIENT" => "((bosh-username))",
+             "BOSH_CLIENT_SECRET" => "((bosh-password))",
+             "BOSH_ENVIRONMENT" => "((bosh-target))"}
+         }
+        ]
       end
       let(:expected_stemcell_init) { 'echo "check-resource -r $BUILD_PIPELINE_NAME/((stemcell-main-name)) --from version:((stemcell.version))" | tee -a result-dir/flight-plan' }
       let(:expected_stemcell_get_step) { { "get" => "((stemcell-main-name))", "trigger" => true, "attempts" => 2 } }
@@ -548,7 +553,6 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
           .select { |job| job['name'] == "upload-stemcell-to-s3" }
         expect(s3_job).to be_empty
       end
-
 
       it 'generates step upload-stemcell-to-director' do
         upload_task = generated_pipeline['jobs']
@@ -616,37 +620,37 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
 
     let(:multi_root_dependencies) do
       deps_yaml = <<~YAML
-      #{root_deployment_name}:
-        shield-expe:
-          stemcells:
-            bosh-openstack-kvm-ubuntu-bionic-go_agent:
-          releases:
-            cf-routing-release:
-              base_location: https://bosh.io/d/github.com/
-              repository: cloudfoundry-incubator/cf-routing-release
-              version: 0.169.0
-          bosh-deployment:
-            active: true
-          status: enabled
-        bui:
-          stemcells:
-            bosh-openstack-kvm-ubuntu-bionic-go_agent:
-          releases:
-            cf-routing-release:
-              base_location: https://bosh.io/d/github.com/
-              repository: cloudfoundry-community/route-registrar-boshrelease
-              version: '3'
-            haproxy-boshrelease:
-              base_location: https://bosh.io/d/github.com/
-              repository: cloudfoundry-community/haproxy-boshrelease
-              version: 8.0.12
-          bosh-deployment:
-            active: true
-          status: enabled
+        #{root_deployment_name}:
+          shield-expe:
+            stemcells:
+              bosh-openstack-kvm-ubuntu-bionic-go_agent:
+            releases:
+              cf-routing-release:
+                base_location: https://bosh.io/d/github.com/
+                repository: cloudfoundry-incubator/cf-routing-release
+                version: 0.169.0
+            bosh-deployment:
+              active: true
+            status: enabled
+          bui:
+            stemcells:
+              bosh-openstack-kvm-ubuntu-bionic-go_agent:
+            releases:
+              cf-routing-release:
+                base_location: https://bosh.io/d/github.com/
+                repository: cloudfoundry-community/route-registrar-boshrelease
+                version: '3'
+              haproxy-boshrelease:
+                base_location: https://bosh.io/d/github.com/
+                repository: cloudfoundry-community/haproxy-boshrelease
+                version: 8.0.12
+            bosh-deployment:
+              active: true
+            status: enabled
       YAML
       YAML.safe_load(deps_yaml)
     end
-    let(:template_processing_error) { subject.process(@pipelines_dir + '/*') }
+    let(:template_processing_error) { subject.process("#{@pipelines_dir}/*" ) }
 
     before(:context) do
       @output_dir = Dir.mktmpdir('generated-pipelines')
@@ -662,18 +666,18 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
     end
   end
 
-  context 'when a bosh is already precompiled' do
+  context 'when a bosh release is already precompiled' do
     subject { TemplateProcessor.new root_deployment_name, config, processor_context }
 
     let(:root_deployment_name) { 'child-root-depls' }
     let(:loaded_config) do
       my_config_yaml = <<~YAML
-          offline-mode:
-            stemcells: true
-          precompile-mode: true
-          #{root_deployment_name}:
-            precompile:
-              depends-on: [parent-root-deployment]
+        offline-mode:
+          stemcells: true
+        precompile-mode: true
+        #{root_deployment_name}:
+          precompile:
+            depends-on: [parent-root-deployment]
       YAML
       YAML.safe_load(my_config_yaml)
     end
@@ -697,7 +701,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
               route-registrar-boshrelease:
                 base_location: https://bosh.io/d/github.com/
                 repository: cloudfoundry-community/route-registrar-boshrelease
-                sha1: xxxddffrpofkldkng654654d8f97g 
+                sha1: xxxddffrpofkldkng654654d8f97g
                 version: '3'
               haproxy-boshrelease:
                 base_location: https://bosh.io/d/github.com/
@@ -752,6 +756,7 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
       generated_pipeline_path = File.join(@pipelines_output_dir, pipeline_template)
       YAML.load_file(generated_pipeline_path, aliases: true)
     end
+    let(:expected_jobs) { %W[compile-and-export-bosh compile-and-export-cf-routing-release init-concourse-boshrelease-and-stemcell-for-#{root_deployment_name} push-boshreleases upload-stemcell-to-director upload-stemcell-to-s3] }
 
     before(:context) do
       @output_dir = Dir.mktmpdir('generated-pipelines')
@@ -770,8 +775,6 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
     before do
       @processed_template = subject.process(@pipelines_dir + '/*')
     end
-
-    let(:expected_jobs) { %W[compile-and-export-bosh compile-and-export-cf-routing-release init-concourse-boshrelease-and-stemcell-for-#{root_deployment_name} push-boshreleases upload-stemcell-to-director upload-stemcell-to-s3] }
 
     it 'compiles only bosh releases not compiled by parent root deployment' do
       filtered_generated_jobs = generated_pipeline['jobs']&.flat_map { |job| job['name'] }

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
@@ -88,14 +88,14 @@ resources:
       paths: ["simple-depls/root-deployment.yml"]
       branch: ((paas-templates-precompile-branch))
       skip_ssl_verification: true
-  - name: ntp_boshrelease-deployment
+  - name: precompile-ntp_boshrelease-deployment
     icon: cube-send
     type: bosh-deployment-v2
     source:
       target: ((bosh-target))
       client: ((bosh-username))
       client_secret: "((bosh-password))"
-      deployment: ntp_boshrelease-deployment
+      deployment: precompile-ntp_boshrelease-deployment
       ca_cert: "-----BEGIN CERTIFICATE-----\nMIIDXDCCAkSgAwIBAgIBATANBgkqhkiG9w0BAQsFADA/MRMwEQYKCZImiZPyLGQB\nGRYDY29tMRYwFAYKCZImiZPyLGQBGRYGb3JhbmdlMRAwDgYDVQQDDAdUZXN0IENB\nMB4XDTE4MDUwODE0MzcwN1oXDTIwMDUwNzE0MzcwN1owPzETMBEGCgmSJomT8ixk\nARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBm9yYW5nZTEQMA4GA1UEAwwHVGVzdCBD\nQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALBLNz1HSlkLUMk6PsYU\nRjPhYi4f1hlDhl1nx/uuObqaePY8neGF8XGUhzc4mnV3DRik4Ufi99t5Ib2xKdv2\nrbl3dSrSfkOTUngAGlKb5WHy2t36gcH6XhY96qAKzeuvWvXPkik6RKmIUh6HuHF0\n47ApkVpauCKWhJibTjsJ1CSEf4lGrBJG9EyEz0fAvsWwySWgDhWbG90WNUPAwChB\n8t3h7WHNXTcriMPth4FIjCgEEde9Xa6r6pCrDFQfLBwy8fJK0cMDjWrGgo8VPHre\n1eXhiSCHowZG7WEM6ikjqeck00cvskzKWNnvgXK5K4wATjynsNJnpd+88cOt7efb\nEQECAwEAAaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYD\nVR0OBBYEFAdQsPXMlmEL7xVLP7E+cESV9qYTMB8GA1UdIwQYMBaAFAdQsPXMlmEL\n7xVLP7E+cESV9qYTMA0GCSqGSIb3DQEBCwUAA4IBAQAQWsP6GjMQhWWohODsNbuq\nG3lxTAIX04kNqXduUL1reO7BbzkBqJP9zbIjfOJra7wNyBHRTP4s2AX/ccvgvUp9\n7OqidvwtDszCBzK1an+0i0F5fn4g8WpRFhWq2OeT65PM058RhjpfvVvYYRGM3a7Z\ni1cJQPgqju6WY5esFEQHyQwR+XpL20h38IkurhQ//HzNUboZjoefCfI1bvDFbPY7\nX0YYYuNm3QGmtI2nei8X0rnnM+nE0G/6nMmFT8p9OkYLxA1FiIuGYajaHLhzgkvM\ntdn1DdO4SqwyR+lVlyUC3c4dPzLUpqpXgLSjgl5PiYD8il+PgAoBwM9mwoda5rC2\n-----END CERTIFICATE-----\n"
   - name: ntp_boshrelease
     type: git
@@ -106,14 +106,14 @@ resources:
       skip_ssl_verification: false
     #    access_token: ((bot-github-access-token))
     version: { ref: ((releases.ntp_boshrelease.version)) }
-  - name: zookeeper_boshrelease-deployment
+  - name: precompile-zookeeper_boshrelease-deployment
     icon: cube-send
     type: bosh-deployment-v2
     source:
       target: ((bosh-target))
       client: ((bosh-username))
       client_secret: "((bosh-password))"
-      deployment: zookeeper_boshrelease-deployment
+      deployment: precompile-zookeeper_boshrelease-deployment
       ca_cert: "-----BEGIN CERTIFICATE-----\nMIIDXDCCAkSgAwIBAgIBATANBgkqhkiG9w0BAQsFADA/MRMwEQYKCZImiZPyLGQB\nGRYDY29tMRYwFAYKCZImiZPyLGQBGRYGb3JhbmdlMRAwDgYDVQQDDAdUZXN0IENB\nMB4XDTE4MDUwODE0MzcwN1oXDTIwMDUwNzE0MzcwN1owPzETMBEGCgmSJomT8ixk\nARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBm9yYW5nZTEQMA4GA1UEAwwHVGVzdCBD\nQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALBLNz1HSlkLUMk6PsYU\nRjPhYi4f1hlDhl1nx/uuObqaePY8neGF8XGUhzc4mnV3DRik4Ufi99t5Ib2xKdv2\nrbl3dSrSfkOTUngAGlKb5WHy2t36gcH6XhY96qAKzeuvWvXPkik6RKmIUh6HuHF0\n47ApkVpauCKWhJibTjsJ1CSEf4lGrBJG9EyEz0fAvsWwySWgDhWbG90WNUPAwChB\n8t3h7WHNXTcriMPth4FIjCgEEde9Xa6r6pCrDFQfLBwy8fJK0cMDjWrGgo8VPHre\n1eXhiSCHowZG7WEM6ikjqeck00cvskzKWNnvgXK5K4wATjynsNJnpd+88cOt7efb\nEQECAwEAAaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYD\nVR0OBBYEFAdQsPXMlmEL7xVLP7E+cESV9qYTMB8GA1UdIwQYMBaAFAdQsPXMlmEL\n7xVLP7E+cESV9qYTMA0GCSqGSIb3DQEBCwUAA4IBAQAQWsP6GjMQhWWohODsNbuq\nG3lxTAIX04kNqXduUL1reO7BbzkBqJP9zbIjfOJra7wNyBHRTP4s2AX/ccvgvUp9\n7OqidvwtDszCBzK1an+0i0F5fn4g8WpRFhWq2OeT65PM058RhjpfvVvYYRGM3a7Z\ni1cJQPgqju6WY5esFEQHyQwR+XpL20h38IkurhQ//HzNUboZjoefCfI1bvDFbPY7\nX0YYYuNm3QGmtI2nei8X0rnnM+nE0G/6nMmFT8p9OkYLxA1FiIuGYajaHLhzgkvM\ntdn1DdO4SqwyR+lVlyUC3c4dPzLUpqpXgLSjgl5PiYD8il+PgAoBwM9mwoda5rC2\n-----END CERTIFICATE-----\n"
   - name: zookeeper_boshrelease
     type: git
@@ -284,8 +284,8 @@ jobs:
                 ruby -ryaml -e 'ruby_manifest=eval(ENV["MANIFEST_CONTENT"]); ruby_manifest["stemcells"] = [ "alias" => "default", "os" => ENV["STEMCELL_OS"], "version" => "latest"];File.open(File.join("generated-files", ENV["MANIFEST_NAME"]), "w") { |file| file.write(ruby_manifest.to_yaml) }'
                 cat generated-files/${MANIFEST_NAME}
           params:
-            MANIFEST_NAME: "ntp_boshrelease-deployment.yml"
-            MANIFEST_CONTENT: '{"name"=>"ntp_boshrelease-deployment", "instance_groups"=>[], "update"=>{"canaries"=>1, "max_in_flight"=>1, "canary_watch_time"=>"1000-90000", "update_watch_time"=>"1000-90000"}, "releases"=>[{"name"=>"ntp_boshrelease", "version"=>"4"}]}'
+            MANIFEST_NAME: "precompile-ntp_boshrelease-deployment.yml"
+            MANIFEST_CONTENT: '{"name"=>"precompile-ntp_boshrelease-deployment", "instance_groups"=>[], "update"=>{"canaries"=>1, "max_in_flight"=>1, "canary_watch_time"=>"1000-90000", "update_watch_time"=>"1000-90000"}, "releases"=>[{"name"=>"ntp_boshrelease", "version"=>"4"}]}'
       - try:
           # this step may fail when boshrelease have been already uploaded to director with another sha1. Indeed, everytime we repackage a bosh release a new sha1 is produced
           task: upload-to-director
@@ -313,10 +313,10 @@ jobs:
             BOSH_CLIENT_SECRET: ((bosh-password))
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CA_CERT: config-resource/shared/certs/internal_paas-ca/server-ca.crt
-      - put: ntp_boshrelease-deployment
+      - put: precompile-ntp_boshrelease-deployment
         attempts: 5
         params:
-          manifest: final-release-manifest/ntp_boshrelease-deployment.yml
+          manifest: final-release-manifest/precompile-ntp_boshrelease-deployment.yml
           cleanup: true
       - task: compile-and-export-ntp_boshrelease
         attempts: 3
@@ -345,16 +345,15 @@ jobs:
                 echo "Exporting ${RELEASE_NAME}/${RELEASE_VERSION} - ${STEMCELL_OS}/${STEMCELL_VERSION}"
                 bosh export-release "${RELEASE_NAME}/${RELEASE_VERSION}" "${STEMCELL_OS}/${STEMCELL_VERSION}" --dir=exported-release
           params:
-            BOSH_DEPLOYMENT: ntp_boshrelease-deployment
+            BOSH_DEPLOYMENT: precompile-ntp_boshrelease-deployment
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CLIENT: ((bosh-username))
             BOSH_CLIENT_SECRET: "((bosh-password))"
             BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
             RELEASE_NAME: ntp_boshrelease
             RELEASE_VERSION: ((releases.ntp_boshrelease.version))
-      - put: ntp_boshrelease-deployment
+      - put: precompile-ntp_boshrelease-deployment
         params:
-          manifest: final-release-manifest/ntp_boshrelease-deployment.yml.yml
           delete:
             enabled: true
             force: true
@@ -399,8 +398,8 @@ jobs:
                 ruby -ryaml -e 'ruby_manifest=eval(ENV["MANIFEST_CONTENT"]); ruby_manifest["stemcells"] = [ "alias" => "default", "os" => ENV["STEMCELL_OS"], "version" => "latest"];File.open(File.join("generated-files", ENV["MANIFEST_NAME"]), "w") { |file| file.write(ruby_manifest.to_yaml) }'
                 cat generated-files/${MANIFEST_NAME}
           params:
-            MANIFEST_NAME: "zookeeper_boshrelease-deployment.yml"
-            MANIFEST_CONTENT: '{"name"=>"zookeeper_boshrelease-deployment", "instance_groups"=>[], "update"=>{"canaries"=>1, "max_in_flight"=>1, "canary_watch_time"=>"1000-90000", "update_watch_time"=>"1000-90000"}, "releases"=>[{"name"=>"zookeeper_boshrelease", "version"=>"0.0.9"}]}'
+            MANIFEST_NAME: "precompile-zookeeper_boshrelease-deployment.yml"
+            MANIFEST_CONTENT: '{"name"=>"precompile-zookeeper_boshrelease-deployment", "instance_groups"=>[], "update"=>{"canaries"=>1, "max_in_flight"=>1, "canary_watch_time"=>"1000-90000", "update_watch_time"=>"1000-90000"}, "releases"=>[{"name"=>"zookeeper_boshrelease", "version"=>"0.0.9"}]}'
       - try:
           # this step may fail when boshrelease have been already uploaded to director with another sha1. Indeed, everytime we repackage a bosh release a new sha1 is produced
           task: upload-to-director
@@ -428,10 +427,10 @@ jobs:
             BOSH_CLIENT_SECRET: ((bosh-password))
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CA_CERT: config-resource/shared/certs/internal_paas-ca/server-ca.crt
-      - put: zookeeper_boshrelease-deployment
+      - put: precompile-zookeeper_boshrelease-deployment
         attempts: 5
         params:
-          manifest: final-release-manifest/zookeeper_boshrelease-deployment.yml
+          manifest: final-release-manifest/precompile-zookeeper_boshrelease-deployment.yml
           cleanup: true
       - task: compile-and-export-zookeeper_boshrelease
         attempts: 3
@@ -460,16 +459,15 @@ jobs:
                 echo "Exporting ${RELEASE_NAME}/${RELEASE_VERSION} - ${STEMCELL_OS}/${STEMCELL_VERSION}"
                 bosh export-release "${RELEASE_NAME}/${RELEASE_VERSION}" "${STEMCELL_OS}/${STEMCELL_VERSION}" --dir=exported-release
           params:
-            BOSH_DEPLOYMENT: zookeeper_boshrelease-deployment
+            BOSH_DEPLOYMENT: precompile-zookeeper_boshrelease-deployment
             BOSH_ENVIRONMENT: ((bosh-target))
             BOSH_CLIENT: ((bosh-username))
             BOSH_CLIENT_SECRET: "((bosh-password))"
             BOSH_CA_CERT: secrets/shared/certs/internal_paas-ca/server-ca.crt
             RELEASE_NAME: zookeeper_boshrelease
             RELEASE_VERSION: ((releases.zookeeper_boshrelease.version))
-      - put: zookeeper_boshrelease-deployment
+      - put: precompile-zookeeper_boshrelease-deployment
         params:
-          manifest: final-release-manifest/zookeeper_boshrelease-deployment.yml.yml
           delete:
             enabled: true
             force: true


### PR DESCRIPTION
It seems that we lost this improvement when we introduced the "shared" pipeline support. Hence, we are renaming, again, the BOSH deployment that is used by precompile to ensure easy identification.