### PR TITLE
switch to elpaasoci images

### DIFF
--- a/ci/fail-github-commit-status.sh
+++ b/ci/fail-github-commit-status.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+OWNER=${OWNER:-orange-cloudfoundry}
+REPO=${REPO:-cf-ops-automation}
+
+usage(){
+ echo "$0 <commit_sha1>"
+   commit_sha1
+ exit 1
+}
+
+if [ $# -ne 1 ];then
+  usage
+fi
+
+gh api --method POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  /repos/$OWNER/$REPO/statuses/$REF \
+  -f state='error' \
+  -f description='Manual update! Set to failure' \
+  -f context='concourse-ci/status'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -56,18 +56,18 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
+      repository: elpaasoci/slack-notification-resource
 
   - name: pull-request
     type: registry-image
     source:
-      repository: teliaoss/github-pr-resource
+      repository: elpaasoci/github-pr-resource
 
   - name: meta
     type: registry-image
     source:
-      repository: olhtbr/metadata-resource
-      tag: 2.0.1
+      repository: elpaasoci/metadata-resource
+      tag: 28e2ea555a3ea41605d954c12fdc10646b889e6d
 resources:
 - name: concourse-meta
   icon: file-document-box-search-outline

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -67,7 +67,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/metadata-resource
-      tag: 28e2ea555a3ea41605d954c12fdc10646b889e6d
+      tag: 2.0.3-orange
 resources:
 - name: concourse-meta
   icon: file-document-box-search-outline

--- a/concourse/pipelines/bootstrap-all-init-pipelines.yml
+++ b/concourse/pipelines/bootstrap-all-init-pipelines.yml
@@ -5,8 +5,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 
 resources:
 - name: failure-alert

--- a/concourse/pipelines/shared/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/shared/concourse-pipeline.yml.erb
@@ -30,8 +30,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 
 resources:
 <% enabled_deployments_with_empty = multi_root_dependencies.select do |root_deployment, root_deployment_info|

--- a/concourse/pipelines/shared/concourse-pipeline.yml.erb
+++ b/concourse/pipelines/shared/concourse-pipeline.yml.erb
@@ -25,7 +25,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/concourse-pipeline-resource
-      tag: 7.8.2
+      tag: 7.9.1
 
   - name: slack-notification
     type: registry-image

--- a/concourse/pipelines/shared/control-plane-pipeline.yml.erb
+++ b/concourse/pipelines/shared/control-plane-pipeline.yml.erb
@@ -24,8 +24,8 @@ resource_types:
   - name: meta
     type: registry-image
     source:
-      repository: olhtbr/metadata-resource
-      tag: 2.0.1
+      repository: elpaasoci/metadata-resource
+      tag: 2.0.3-orange
   - name: concourse-5-pipeline
     type: registry-image
     source:

--- a/concourse/pipelines/shared/control-plane-pipeline.yml.erb
+++ b/concourse/pipelines/shared/control-plane-pipeline.yml.erb
@@ -35,7 +35,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/concourse-pipeline-resource
-      tag: 7.8.2
+      tag: 7.9.1
 resources:
 - name: concourse-audit-trail
   icon: source-pull

--- a/concourse/pipelines/shared/control-plane-pipeline.yml.erb
+++ b/concourse/pipelines/shared/control-plane-pipeline.yml.erb
@@ -246,8 +246,8 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: orange-cloudfoundry/concourse-fly
-            tag: "7.9.1"
+            repository: elpaasoci/concourse-fly
+            tag: "7ce5aa85675911e224c72a3d410fd63d93be1442"
         inputs:
           - name: selected-pipelines
         outputs:
@@ -316,8 +316,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: orange-cloudfoundry/concourse-fly
-              tag: "7.9.1"
+              repository: elpaasoci/concourse-fly
+              tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
           inputs:
             - name: concourse-generated-pipeline
           outputs:
@@ -393,8 +393,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: orange-cloudfoundry/concourse-fly
-              tag: '7.9.1'
+              repository: elpaasoci/concourse-fly
+              tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
           inputs:
             - name: concourse-micro
           outputs:
@@ -446,8 +446,8 @@ jobs:
   #        image_resource:
   #          type: registry-image
   #          source:
-  #            repository: orange-cloudfoundry/concourse-fly
-  #            tag: '7.9.1'
+  #            repository: elpaasoci/concourse-fly
+  #            tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/concourse/pipelines/shared/control-plane-pipeline.yml.erb
+++ b/concourse/pipelines/shared/control-plane-pipeline.yml.erb
@@ -19,8 +19,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
   - name: meta
     type: registry-image
     source:

--- a/concourse/pipelines/shared/control-plane-pipeline.yml.erb
+++ b/concourse/pipelines/shared/control-plane-pipeline.yml.erb
@@ -246,8 +246,8 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: teliaoss/concourse-fly
-            tag: "20210905"
+            repository: orange-cloudfoundry/concourse-fly
+            tag: "7.9.1"
         inputs:
           - name: selected-pipelines
         outputs:
@@ -316,8 +316,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: teliaoss/concourse-fly
-              tag: "20210905"
+              repository: orange-cloudfoundry/concourse-fly
+              tag: "7.9.1"
           inputs:
             - name: concourse-generated-pipeline
           outputs:
@@ -393,8 +393,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: teliaoss/concourse-fly
-              tag: '20210905'
+              repository: orange-cloudfoundry/concourse-fly
+              tag: '7.9.1'
           inputs:
             - name: concourse-micro
           outputs:
@@ -446,8 +446,8 @@ jobs:
   #        image_resource:
   #          type: registry-image
   #          source:
-  #            repository: teliaoss/concourse-fly
-  #            tag: '20210905'
+  #            repository: orange-cloudfoundry/concourse-fly
+  #            tag: '7.9.1'
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/concourse/pipelines/shared/kubernetes-pipeline.yml.erb
+++ b/concourse/pipelines/shared/kubernetes-pipeline.yml.erb
@@ -41,8 +41,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/concourse/pipelines/shared/kubernetes-pipeline.yml.erb
+++ b/concourse/pipelines/shared/kubernetes-pipeline.yml.erb
@@ -46,8 +46,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 
 resources:
 <% unless enabled_deployments.empty? %>

--- a/concourse/pipelines/sync-feature-branches.yml
+++ b/concourse/pipelines/sync-feature-branches.yml
@@ -5,8 +5,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 
   - name: git-branch-heads
     type: registry-image

--- a/concourse/pipelines/sync-hotfix-branches.yml
+++ b/concourse/pipelines/sync-hotfix-branches.yml
@@ -5,8 +5,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 
   - name: git-branch-heads
     type: registry-image

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -118,8 +118,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 
 resources:
 - name: concourse-meta

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -112,8 +112,8 @@ resource_types:
 - name: bosh-errand
   type: registry-image
   source:
-    repository: cfcommunity/bosh2-errand-resource
-    tag: v0.1.2
+    repository: elpaasoci/bosh2-errand-resource
+    tag: v0.1.2-orange
 
 - name: meta
   type: registry-image

--- a/concourse/pipelines/template/bosh-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-pipeline.yml.erb
@@ -101,8 +101,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
+++ b/concourse/pipelines/template/bosh-precompile-pipeline.yml.erb
@@ -98,8 +98,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/concourse/pipelines/template/cf-apps-pipeline.yml.erb
+++ b/concourse/pipelines/template/cf-apps-pipeline.yml.erb
@@ -22,8 +22,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 resources:
 
 <% if ! all_cf_apps.empty? %>

--- a/concourse/pipelines/template/k8s-pipeline.yml.erb
+++ b/concourse/pipelines/template/k8s-pipeline.yml.erb
@@ -50,8 +50,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 
 resources:
 - name: failure-alert

--- a/concourse/pipelines/template/k8s-pipeline.yml.erb
+++ b/concourse/pipelines/template/k8s-pipeline.yml.erb
@@ -45,8 +45,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
@@ -67,8 +67,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: concourse-meta
   icon: file-document-box-search-outline

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
@@ -52,8 +52,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-generated.yml
@@ -62,8 +62,8 @@ resource_types:
 - name: bosh-errand
   type: registry-image
   source:
-    repository: cfcommunity/bosh2-errand-resource
-    tag: v0.1.2
+    repository: elpaasoci/bosh2-errand-resource
+    tag: v0.1.2-orange
 - name: meta
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-bosh-precompile-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-bosh-precompile-generated.yml
@@ -15,8 +15,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/another-world-root-depls-cf-apps-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-cf-apps-generated.yml
@@ -6,8 +6,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 resources:
 jobs:
 - name: this-is-an-empty-pipeline

--- a/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
@@ -11,8 +11,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/another-world-root-depls-k8s-generated.yml
@@ -6,8 +6,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
@@ -67,8 +67,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: concourse-meta
   icon: file-document-box-search-outline

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
@@ -52,8 +52,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-generated.yml
@@ -62,8 +62,8 @@ resource_types:
 - name: bosh-errand
   type: registry-image
   source:
-    repository: cfcommunity/bosh2-errand-resource
-    tag: v0.1.2
+    repository: elpaasoci/bosh2-errand-resource
+    tag: v0.1.2-orange
 - name: meta
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-precompile-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-bosh-precompile-generated.yml
@@ -15,8 +15,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-cf-apps-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-cf-apps-generated.yml
@@ -6,8 +6,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
@@ -11,8 +11,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
+++ b/docs/reference_dataset/pipelines/hello-world-root-depls-k8s-generated.yml
@@ -6,8 +6,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/root-deployment.yml
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/root-deployment.yml
@@ -2,7 +2,7 @@
 name: hello-world-root-depls
 
 stemcell:
-  version: "1.260" # Mandatory
+  version: "1.404" # Mandatory
   sha1: # Optional
 
 releases:

--- a/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
@@ -93,8 +93,8 @@ describe 'BoshPipelineTemplateProcessing' do
       - name: bosh-errand
         type: registry-image
         source:
-          repository: cfcommunity/bosh2-errand-resource
-          tag: v0.1.2
+          repository: elpaasoci/bosh2-errand-resource
+          tag: v0.1.2-orange
       - name: meta
         type: registry-image
         source:

--- a/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
@@ -98,8 +98,8 @@ describe 'BoshPipelineTemplateProcessing' do
       - name: meta
         type: registry-image
         source:
-          repository: olhtbr/metadata-resource
-          tag: 2.0.1
+          repository: elpaasoci/metadata-resource
+          tag: 2.0.3-orange
 
     YAML
     YAML.safe_load(resource_types_yaml)

--- a/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_pipeline_spec.rb
@@ -83,8 +83,8 @@ describe 'BoshPipelineTemplateProcessing' do
       - name: slack-notification
         type: registry-image
         source:
-          repository: cfcommunity/slack-notification-resource
-          tag: v1.4.2
+          repository: elpaasoci/slack-notification-resource
+          tag: v1.7.0-orange
       - name: bosh-deployment-v2
         type: registry-image
         source:

--- a/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_bosh_precompile_pipeline_spec.rb
@@ -93,8 +93,8 @@ describe 'BoshPrecompilePipelineTemplateProcessing' do
       - name: slack-notification
         type: registry-image
         source:
-          repository: cfcommunity/slack-notification-resource
-          tag: v1.4.2
+          repository: elpaasoci/slack-notification-resource
+          tag: v1.7.0-orange
       - name: bosh-deployment-v2
         type: registry-image
         source:

--- a/spec/lib/template_processor/template_processor_for_cf_apps_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_cf_apps_pipeline_spec.rb
@@ -77,8 +77,8 @@ describe 'CfAppsPipelineTemplateProcessing' do
       - name: slack-notification
         type: registry-image
         source:
-          repository: cfcommunity/slack-notification-resource
-          tag: v1.4.2
+          repository: elpaasoci/slack-notification-resource
+          tag: v1.7.0-orange
     YAML
     YAML.safe_load(resource_types_yaml)
   end

--- a/spec/lib/template_processor/template_processor_for_shared_concourse_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_shared_concourse_pipeline_spec.rb
@@ -85,8 +85,8 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
       - name: slack-notification
         type: registry-image
         source:
-          repository: cfcommunity/slack-notification-resource
-          tag: v1.4.2
+          repository: elpaasoci/slack-notification-resource
+          tag: v1.7.0-orange
       - name: concourse-5-pipeline
         type: registry-image
         source:

--- a/spec/lib/template_processor/template_processor_for_shared_concourse_pipeline_spec.rb
+++ b/spec/lib/template_processor/template_processor_for_shared_concourse_pipeline_spec.rb
@@ -96,7 +96,7 @@ describe 'ConcoursePipelineTemplateProcessing (ie: concourse-pipeline.yml.erb)' 
         type: registry-image
         source:
           repository: elpaasoci/concourse-pipeline-resource
-          tag: 7.8.2
+          tag: 7.9.1
     YAML
     YAML.safe_load(resource_types_yaml)
   end

--- a/spec/lib/template_processor/template_processor_spec.rb
+++ b/spec/lib/template_processor/template_processor_spec.rb
@@ -68,7 +68,7 @@ describe TemplateProcessor do
           'resource_types' => [
             {  'name' => 'slack-notification',
                'type' => 'docker-image',
-               'source' => { 'repository' => 'cfcommunity/slack-notification-resource' } }
+               'source' => { 'repository' => 'elpaasoci/slack-notification-resource' } }
           ],
           'resources' => [],
           'jobs' => [
@@ -110,7 +110,7 @@ describe TemplateProcessor do
             - name: slack-notification
               type: registry-image
               source:
-                repository: cfcommunity/slack-notification-resource
+                repository: elpaasoci/slack-notification-resource
             resources: []
             jobs:
             - name: "good"

--- a/spec/lib/template_processor/test_fixtures/resource_types_fixture.rb
+++ b/spec/lib/template_processor/test_fixtures/resource_types_fixture.rb
@@ -5,8 +5,8 @@ module Coa
         name: slack-notification
         type: registry-image
         source:
-          repository: cfcommunity/slack-notification-resource
-          tag: v1.4.2
+          repository: elpaasoci/slack-notification-resource
+          tag: v1.7.0-orange
       meta:
         name: meta
         type: registry-image

--- a/spec/lib/template_processor/test_fixtures/resource_types_fixture.rb
+++ b/spec/lib/template_processor/test_fixtures/resource_types_fixture.rb
@@ -11,8 +11,8 @@ module Coa
         name: meta
         type: registry-image
         source:
-          repository: olhtbr/metadata-resource
-          tag: 2.0.1
+          repository: elpaasoci/metadata-resource
+          tag: 2.0.3-orange
 
 
     YAML

--- a/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/apps-depls-cf-apps-ref.yml
@@ -6,8 +6,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
@@ -67,8 +67,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: concourse-meta
   icon: file-document-box-search-outline

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
@@ -52,8 +52,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/delete-depls-bosh-ref.yml
@@ -62,8 +62,8 @@ resource_types:
 - name: bosh-errand
   type: registry-image
   source:
-    repository: cfcommunity/bosh2-errand-resource
-    tag: v0.1.2
+    repository: elpaasoci/bosh2-errand-resource
+    tag: v0.1.2-orange
 - name: meta
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-bosh-precompile.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-bosh-precompile.yml
@@ -15,8 +15,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-cf-apps.yml
@@ -6,8 +6,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 resources:
 jobs:
 - name: this-is-an-empty-pipeline

--- a/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
@@ -6,8 +6,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
   - name: meta
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
@@ -131,7 +131,7 @@ jobs:
             type: registry-image
             source:
               repository: elpaasoci/concourse-fly
-              tag: '7.9.1'
+              tag: '7ce5aa85675911e224c72a3d410fd63d93be1442'
           inputs:
             - name: concourse-micro
           outputs:
@@ -182,7 +182,7 @@ jobs:
   #          type: registry-image
   #          source:
   #            repository: elpaasoci/concourse-fly
-  #            tag: '7.9.1'
+  #            tag: '7ce5aa85675911e224c72a3d410fd63d93be1442'
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
@@ -22,7 +22,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/concourse-pipeline-resource
-      tag: 7.8.2
+      tag: 7.9.1
 resources:
 - name: concourse-audit-trail
   icon: source-pull

--- a/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
@@ -11,8 +11,8 @@ resource_types:
   - name: meta
     type: registry-image
     source:
-      repository: olhtbr/metadata-resource
-      tag: 2.0.1
+      repository: elpaasoci/metadata-resource
+      tag: 2.0.3-orange
   - name: concourse-5-pipeline
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-control-plane-update.yml
@@ -130,8 +130,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: teliaoss/concourse-fly
-              tag: '20210905'
+              repository: elpaasoci/concourse-fly
+              tag: '7.9.1'
           inputs:
             - name: concourse-micro
           outputs:
@@ -181,8 +181,8 @@ jobs:
   #        image_resource:
   #          type: registry-image
   #          source:
-  #            repository: teliaoss/concourse-fly
-  #            tag: '20210905'
+  #            repository: elpaasoci/concourse-fly
+  #            tag: '7.9.1'
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -67,8 +67,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: concourse-meta
   icon: file-document-box-search-outline

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -52,8 +52,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-depls.yml
@@ -62,8 +62,8 @@ resource_types:
 - name: bosh-errand
   type: registry-image
   source:
-    repository: cfcommunity/bosh2-errand-resource
-    tag: v0.1.2
+    repository: elpaasoci/bosh2-errand-resource
+    tag: v0.1.2-orange
 - name: meta
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-k8s-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-k8s-depls.yml
@@ -11,8 +11,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/spec/scripts/generate-depls/fixtures/references/empty-k8s-depls.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-k8s-depls.yml
@@ -6,8 +6,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-concourse.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-concourse.yml
@@ -16,8 +16,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 resources:
 jobs:
 - name: this-is-an-empty-pipeline

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-concourse.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-concourse.yml
@@ -12,7 +12,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/concourse-pipeline-resource
-      tag: 7.8.2
+      tag: 7.9.1
   - name: slack-notification
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
@@ -6,8 +6,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
   - name: meta
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
@@ -131,7 +131,7 @@ jobs:
             type: registry-image
             source:
               repository: elpaasoci/concourse-fly
-              tag: '7.9.1'
+              tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
           inputs:
             - name: concourse-micro
           outputs:
@@ -182,7 +182,7 @@ jobs:
   #          type: registry-image
   #          source:
   #            repository: elpaasoci/concourse-fly
-  #            tag: '7.9.1'
+  #            tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
@@ -22,7 +22,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/concourse-pipeline-resource
-      tag: 7.8.2
+      tag: 7.9.1
 resources:
 - name: concourse-audit-trail
   icon: source-pull

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
@@ -11,8 +11,8 @@ resource_types:
   - name: meta
     type: registry-image
     source:
-      repository: olhtbr/metadata-resource
-      tag: 2.0.1
+      repository: elpaasoci/metadata-resource
+      tag: 2.0.3-orange
   - name: concourse-5-pipeline
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-control-plane.yml
@@ -130,8 +130,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: teliaoss/concourse-fly
-              tag: '20210905'
+              repository: elpaasoci/concourse-fly
+              tag: '7.9.1'
           inputs:
             - name: concourse-micro
           outputs:
@@ -181,8 +181,8 @@ jobs:
   #        image_resource:
   #          type: registry-image
   #          source:
-  #            repository: teliaoss/concourse-fly
-  #            tag: '20210905'
+  #            repository: elpaasoci/concourse-fly
+  #            tag: '7.9.1'
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-kubernetes.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-kubernetes.yml
@@ -6,8 +6,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/empty-shared-kubernetes.yml
+++ b/spec/scripts/generate-depls/fixtures/references/empty-shared-kubernetes.yml
@@ -11,8 +11,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 jobs:
   - name: this-is-an-empty-pipeline

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-precompile-ref.yml
@@ -15,8 +15,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -67,8 +67,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: concourse-meta
   icon: file-document-box-search-outline

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -52,8 +52,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: bosh-deployment-v2
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-bosh-ref.yml
@@ -62,8 +62,8 @@ resource_types:
 - name: bosh-errand
   type: registry-image
   source:
-    repository: cfcommunity/bosh2-errand-resource
-    tag: v0.1.2
+    repository: elpaasoci/bosh2-errand-resource
+    tag: v0.1.2-orange
 - name: meta
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
@@ -11,8 +11,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-depls-k8s-ref.yml
@@ -6,8 +6,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-concourse.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-concourse.yml
@@ -16,8 +16,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-concourse.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-concourse.yml
@@ -12,7 +12,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/concourse-pipeline-resource
-      tag: 7.8.2
+      tag: 7.9.1
   - name: slack-notification
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
@@ -6,8 +6,8 @@ resource_types:
   - name: slack-notification
     type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
-      tag: v1.4.2
+      repository: elpaasoci/slack-notification-resource
+      tag: v1.7.0-orange
   - name: meta
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
@@ -22,7 +22,7 @@ resource_types:
     type: registry-image
     source:
       repository: elpaasoci/concourse-pipeline-resource
-      tag: 7.8.2
+      tag: 7.9.1
 resources:
 - name: concourse-audit-trail
   icon: source-pull

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
@@ -217,8 +217,8 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: teliaoss/concourse-fly
-            tag: "20210905"
+            repository: elpaasoci/concourse-fly
+            tag: "7.9.1"
         inputs:
           - name: selected-pipelines
         outputs:
@@ -338,8 +338,8 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: teliaoss/concourse-fly
-            tag: "20210905"
+            repository: elpaasoci/concourse-fly
+            tag: "7.9.1"
         inputs:
           - name: selected-pipelines
         outputs:
@@ -459,8 +459,8 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: teliaoss/concourse-fly
-            tag: "20210905"
+            repository: elpaasoci/concourse-fly
+            tag: "7.9.1"
         inputs:
           - name: selected-pipelines
         outputs:
@@ -580,8 +580,8 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: teliaoss/concourse-fly
-            tag: "20210905"
+            repository: elpaasoci/concourse-fly
+            tag: "7.9.1"
         inputs:
           - name: selected-pipelines
         outputs:
@@ -645,8 +645,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: teliaoss/concourse-fly
-              tag: "20210905"
+              repository: elpaasoci/concourse-fly
+              tag: "7.9.1"
           inputs:
             - name: concourse-generated-pipeline
           outputs:
@@ -719,8 +719,8 @@ jobs:
           image_resource:
             type: registry-image
             source:
-              repository: teliaoss/concourse-fly
-              tag: '20210905'
+              repository: elpaasoci/concourse-fly
+              tag: '7.9.1'
           inputs:
             - name: concourse-micro
           outputs:
@@ -770,8 +770,8 @@ jobs:
   #        image_resource:
   #          type: registry-image
   #          source:
-  #            repository: teliaoss/concourse-fly
-  #            tag: '20210905'
+  #            repository: elpaasoci/concourse-fly
+  #            tag: '7.9.1'
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
@@ -11,8 +11,8 @@ resource_types:
   - name: meta
     type: registry-image
     source:
-      repository: olhtbr/metadata-resource
-      tag: 2.0.1
+      repository: elpaasoci/metadata-resource
+      tag: 2.0.3-orange
   - name: concourse-5-pipeline
     type: registry-image
     source:

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-control-plane.yml
@@ -218,7 +218,7 @@ jobs:
           type: registry-image
           source:
             repository: elpaasoci/concourse-fly
-            tag: "7.9.1"
+            tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
         inputs:
           - name: selected-pipelines
         outputs:
@@ -339,7 +339,7 @@ jobs:
           type: registry-image
           source:
             repository: elpaasoci/concourse-fly
-            tag: "7.9.1"
+            tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
         inputs:
           - name: selected-pipelines
         outputs:
@@ -460,7 +460,7 @@ jobs:
           type: registry-image
           source:
             repository: elpaasoci/concourse-fly
-            tag: "7.9.1"
+            tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
         inputs:
           - name: selected-pipelines
         outputs:
@@ -581,7 +581,7 @@ jobs:
           type: registry-image
           source:
             repository: elpaasoci/concourse-fly
-            tag: "7.9.1"
+            tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
         inputs:
           - name: selected-pipelines
         outputs:
@@ -646,7 +646,7 @@ jobs:
             type: registry-image
             source:
               repository: elpaasoci/concourse-fly
-              tag: "7.9.1"
+              tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
           inputs:
             - name: concourse-generated-pipeline
           outputs:
@@ -720,7 +720,7 @@ jobs:
             type: registry-image
             source:
               repository: elpaasoci/concourse-fly
-              tag: '7.9.1'
+              tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
           inputs:
             - name: concourse-micro
           outputs:
@@ -771,7 +771,7 @@ jobs:
   #          type: registry-image
   #          source:
   #            repository: elpaasoci/concourse-fly
-  #            tag: '7.9.1'
+  #            tag: 7ce5aa85675911e224c72a3d410fd63d93be1442
   #        inputs:
   #          - name: concourse-micro-legacy
   #        outputs:

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-kubernetes.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-kubernetes.yml
@@ -11,8 +11,8 @@ resource_types:
 - name: meta
   type: registry-image
   source:
-    repository: olhtbr/metadata-resource
-    tag: 2.0.1
+    repository: elpaasoci/metadata-resource
+    tag: 2.0.3-orange
 resources:
 - name: failure-alert
   icon: slack

--- a/spec/scripts/generate-depls/fixtures/references/simple-shared-kubernetes.yml
+++ b/spec/scripts/generate-depls/fixtures/references/simple-shared-kubernetes.yml
@@ -6,8 +6,8 @@ resource_types:
 - name: slack-notification
   type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: v1.4.2
+    repository: elpaasoci/slack-notification-resource
+    tag: v1.7.0-orange
 - name: meta
   type: registry-image
   source:

--- a/spec/tasks/task_spec_helper.rb
+++ b/spec/tasks/task_spec_helper.rb
@@ -5,11 +5,11 @@ class TaskSpecHelper
   end
 
   def self.fly_image
-    'elpaasoci/concourse-fly' #from https://github.com/telia-oss/concourse-images
+    'elpaasoci/concourse-fly' #from https://github.com/orange-cloudfoundry/concourse-images
   end
 
   def self.fly_image_version
-    '7.9.1'
+    '7ce5aa85675911e224c72a3d410fd63d93be1442' # ie '7.9.1'
   end
 
   def self.orange_default_image_version

--- a/spec/tasks/task_spec_helper.rb
+++ b/spec/tasks/task_spec_helper.rb
@@ -5,11 +5,11 @@ class TaskSpecHelper
   end
 
   def self.fly_image
-    'teliaoss/concourse-fly'
+    'elpaasoci/concourse-fly' #from https://github.com/telia-oss/concourse-images
   end
 
   def self.fly_image_version
-    '20210905'
+    '7.9.1'
   end
 
   def self.orange_default_image_version


### PR DESCRIPTION
to avoid supply chain attacks, we switch to our own images

Changes proposed in this pull-request:
- switch to elpaasoci/concourse-fly
- bump elpaasoci/concourse-pipeline-resource to 7.9.1
- switch to elpaasoci/slack-notification-resource: v1.7.0-orange
- switch to elpaasoci/metadata-resource:2.0.3-orange
- switch to elpaasoci/bosh2-errand-resource:v01.2-orange