### PR TITLE
Include bosh cli in post deploy

### DIFF
--- a/concourse/tasks/cf_push.yml
+++ b/concourse/tasks/cf_push.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: elpaasoci/cf-cli
+    repository: elpaasoci/bosh-cli-v2-cf-cli
     tag: 08122693acec179b207390cd889600c8148c541c
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/post_bosh_deploy.yml
+++ b/concourse/tasks/post_bosh_deploy.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: elpaasoci/cf-cli
+    repository: elpaasoci/bosh-cli-v2-cf-cli
     tag: 08122693acec179b207390cd889600c8148c541c
 inputs:
   - name: scripts-resource

--- a/concourse/tasks/post_deploy/run.sh
+++ b/concourse/tasks/post_deploy/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 CURRENT_DIR=$(pwd)

--- a/concourse/tasks/pre_deploy/run.sh
+++ b/concourse/tasks/pre_deploy/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/check-available-clis-during-deploy.sh
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/check-available-clis-during-deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+echo "==== List CLIs ===="
+echo "Bosh cli is available"
+bosh --version
+echo "---"
+echo "cf is available"
+cf --version
+echo "---"
+echo "credhub is available"
+credhub --version
+echo "---"
+echo "spruce is available"
+spruce --version
+echo "---"
+echo "bash is available"
+bash --version
+echo "---"
+echo "envsubst is available"
+envsubst --version
+echo "---"
+echo "jq is available"
+jq --version
+echo "---"
+echo "==== End List CLIs ===="
+
+

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/post-deploy.sh
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/post-deploy.sh
@@ -2,3 +2,5 @@
 
 echo 'Bye bye, World!'
 echo 'Here you can execute shell commands after deploying'
+
+$CUSTOM_SCRIPT_DIR/check-available-clis-during-deploy.sh

--- a/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/pre-deploy.sh
+++ b/docs/reference_dataset/template_repository/hello-world-root-depls/bosh-deployment-sample/template/pre-deploy.sh
@@ -2,3 +2,5 @@
 
 echo 'Hello, World!'
 echo 'Here you can execute shell commands before deploying'
+
+$CUSTOM_SCRIPT_DIR/check-available-clis-during-deploy.sh

--- a/scripts/cf/push.sh
+++ b/scripts/cf/push.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 set -o pipefail

--- a/spec/tasks/all_tasks_spec.rb
+++ b/spec/tasks/all_tasks_spec.rb
@@ -34,7 +34,7 @@ describe 'all tasks' do
         TaskSpecHelper.curl_image + ':' + TaskSpecHelper.curl_image_version,
         TaskSpecHelper.git_image + ':' + TaskSpecHelper.git_image_version,
         TaskSpecHelper.bosh_cli_v2_image + ':' + TaskSpecHelper.bosh_cli_v2_image_version,
-        TaskSpecHelper.cf_cli_image + ':' + TaskSpecHelper.cf_cli_image_version,
+        #TaskSpecHelper.cf_cli_image + ':' + TaskSpecHelper.cf_cli_image_version,
         TaskSpecHelper.spruce_image + ':' + TaskSpecHelper.spruce_image_version,
         TaskSpecHelper.ruby_image + ':' + TaskSpecHelper.ruby_image_version,
         TaskSpecHelper.ruby_image + ':' + TaskSpecHelper.ruby_slim_image_version,

--- a/spec/tasks/apply_iaas_type_and_profiles/task_spec.rb
+++ b/spec/tasks/apply_iaas_type_and_profiles/task_spec.rb
@@ -19,6 +19,7 @@ describe 'apply_iaas_type_and_profiles task' do
 
       Dir.chdir(@templates_dir) do
         `git init .`
+        `git branch -m main`
         `git add .`
         `git commit -a -m"initial commit"`
         %w[commit_message commit_timestamp committer describe_ref ref short_ref].each do |filename|

--- a/spec/tasks/bosh_update_config/cloud_config_spec.rb
+++ b/spec/tasks/bosh_update_config/cloud_config_spec.rb
@@ -62,7 +62,7 @@ describe 'bosh_update_cloud_config task' do
   context 'Pre-requisite' do
     let(:task) { YAML.load_file 'concourse/tasks/bosh_update_config/task.yml' }
 
-    it 'uses alphagov bosh-cli-v2 image' do
+    it 'uses bosh-cli-v2 image' do
       docker_image_used = task['image_resource']['source']['repository'].to_s
       expect(docker_image_used).to match('elpaasoci/bosh-cli-v2')
     end

--- a/spec/tasks/bosh_update_config/cpi_config_spec.rb
+++ b/spec/tasks/bosh_update_config/cpi_config_spec.rb
@@ -103,7 +103,7 @@ describe 'bosh_update_CPI_config task' do
   context 'Pre-requisite' do
     let(:task) { YAML.load_file 'concourse/tasks/bosh_update_config/task.yml' }
 
-    it 'uses alphagov bosh-cli-v2 image' do
+    it 'uses bosh-cli-v2 image' do
       docker_image_used = task['image_resource']['source']['repository'].to_s
       expect(docker_image_used).to match('elpaasoci/bosh-cli-v2')
     end

--- a/spec/tasks/bosh_update_config/runtime_config_spec.rb
+++ b/spec/tasks/bosh_update_config/runtime_config_spec.rb
@@ -53,7 +53,7 @@ describe 'bosh_update_runtime_config task' do
   context 'Pre-requisite' do
     let(:task) { YAML.load_file 'concourse/tasks/bosh_update_config/task.yml' }
 
-    it 'uses alphagov bosh-cli-v2 image' do
+    it 'uses bosh-cli-v2 image' do
       docker_image_used = task['image_resource']['source']['repository'].to_s
       expect(docker_image_used).to match('elpaasoci/bosh-cli-v2')
     end

--- a/spec/tasks/execute_deploy_script/task_spec.rb
+++ b/spec/tasks/execute_deploy_script/task_spec.rb
@@ -54,7 +54,7 @@ describe 'execute_deploy_script task' do
   context 'when pre-requisites are valid' do
     let(:task) { YAML.load_file 'concourse/tasks/execute_deploy_script.yml' }
 
-    it 'uses alphagov bosh-cli-v2 image' do
+    it 'uses bosh-cli-v2 image' do
       docker_image_used = task['image_resource']['source']['repository'].to_s
       expect(docker_image_used).to match(TaskSpecHelper.bosh_cli_v2_image)
     end

--- a/spec/tasks/post_deploy/task_spec.rb
+++ b/spec/tasks/post_deploy/task_spec.rb
@@ -6,9 +6,9 @@ describe 'post_deploy task' do
   context 'Pre-requisite' do
     let(:task) { YAML.load_file 'concourse/tasks/post_bosh_deploy.yml' }
 
-    it 'uses alphagov cf-cli image' do
+    it 'uses bosh-cli-v2-cf-cli image' do
       docker_image_used = task['image_resource']['source']['repository'].to_s
-      expect(docker_image_used).to match('elpaasoci/cf-cli')
+      expect(docker_image_used).to match('elpaasoci/bosh-cli-v2-cf-cli')
     end
   end
 

--- a/spec/tasks/task_spec_helper.rb
+++ b/spec/tasks/task_spec_helper.rb
@@ -69,7 +69,7 @@ class TaskSpecHelper
   end
 
   def self.cf_cli_image
-    'elpaasoci/cf-cli'
+    'elpaasoci/bosh-cli-v2-cf-cli'
   end
 
   def self.cf_cli_image_version


### PR DESCRIPTION
Changes proposed in this pull-request:
- use bosh-cli-v2-cf-cli image instead of cf-cli image