### PR TITLE
tasks(repackage_boshreleases_fallback): fix deserialization

### DIFF
--- a/concourse/tasks/repackage_boshreleases_fallback/repackage_releases_fallback.rb
+++ b/concourse/tasks/repackage_boshreleases_fallback/repackage_releases_fallback.rb
@@ -23,7 +23,7 @@ class RepackageReleasesFallback
 
   def initialize(repackaged_error_filepath = "")
     @repackaged_errors = if File.exist?(repackaged_error_filepath)
-                           YAML.load_file(repackaged_error_filepath, aliases: true) || {}
+                           YAML.load_file(repackaged_error_filepath, aliases: true, permitted_classes: [Tasks::Bosh::BoshCliError]) || {}
                          else
                            {}
                          end

--- a/spec/tasks/repackage_boshreleases_fallback/bosh_connection_refused/errors.yml
+++ b/spec/tasks/repackage_boshreleases_fallback/bosh_connection_refused/errors.yml
@@ -1,0 +1,20 @@
+---
+Bosh director: !ruby/exception:Tasks::Bosh::BoshCliError
+  message: |-
+    Stderr:
+    Stdout:
+    {
+        "Tables": null,
+        "Blocks": null,
+        "Lines": [
+            "Fetching info:\n  Performing request GET 'https://192.168.116.158:25555/info':\n    Performing GET request:\n      Retry: Get \"https://192.168.116.158:25555/info\": dial tcp 192.168.116.158:25555: connect: connection refused",
+            "Exit code 1"
+        ]
+    }
+  backtrace:
+    - "/tmp/build/22f65861/cf-ops-automation/lib/tasks/bosh/executor.rb:39:in `handle_bosh_cli_response'"
+    - "/tmp/build/22f65861/cf-ops-automation/lib/tasks/bosh/executor.rb:34:in `run_command'"
+    - "/tmp/build/22f65861/cf-ops-automation/lib/tasks/bosh/list_releases.rb:7:in `execute'"
+    - "/tmp/build/22f65861/cf-ops-automation/concourse/tasks/repackage_boshreleases/repackage_releases.rb:133:in `filter_releases'"
+    - "/tmp/build/22f65861/cf-ops-automation/concourse/tasks/repackage_boshreleases/repackage_releases.rb:32:in `process'"
+    - cf-ops-automation/concourse/tasks/repackage_boshreleases/run.rb:42:in `<main>'

--- a/spec/tasks/repackage_boshreleases_fallback/repackage_releases_fallback_spec.rb
+++ b/spec/tasks/repackage_boshreleases_fallback/repackage_releases_fallback_spec.rb
@@ -45,6 +45,14 @@ describe RepackageReleasesFallback do
       it "creates an object with errors" do
         expect(repackage_releases_fallback.has_errors?).to be_truthy
       end
+      end
+
+    context "when bosh returns an errors" do
+      let(:repackaged_releases_path) { File.join(basedir, 'bosh_connection_refused') }
+
+      it "creates an object with errors" do
+        expect(repackage_releases_fallback.has_errors?).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
As of Ruby 3.1, if you use YAML.load_file, you must explicitly list the classes that are allowed for deserialization.
Otherwise, a `Psych::DisallowedClass` error will be thrown.

Fixes #442

Changes proposed in this pull-request:
- add BoshCliError to allowed classes for deserilization
- add test to illustrate the error